### PR TITLE
 refactor: Make lakehouse Iceberg tests work

### DIFF
--- a/velox/connectors/lakehouse/common/CMakeLists.txt
+++ b/velox/connectors/lakehouse/common/CMakeLists.txt
@@ -40,3 +40,6 @@ velox_add_library(velox_lakehouse_hive_partition_function HivePartitionFunction.
 
 velox_link_libraries(velox_lakehouse_hive_partition_function velox_core velox_exec)
 
+if(VELOX_BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/velox/connectors/lakehouse/common/tests/CMakeLists.txt
+++ b/velox/connectors/lakehouse/common/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(
+  velox_lakehouse_common_test_lib HiveConnectorTestBase.cpp PlanBuilder.cpp)
+
+target_link_libraries(
+  velox_lakehouse_common_test_lib velox_exec_test_lib)

--- a/velox/connectors/lakehouse/common/tests/HiveConnectorTestBase.cpp
+++ b/velox/connectors/lakehouse/common/tests/HiveConnectorTestBase.cpp
@@ -1,0 +1,440 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/file/tests/FaultyFileSystem.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
+#include "velox/dwio/dwrf/writer/FlushPolicy.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/dwio/text/RegisterTextReader.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+
+namespace facebook::velox::exec::test {
+
+HiveConnectorTestBase::HiveConnectorTestBase() {
+  filesystems::registerLocalFileSystem();
+  tests::utils::registerFaultyFileSystem();
+}
+
+void HiveConnectorTestBase::SetUp() {
+  OperatorTestBase::SetUp();
+  connector::registerConnectorFactory(
+      std::make_shared<connector::hive::HiveConnectorFactory>());
+  auto hiveConnector =
+      connector::getConnectorFactory(
+          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+          ->newConnector(
+              kHiveConnectorId,
+              std::make_shared<config::ConfigBase>(
+                  std::unordered_map<std::string, std::string>()),
+              ioExecutor_.get());
+  connector::registerConnector(hiveConnector);
+  dwio::common::registerFileSinks();
+  dwrf::registerDwrfReaderFactory();
+  dwrf::registerDwrfWriterFactory();
+  text::registerTextReaderFactory();
+}
+
+void HiveConnectorTestBase::TearDown() {
+  // Make sure all pending loads are finished or cancelled before unregister
+  // connector.
+  ioExecutor_.reset();
+  dwrf::unregisterDwrfReaderFactory();
+  dwrf::unregisterDwrfWriterFactory();
+  connector::unregisterConnector(kHiveConnectorId);
+  connector::unregisterConnectorFactory(
+      connector::hive::HiveConnectorFactory::kHiveConnectorName);
+  text::unregisterTextReaderFactory();
+  OperatorTestBase::TearDown();
+}
+
+void HiveConnectorTestBase::resetHiveConnector(
+    const std::shared_ptr<const config::ConfigBase>& config) {
+  connector::unregisterConnector(kHiveConnectorId);
+  auto hiveConnector =
+      connector::getConnectorFactory(
+          connector::hive::HiveConnectorFactory::kHiveConnectorName)
+          ->newConnector(kHiveConnectorId, config, ioExecutor_.get());
+  connector::registerConnector(hiveConnector);
+}
+
+void HiveConnectorTestBase::writeToFiles(
+    const std::vector<std::string>& filePaths,
+    std::vector<RowVectorPtr> vectors) {
+  VELOX_CHECK_EQ(filePaths.size(), vectors.size());
+  for (int i = 0; i < filePaths.size(); ++i) {
+    writeToFile(filePaths[i], std::vector{vectors[i]});
+  }
+}
+
+void HiveConnectorTestBase::writeToFile(
+    const std::string& filePath,
+    RowVectorPtr vector) {
+  writeToFile(filePath, std::vector{vector});
+}
+
+void HiveConnectorTestBase::writeToFile(
+    const std::string& filePath,
+    const std::vector<RowVectorPtr>& vectors,
+    std::shared_ptr<dwrf::Config> config,
+    const std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()>&
+        flushPolicyFactory) {
+  writeToFile(
+      filePath,
+      vectors,
+      std::move(config),
+      vectors[0]->type(),
+      flushPolicyFactory);
+}
+
+void HiveConnectorTestBase::writeToFile(
+    const std::string& filePath,
+    const std::vector<RowVectorPtr>& vectors,
+    std::shared_ptr<dwrf::Config> config,
+    const TypePtr& schema,
+    const std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()>&
+        flushPolicyFactory) {
+  velox::dwrf::WriterOptions options;
+  options.config = config;
+  options.schema = schema;
+  auto fs = filesystems::getFileSystem(filePath, {});
+  auto writeFile = fs->openFileForWrite(
+      filePath,
+      {.shouldCreateParentDirectories = true,
+       .shouldThrowOnFileAlreadyExists = false});
+  auto sink = std::make_unique<dwio::common::WriteFileSink>(
+      std::move(writeFile), filePath);
+  auto childPool = rootPool_->addAggregateChild("HiveConnectorTestBase.Writer");
+  options.memoryPool = childPool.get();
+  options.flushPolicyFactory = flushPolicyFactory;
+
+  facebook::velox::dwrf::Writer writer{std::move(sink), options};
+  for (size_t i = 0; i < vectors.size(); ++i) {
+    writer.write(vectors[i]);
+  }
+  writer.close();
+}
+
+void HiveConnectorTestBase::createDirectory(const std::string& directoryPath) {
+  auto fs = filesystems::getFileSystem(directoryPath, {});
+  fs->mkdir(directoryPath);
+}
+
+void HiveConnectorTestBase::removeDirectory(const std::string& directoryPath) {
+  auto fs = filesystems::getFileSystem(directoryPath, {});
+  if (fs->exists(directoryPath)) {
+    fs->rmdir(directoryPath);
+  }
+}
+
+void HiveConnectorTestBase::removeFile(const std::string& filePath) {
+  auto fs = filesystems::getFileSystem(filePath, {});
+  if (fs->exists(filePath)) {
+    fs->remove(filePath);
+  }
+}
+
+std::vector<RowVectorPtr> HiveConnectorTestBase::makeVectors(
+    const RowTypePtr& rowType,
+    int32_t numVectors,
+    int32_t rowsPerVector) {
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < numVectors; ++i) {
+    auto vector = std::dynamic_pointer_cast<RowVector>(
+        velox::test::BatchMaker::createBatch(rowType, rowsPerVector, *pool_));
+    vectors.push_back(vector);
+  }
+  return vectors;
+}
+
+std::shared_ptr<exec::Task> HiveConnectorTestBase::assertQuery(
+    const core::PlanNodePtr& plan,
+    const std::vector<std::shared_ptr<TempFilePath>>& filePaths,
+    const std::string& duckDbSql) {
+  return OperatorTestBase::assertQuery(
+      plan, makeHiveConnectorSplits(filePaths), duckDbSql);
+}
+
+std::shared_ptr<Task> HiveConnectorTestBase::assertQuery(
+    const core::PlanNodePtr& plan,
+    const std::vector<std::shared_ptr<connector::ConnectorSplit>>& splits,
+    const std::string& duckDbSql,
+    const int32_t numPrefetchSplit) {
+  return AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(
+          core::QueryConfig::kMaxSplitPreloadPerDriver,
+          std::to_string(numPrefetchSplit))
+      .splits(splits)
+      .assertResults(duckDbSql);
+}
+
+std::vector<std::shared_ptr<TempFilePath>> HiveConnectorTestBase::makeFilePaths(
+    int count) {
+  std::vector<std::shared_ptr<TempFilePath>> filePaths;
+
+  filePaths.reserve(count);
+  for (auto i = 0; i < count; ++i) {
+    filePaths.emplace_back(TempFilePath::create());
+  }
+  return filePaths;
+}
+
+std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>>
+HiveConnectorTestBase::makeHiveConnectorSplits(
+    const std::string& filePath,
+    uint32_t splitCount,
+    dwio::common::FileFormat format,
+    const std::optional<
+        std::unordered_map<std::string, std::optional<std::string>>>&
+        partitionKeys,
+    const std::optional<std::unordered_map<std::string, std::string>>&
+        infoColumns) {
+  auto file =
+      filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);
+  const uint64_t fileSize = file->size();
+  // Take the upper bound.
+  const uint64_t splitSize = std::ceil((fileSize) / splitCount);
+  std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>> splits;
+  // Add all the splits.
+  for (uint32_t i = 0; i < splitCount; i++) {
+    auto splitBuilder = HiveConnectorSplitBuilder(filePath)
+                            .fileFormat(format)
+                            .start(i * splitSize)
+                            .length(splitSize);
+    if (infoColumns.has_value()) {
+      for (const auto& infoColumn : infoColumns.value()) {
+        splitBuilder.infoColumn(infoColumn.first, infoColumn.second);
+      }
+    }
+    if (partitionKeys.has_value()) {
+      for (const auto& partitionKey : partitionKeys.value()) {
+        splitBuilder.partitionKey(partitionKey.first, partitionKey.second);
+      }
+    }
+
+    auto split = splitBuilder.build();
+    splits.push_back(std::move(split));
+  }
+  return splits;
+}
+
+std::unique_ptr<connector::hive::HiveColumnHandle>
+HiveConnectorTestBase::makeColumnHandle(
+    const std::string& name,
+    const TypePtr& type,
+    const std::vector<std::string>& requiredSubfields) {
+  return makeColumnHandle(name, type, type, requiredSubfields);
+}
+
+std::unique_ptr<connector::hive::HiveColumnHandle>
+HiveConnectorTestBase::makeColumnHandle(
+    const std::string& name,
+    const TypePtr& dataType,
+    const TypePtr& hiveType,
+    const std::vector<std::string>& requiredSubfields,
+    connector::hive::HiveColumnHandle::ColumnType columnType) {
+  std::vector<common::Subfield> subfields;
+  subfields.reserve(requiredSubfields.size());
+  for (auto& path : requiredSubfields) {
+    subfields.emplace_back(path);
+  }
+
+  return std::make_unique<connector::hive::HiveColumnHandle>(
+      name, columnType, dataType, hiveType, std::move(subfields));
+}
+
+std::vector<std::shared_ptr<connector::ConnectorSplit>>
+HiveConnectorTestBase::makeHiveConnectorSplits(
+    const std::vector<std::shared_ptr<TempFilePath>>& filePaths) {
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> splits;
+  splits.reserve(filePaths.size());
+  for (const auto& filePath : filePaths) {
+    splits.push_back(makeHiveConnectorSplit(
+        filePath->getPath(),
+        filePath->fileSize(),
+        filePath->fileModifiedTime(),
+        0,
+        std::numeric_limits<uint64_t>::max()));
+  }
+  return splits;
+}
+
+std::shared_ptr<connector::hive::HiveConnectorSplit>
+HiveConnectorTestBase::makeHiveConnectorSplit(
+    const std::string& filePath,
+    uint64_t start,
+    uint64_t length,
+    int64_t splitWeight,
+    bool cacheable) {
+  return HiveConnectorSplitBuilder(filePath)
+      .start(start)
+      .length(length)
+      .splitWeight(splitWeight)
+      .cacheable(cacheable)
+      .build();
+}
+
+std::shared_ptr<connector::hive::HiveConnectorSplit>
+HiveConnectorTestBase::makeHiveConnectorSplit(
+    const std::string& filePath,
+    int64_t fileSize,
+    int64_t fileModifiedTime,
+    uint64_t start,
+    uint64_t length) {
+  return HiveConnectorSplitBuilder(filePath)
+      .infoColumn("$file_size", fmt::format("{}", fileSize))
+      .infoColumn("$file_modified_time", fmt::format("{}", fileModifiedTime))
+      .start(start)
+      .length(length)
+      .build();
+}
+
+// static
+std::shared_ptr<connector::hive::HiveInsertTableHandle>
+HiveConnectorTestBase::makeHiveInsertTableHandle(
+    const std::vector<std::string>& tableColumnNames,
+    const std::vector<TypePtr>& tableColumnTypes,
+    const std::vector<std::string>& partitionedBy,
+    std::shared_ptr<connector::hive::LocationHandle> locationHandle,
+    const dwio::common::FileFormat tableStorageFormat,
+    const std::optional<common::CompressionKind> compressionKind,
+    const std::shared_ptr<dwio::common::WriterOptions>& writerOptions,
+    const bool ensureFiles) {
+  return makeHiveInsertTableHandle(
+      tableColumnNames,
+      tableColumnTypes,
+      partitionedBy,
+      nullptr,
+      std::move(locationHandle),
+      tableStorageFormat,
+      compressionKind,
+      {},
+      writerOptions,
+      ensureFiles);
+}
+
+// static
+std::shared_ptr<connector::hive::HiveInsertTableHandle>
+HiveConnectorTestBase::makeHiveInsertTableHandle(
+    const std::vector<std::string>& tableColumnNames,
+    const std::vector<TypePtr>& tableColumnTypes,
+    const std::vector<std::string>& partitionedBy,
+    std::shared_ptr<connector::hive::HiveBucketProperty> bucketProperty,
+    std::shared_ptr<connector::hive::LocationHandle> locationHandle,
+    const dwio::common::FileFormat tableStorageFormat,
+    const std::optional<common::CompressionKind> compressionKind,
+    const std::unordered_map<std::string, std::string>& serdeParameters,
+    const std::shared_ptr<dwio::common::WriterOptions>& writerOptions,
+    const bool ensureFiles) {
+  std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
+      columnHandles;
+  std::vector<std::string> bucketedBy;
+  std::vector<TypePtr> bucketedTypes;
+  std::vector<std::shared_ptr<const connector::hive::HiveSortingColumn>>
+      sortedBy;
+  if (bucketProperty != nullptr) {
+    bucketedBy = bucketProperty->bucketedBy();
+    bucketedTypes = bucketProperty->bucketedTypes();
+    sortedBy = bucketProperty->sortedBy();
+  }
+  int32_t numPartitionColumns{0};
+  int32_t numSortingColumns{0};
+  int32_t numBucketColumns{0};
+  for (int i = 0; i < tableColumnNames.size(); ++i) {
+    for (int j = 0; j < bucketedBy.size(); ++j) {
+      if (bucketedBy[j] == tableColumnNames[i]) {
+        ++numBucketColumns;
+      }
+    }
+    for (int j = 0; j < sortedBy.size(); ++j) {
+      if (sortedBy[j]->sortColumn() == tableColumnNames[i]) {
+        ++numSortingColumns;
+      }
+    }
+    if (std::find(
+            partitionedBy.cbegin(),
+            partitionedBy.cend(),
+            tableColumnNames.at(i)) != partitionedBy.cend()) {
+      ++numPartitionColumns;
+      columnHandles.push_back(
+          std::make_shared<connector::hive::HiveColumnHandle>(
+              tableColumnNames.at(i),
+              connector::hive::HiveColumnHandle::ColumnType::kPartitionKey,
+              tableColumnTypes.at(i),
+              tableColumnTypes.at(i)));
+    } else {
+      columnHandles.push_back(
+          std::make_shared<connector::hive::HiveColumnHandle>(
+              tableColumnNames.at(i),
+              connector::hive::HiveColumnHandle::ColumnType::kRegular,
+              tableColumnTypes.at(i),
+              tableColumnTypes.at(i)));
+    }
+  }
+  VELOX_CHECK_EQ(numPartitionColumns, partitionedBy.size());
+  VELOX_CHECK_EQ(numBucketColumns, bucketedBy.size());
+  VELOX_CHECK_EQ(numSortingColumns, sortedBy.size());
+
+  return std::make_shared<connector::hive::HiveInsertTableHandle>(
+      columnHandles,
+      locationHandle,
+      tableStorageFormat,
+      bucketProperty,
+      compressionKind,
+      serdeParameters,
+      writerOptions,
+      ensureFiles);
+}
+
+std::shared_ptr<connector::hive::HiveColumnHandle>
+HiveConnectorTestBase::regularColumn(
+    const std::string& name,
+    const TypePtr& type) {
+  return std::make_shared<connector::hive::HiveColumnHandle>(
+      name,
+      connector::hive::HiveColumnHandle::ColumnType::kRegular,
+      type,
+      type);
+}
+
+std::shared_ptr<connector::hive::HiveColumnHandle>
+HiveConnectorTestBase::synthesizedColumn(
+    const std::string& name,
+    const TypePtr& type) {
+  return std::make_shared<connector::hive::HiveColumnHandle>(
+      name,
+      connector::hive::HiveColumnHandle::ColumnType::kSynthesized,
+      type,
+      type);
+}
+
+std::shared_ptr<connector::hive::HiveColumnHandle>
+HiveConnectorTestBase::partitionKey(
+    const std::string& name,
+    const TypePtr& type) {
+  return std::make_shared<connector::hive::HiveColumnHandle>(
+      name,
+      connector::hive::HiveColumnHandle::ColumnType::kPartitionKey,
+      type,
+      type);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/connectors/lakehouse/common/tests/HiveConnectorTestBase.h
+++ b/velox/connectors/lakehouse/common/tests/HiveConnectorTestBase.h
@@ -15,19 +15,19 @@
  */
 #pragma once
 
-#include "velox/connectors/hive/HiveConnectorSplit.h"
-#include "velox/connectors/hive/HiveDataSink.h"
-#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/lakehouse/common/HiveConnectorSplit.h"
+#include "velox/connectors/lakehouse/common/HiveDataSink.h"
+#include "velox/connectors/lakehouse/common/TableHandle.h"
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
 
-namespace facebook::velox::exec::test {
+namespace facebook::velox::connector::lakehouse::common::test {
 
 static const std::string kHiveConnectorId = "test-hive";
 
-class HiveConnectorTestBase : public OperatorTestBase {
+class HiveConnectorTestBase : public exec::test::OperatorTestBase {
  public:
   HiveConnectorTestBase();
 
@@ -76,36 +76,35 @@ class HiveConnectorTestBase : public OperatorTestBase {
       int32_t numVectors,
       int32_t rowsPerVector);
 
-  using OperatorTestBase::assertQuery;
+  using exec::test::OperatorTestBase::assertQuery;
 
   /// Assumes plan has a single TableScan node.
   std::shared_ptr<exec::Task> assertQuery(
       const core::PlanNodePtr& plan,
-      const std::vector<std::shared_ptr<TempFilePath>>& filePaths,
+      const std::vector<std::shared_ptr<exec::test::TempFilePath>>& filePaths,
       const std::string& duckDbSql);
 
-  std::shared_ptr<Task> assertQuery(
+  std::shared_ptr<exec::Task> assertQuery(
       const core::PlanNodePtr& plan,
       const std::vector<std::shared_ptr<connector::ConnectorSplit>>& splits,
       const std::string& duckDbSql,
       const int32_t numPrefetchSplit);
 
-  static std::vector<std::shared_ptr<TempFilePath>> makeFilePaths(int count);
+  static std::vector<std::shared_ptr<exec::test::TempFilePath>> makeFilePaths(
+      int count);
 
   static std::vector<std::shared_ptr<connector::ConnectorSplit>>
   makeHiveConnectorSplits(
-      const std::vector<std::shared_ptr<TempFilePath>>& filePaths);
+      const std::vector<std::shared_ptr<exec::test::TempFilePath>>& filePaths);
 
-  static std::shared_ptr<connector::hive::HiveConnectorSplit>
-  makeHiveConnectorSplit(
+  static std::shared_ptr<HiveConnectorSplit> makeHiveConnectorSplit(
       const std::string& filePath,
       uint64_t start = 0,
       uint64_t length = std::numeric_limits<uint64_t>::max(),
       int64_t splitWeight = 0,
       bool cacheable = true);
 
-  static std::shared_ptr<connector::hive::HiveConnectorSplit>
-  makeHiveConnectorSplit(
+  static std::shared_ptr<HiveConnectorSplit> makeHiveConnectorSplit(
       const std::string& filePath,
       int64_t fileSize,
       int64_t fileModifiedTime,
@@ -114,7 +113,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
 
   /// Split file at path 'filePath' into 'splitCount' splits. If not local file,
   /// file size can be given as 'externalSize'.
-  static std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>>
+  static std::vector<std::shared_ptr<HiveConnectorSplit>>
   makeHiveConnectorSplits(
       const std::string& filePath,
       uint32_t splitCount,
@@ -125,15 +124,15 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::optional<std::unordered_map<std::string, std::string>>&
           infoColumns = {});
 
-  static std::shared_ptr<connector::hive::HiveTableHandle> makeTableHandle(
-      common::SubfieldFilters subfieldFilters = {},
+  static std::shared_ptr<HiveTableHandle> makeTableHandle(
+      velox::common::SubfieldFilters subfieldFilters = {},
       const core::TypedExprPtr& remainingFilter = nullptr,
       const std::string& tableName = "hive_table",
       const RowTypePtr& dataColumns = nullptr,
       bool filterPushdownEnabled = true,
       const std::unordered_map<std::string, std::string>& tableParameters =
           {}) {
-    return std::make_shared<connector::hive::HiveTableHandle>(
+    return std::make_shared<HiveTableHandle>(
         kHiveConnectorId,
         tableName,
         filterPushdownEnabled,
@@ -146,7 +145,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
   /// @param name Column name.
   /// @param type Column type.
   /// @param Required subfields of this column.
-  static std::unique_ptr<connector::hive::HiveColumnHandle> makeColumnHandle(
+  static std::unique_ptr<HiveColumnHandle> makeColumnHandle(
       const std::string& name,
       const TypePtr& type,
       const std::vector<std::string>& requiredSubfields);
@@ -155,25 +154,24 @@ class HiveConnectorTestBase : public OperatorTestBase {
   /// @param type Column type.
   /// @param type Hive type.
   /// @param Required subfields of this column.
-  static std::unique_ptr<connector::hive::HiveColumnHandle> makeColumnHandle(
+  static std::unique_ptr<HiveColumnHandle> makeColumnHandle(
       const std::string& name,
       const TypePtr& dataType,
       const TypePtr& hiveType,
       const std::vector<std::string>& requiredSubfields,
-      connector::hive::HiveColumnHandle::ColumnType columnType =
-          connector::hive::HiveColumnHandle::ColumnType::kRegular);
+      HiveColumnHandle::ColumnType columnType =
+          HiveColumnHandle::ColumnType::kRegular);
 
   /// @param targetDirectory Final directory of the target table after commit.
   /// @param writeDirectory Write directory of the target table before commit.
   /// @param tableType Whether to create a new table, insert into an existing
   /// table, or write a temporary table.
   /// @param writeMode How to write to the target directory.
-  static std::shared_ptr<connector::hive::LocationHandle> makeLocationHandle(
+  static std::shared_ptr<LocationHandle> makeLocationHandle(
       std::string targetDirectory,
       std::optional<std::string> writeDirectory = std::nullopt,
-      connector::hive::LocationHandle::TableType tableType =
-          connector::hive::LocationHandle::TableType::kNew) {
-    return std::make_shared<connector::hive::LocationHandle>(
+      LocationHandle::TableType tableType = LocationHandle::TableType::kNew) {
+    return std::make_shared<LocationHandle>(
         targetDirectory, writeDirectory.value_or(targetDirectory), tableType);
   }
 
@@ -190,43 +188,41 @@ class HiveConnectorTestBase : public OperatorTestBase {
   /// @param serdeParameters Table writer configuration parameters.
   /// @param ensureFiles When this option is set the HiveDataSink will always
   /// create a file even if there is no data.
-  static std::shared_ptr<connector::hive::HiveInsertTableHandle>
-  makeHiveInsertTableHandle(
+  static std::shared_ptr<HiveInsertTableHandle> makeHiveInsertTableHandle(
       const std::vector<std::string>& tableColumnNames,
       const std::vector<TypePtr>& tableColumnTypes,
       const std::vector<std::string>& partitionedBy,
-      std::shared_ptr<connector::hive::HiveBucketProperty> bucketProperty,
-      std::shared_ptr<connector::hive::LocationHandle> locationHandle,
+      std::shared_ptr<HiveBucketProperty> bucketProperty,
+      std::shared_ptr<LocationHandle> locationHandle,
       const dwio::common::FileFormat tableStorageFormat =
           dwio::common::FileFormat::DWRF,
-      const std::optional<common::CompressionKind> compressionKind = {},
+      const std::optional<velox::common::CompressionKind> compressionKind = {},
       const std::unordered_map<std::string, std::string>& serdeParameters = {},
       const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
           nullptr,
       const bool ensureFiles = false);
 
-  static std::shared_ptr<connector::hive::HiveInsertTableHandle>
-  makeHiveInsertTableHandle(
+  static std::shared_ptr<HiveInsertTableHandle> makeHiveInsertTableHandle(
       const std::vector<std::string>& tableColumnNames,
       const std::vector<TypePtr>& tableColumnTypes,
       const std::vector<std::string>& partitionedBy,
-      std::shared_ptr<connector::hive::LocationHandle> locationHandle,
+      std::shared_ptr<LocationHandle> locationHandle,
       const dwio::common::FileFormat tableStorageFormat =
           dwio::common::FileFormat::DWRF,
-      const std::optional<common::CompressionKind> compressionKind = {},
+      const std::optional<velox::common::CompressionKind> compressionKind = {},
       const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
           nullptr,
       const bool ensureFiles = false);
 
-  static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
+  static std::shared_ptr<HiveColumnHandle> regularColumn(
       const std::string& name,
       const TypePtr& type);
 
-  static std::shared_ptr<connector::hive::HiveColumnHandle> partitionKey(
+  static std::shared_ptr<HiveColumnHandle> partitionKey(
       const std::string& name,
       const TypePtr& type);
 
-  static std::shared_ptr<connector::hive::HiveColumnHandle> synthesizedColumn(
+  static std::shared_ptr<HiveColumnHandle> synthesizedColumn(
       const std::string& name,
       const TypePtr& type);
 
@@ -242,15 +238,14 @@ class HiveConnectorTestBase : public OperatorTestBase {
   }
 };
 
-/// Same as connector::hive::HiveConnectorBuilder, except that this defaults
+/// Same as HiveConnectorBuilder, except that this defaults
 /// connectorId to kHiveConnectorId.
-class HiveConnectorSplitBuilder
-    : public connector::hive::HiveConnectorSplitBuilder {
+class HiveConnectorSplitBuilder : public common::HiveConnectorSplitBuilder {
  public:
   explicit HiveConnectorSplitBuilder(std::string filePath)
-      : connector::hive::HiveConnectorSplitBuilder(std::move(filePath)) {
+      : common::HiveConnectorSplitBuilder(std::move(filePath)) {
     connectorId(kHiveConnectorId);
   }
 };
 
-} // namespace facebook::velox::exec::test
+} // namespace facebook::velox::connector::lakehouse::common::test

--- a/velox/connectors/lakehouse/common/tests/HiveConnectorTestBase.h
+++ b/velox/connectors/lakehouse/common/tests/HiveConnectorTestBase.h
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/dwrf/common/Config.h"
+#include "velox/dwio/dwrf/writer/FlushPolicy.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/TempFilePath.h"
+
+namespace facebook::velox::exec::test {
+
+static const std::string kHiveConnectorId = "test-hive";
+
+class HiveConnectorTestBase : public OperatorTestBase {
+ public:
+  HiveConnectorTestBase();
+
+  void SetUp() override;
+  void TearDown() override;
+
+  void resetHiveConnector(
+      const std::shared_ptr<const config::ConfigBase>& config);
+
+  void writeToFiles(
+      const std::vector<std::string>& filePaths,
+      std::vector<RowVectorPtr> vectors);
+
+  void writeToFile(const std::string& filePath, RowVectorPtr vector);
+
+  void writeToFile(
+      const std::string& filePath,
+      const std::vector<RowVectorPtr>& vectors,
+      std::shared_ptr<dwrf::Config> config =
+          std::make_shared<facebook::velox::dwrf::Config>(),
+      const std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()>&
+          flushPolicyFactory = nullptr);
+
+  void writeToFile(
+      const std::string& filePath,
+      const std::vector<RowVectorPtr>& vectors,
+      std::shared_ptr<dwrf::Config> config,
+      const TypePtr& schema,
+      const std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()>&
+          flushPolicyFactory = nullptr);
+
+  // Creates a directory using matching file system based on directoryPath.
+  // No throw when directory already exists.
+  void createDirectory(const std::string& directoryPath);
+
+  // Removes a directory using matching file system based on directoryPath.
+  // No op when directory does not exist.
+  void removeDirectory(const std::string& directoryPath);
+
+  // Removes a file using matching file system based on filePath.
+  // No op when file does not exist.
+  void removeFile(const std::string& filePath);
+
+  std::vector<RowVectorPtr> makeVectors(
+      const RowTypePtr& rowType,
+      int32_t numVectors,
+      int32_t rowsPerVector);
+
+  using OperatorTestBase::assertQuery;
+
+  /// Assumes plan has a single TableScan node.
+  std::shared_ptr<exec::Task> assertQuery(
+      const core::PlanNodePtr& plan,
+      const std::vector<std::shared_ptr<TempFilePath>>& filePaths,
+      const std::string& duckDbSql);
+
+  std::shared_ptr<Task> assertQuery(
+      const core::PlanNodePtr& plan,
+      const std::vector<std::shared_ptr<connector::ConnectorSplit>>& splits,
+      const std::string& duckDbSql,
+      const int32_t numPrefetchSplit);
+
+  static std::vector<std::shared_ptr<TempFilePath>> makeFilePaths(int count);
+
+  static std::vector<std::shared_ptr<connector::ConnectorSplit>>
+  makeHiveConnectorSplits(
+      const std::vector<std::shared_ptr<TempFilePath>>& filePaths);
+
+  static std::shared_ptr<connector::hive::HiveConnectorSplit>
+  makeHiveConnectorSplit(
+      const std::string& filePath,
+      uint64_t start = 0,
+      uint64_t length = std::numeric_limits<uint64_t>::max(),
+      int64_t splitWeight = 0,
+      bool cacheable = true);
+
+  static std::shared_ptr<connector::hive::HiveConnectorSplit>
+  makeHiveConnectorSplit(
+      const std::string& filePath,
+      int64_t fileSize,
+      int64_t fileModifiedTime,
+      uint64_t start,
+      uint64_t length);
+
+  /// Split file at path 'filePath' into 'splitCount' splits. If not local file,
+  /// file size can be given as 'externalSize'.
+  static std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>>
+  makeHiveConnectorSplits(
+      const std::string& filePath,
+      uint32_t splitCount,
+      dwio::common::FileFormat format,
+      const std::optional<
+          std::unordered_map<std::string, std::optional<std::string>>>&
+          partitionKeys = {},
+      const std::optional<std::unordered_map<std::string, std::string>>&
+          infoColumns = {});
+
+  static std::shared_ptr<connector::hive::HiveTableHandle> makeTableHandle(
+      common::SubfieldFilters subfieldFilters = {},
+      const core::TypedExprPtr& remainingFilter = nullptr,
+      const std::string& tableName = "hive_table",
+      const RowTypePtr& dataColumns = nullptr,
+      bool filterPushdownEnabled = true,
+      const std::unordered_map<std::string, std::string>& tableParameters =
+          {}) {
+    return std::make_shared<connector::hive::HiveTableHandle>(
+        kHiveConnectorId,
+        tableName,
+        filterPushdownEnabled,
+        std::move(subfieldFilters),
+        remainingFilter,
+        dataColumns,
+        tableParameters);
+  }
+
+  /// @param name Column name.
+  /// @param type Column type.
+  /// @param Required subfields of this column.
+  static std::unique_ptr<connector::hive::HiveColumnHandle> makeColumnHandle(
+      const std::string& name,
+      const TypePtr& type,
+      const std::vector<std::string>& requiredSubfields);
+
+  /// @param name Column name.
+  /// @param type Column type.
+  /// @param type Hive type.
+  /// @param Required subfields of this column.
+  static std::unique_ptr<connector::hive::HiveColumnHandle> makeColumnHandle(
+      const std::string& name,
+      const TypePtr& dataType,
+      const TypePtr& hiveType,
+      const std::vector<std::string>& requiredSubfields,
+      connector::hive::HiveColumnHandle::ColumnType columnType =
+          connector::hive::HiveColumnHandle::ColumnType::kRegular);
+
+  /// @param targetDirectory Final directory of the target table after commit.
+  /// @param writeDirectory Write directory of the target table before commit.
+  /// @param tableType Whether to create a new table, insert into an existing
+  /// table, or write a temporary table.
+  /// @param writeMode How to write to the target directory.
+  static std::shared_ptr<connector::hive::LocationHandle> makeLocationHandle(
+      std::string targetDirectory,
+      std::optional<std::string> writeDirectory = std::nullopt,
+      connector::hive::LocationHandle::TableType tableType =
+          connector::hive::LocationHandle::TableType::kNew) {
+    return std::make_shared<connector::hive::LocationHandle>(
+        targetDirectory, writeDirectory.value_or(targetDirectory), tableType);
+  }
+
+  /// Build a HiveInsertTableHandle.
+  /// @param tableColumnNames Column names of the target table. Corresponding
+  /// type of tableColumnNames[i] is tableColumnTypes[i].
+  /// @param tableColumnTypes Column types of the target table. Corresponding
+  /// name of tableColumnTypes[i] is tableColumnNames[i].
+  /// @param partitionedBy A list of partition columns of the target table.
+  /// @param bucketProperty if not nulll, specifies the property for a bucket
+  /// table.
+  /// @param locationHandle Location handle for the table write.
+  /// @param compressionKind compression algorithm to use for table write.
+  /// @param serdeParameters Table writer configuration parameters.
+  /// @param ensureFiles When this option is set the HiveDataSink will always
+  /// create a file even if there is no data.
+  static std::shared_ptr<connector::hive::HiveInsertTableHandle>
+  makeHiveInsertTableHandle(
+      const std::vector<std::string>& tableColumnNames,
+      const std::vector<TypePtr>& tableColumnTypes,
+      const std::vector<std::string>& partitionedBy,
+      std::shared_ptr<connector::hive::HiveBucketProperty> bucketProperty,
+      std::shared_ptr<connector::hive::LocationHandle> locationHandle,
+      const dwio::common::FileFormat tableStorageFormat =
+          dwio::common::FileFormat::DWRF,
+      const std::optional<common::CompressionKind> compressionKind = {},
+      const std::unordered_map<std::string, std::string>& serdeParameters = {},
+      const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
+          nullptr,
+      const bool ensureFiles = false);
+
+  static std::shared_ptr<connector::hive::HiveInsertTableHandle>
+  makeHiveInsertTableHandle(
+      const std::vector<std::string>& tableColumnNames,
+      const std::vector<TypePtr>& tableColumnTypes,
+      const std::vector<std::string>& partitionedBy,
+      std::shared_ptr<connector::hive::LocationHandle> locationHandle,
+      const dwio::common::FileFormat tableStorageFormat =
+          dwio::common::FileFormat::DWRF,
+      const std::optional<common::CompressionKind> compressionKind = {},
+      const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
+          nullptr,
+      const bool ensureFiles = false);
+
+  static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
+      const std::string& name,
+      const TypePtr& type);
+
+  static std::shared_ptr<connector::hive::HiveColumnHandle> partitionKey(
+      const std::string& name,
+      const TypePtr& type);
+
+  static std::shared_ptr<connector::hive::HiveColumnHandle> synthesizedColumn(
+      const std::string& name,
+      const TypePtr& type);
+
+  static connector::ColumnHandleMap allRegularColumns(
+      const RowTypePtr& rowType) {
+    connector::ColumnHandleMap assignments;
+    assignments.reserve(rowType->size());
+    for (uint32_t i = 0; i < rowType->size(); ++i) {
+      const auto& name = rowType->nameOf(i);
+      assignments[name] = regularColumn(name, rowType->childAt(i));
+    }
+    return assignments;
+  }
+};
+
+/// Same as connector::hive::HiveConnectorBuilder, except that this defaults
+/// connectorId to kHiveConnectorId.
+class HiveConnectorSplitBuilder
+    : public connector::hive::HiveConnectorSplitBuilder {
+ public:
+  explicit HiveConnectorSplitBuilder(std::string filePath)
+      : connector::hive::HiveConnectorSplitBuilder(std::move(filePath)) {
+    connectorId(kHiveConnectorId);
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/connectors/lakehouse/common/tests/PlanBuilder.cpp
+++ b/velox/connectors/lakehouse/common/tests/PlanBuilder.cpp
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-#include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/connectors/hive/HiveConnector.h"
-#include "velox/connectors/hive/TableHandle.h"
-#include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/connectors/lakehouse/common/tests/PlanBuilder.h"
+
+#include "velox/common/base/Status.h"
+#include "velox/connectors/lakehouse/common/HiveConnector.h"
+#include "velox/connectors/lakehouse/common/TableHandle.h"
 #include "velox/core/FilterToExpression.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/Aggregate.h"
@@ -28,16 +29,17 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
+#include "velox/expression/FunctionSignature.h"
 #include "velox/expression/SignatureBinder.h"
 #include "velox/expression/VectorReaders.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/TypeResolver.h"
 
 using namespace facebook::velox;
-using namespace facebook::velox::connector;
-using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::connector::lakehouse::common;
 
-namespace facebook::velox::exec::test {
+namespace facebook::velox::connector::lakehouse::common::test {
 namespace {
 
 core::TypedExprPtr parseExpr(
@@ -120,47 +122,6 @@ PlanBuilder& PlanBuilder::tableScanWithPushDown(
       .endTableScan();
 }
 
-PlanBuilder& PlanBuilder::tpchTableScan(
-    tpch::Table table,
-    std::vector<std::string> columnNames,
-    double scaleFactor,
-    std::string_view connectorId,
-    const std::string& filter) {
-  connector::ColumnHandleMap assignmentsMap;
-  std::vector<TypePtr> outputTypes;
-
-  assignmentsMap.reserve(columnNames.size());
-  outputTypes.reserve(columnNames.size());
-
-  for (const auto& columnName : columnNames) {
-    assignmentsMap.emplace(
-        columnName,
-        std::make_shared<connector::tpch::TpchColumnHandle>(columnName));
-    outputTypes.emplace_back(resolveTpchColumn(table, columnName));
-  }
-  auto rowType = ROW(std::move(columnNames), std::move(outputTypes));
-
-  core::TypedExprPtr filterExpression;
-  if (!filter.empty()) {
-    auto expression = parse::parseExpr(filter, options_);
-    filterExpression =
-        core::Expressions::inferTypes(expression, rowType, pool_);
-  }
-
-  auto tableHandle = std::make_shared<connector::tpch::TpchTableHandle>(
-      std::string(connectorId),
-      table,
-      scaleFactor,
-      std::move(filterExpression));
-
-  return TableScanBuilder(*this)
-      .filtersAsNode(filtersAsNode_ ? planNodeIdGenerator_ : nullptr)
-      .outputType(rowType)
-      .tableHandle(tableHandle)
-      .assignments(assignmentsMap)
-      .endTableScan();
-}
-
 PlanBuilder::TableScanBuilder& PlanBuilder::TableScanBuilder::subfieldFilters(
     std::vector<std::string> subfieldFilters) {
   VELOX_CHECK(subfieldFiltersMap_.empty());
@@ -185,7 +146,7 @@ PlanBuilder::TableScanBuilder& PlanBuilder::TableScanBuilder::subfieldFilters(
 
     auto it = columnAliases_.find(subfield.toString());
     if (it != columnAliases_.end()) {
-      subfield = common::Subfield(it->second);
+      subfield = velox::common::Subfield(it->second);
     }
     VELOX_CHECK_EQ(
         subfieldFiltersMap_.count(subfield),
@@ -200,7 +161,7 @@ PlanBuilder::TableScanBuilder& PlanBuilder::TableScanBuilder::subfieldFilters(
 
 PlanBuilder::TableScanBuilder&
 PlanBuilder::TableScanBuilder::subfieldFiltersMap(
-    const common::SubfieldFilters& filtersMap) {
+    const velox::common::SubfieldFilters& filtersMap) {
   for (const auto& [k, v] : filtersMap) {
     subfieldFiltersMap_[k.clone()] = v->clone();
   }
@@ -316,7 +277,8 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
   // columnHandles, bucketProperty and locationHandle.
   if (!insertHandle_) {
     // Create column handles.
-    std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
+    std::vector<
+        std::shared_ptr<const connector::lakehouse::common::HiveColumnHandle>>
         columnHandles;
     for (auto i = 0; i < outputType->size(); ++i) {
       const auto column = outputType->nameOf(i);
@@ -324,20 +286,22 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
           std::find(partitionBy_.begin(), partitionBy_.end(), column) !=
           partitionBy_.end();
       columnHandles.push_back(
-          std::make_shared<connector::hive::HiveColumnHandle>(
+          std::make_shared<connector::lakehouse::common::HiveColumnHandle>(
               column,
-              isPartitionKey
-                  ? connector::hive::HiveColumnHandle::ColumnType::kPartitionKey
-                  : connector::hive::HiveColumnHandle::ColumnType::kRegular,
+              isPartitionKey ? connector::lakehouse::common::HiveColumnHandle::
+                                   ColumnType::kPartitionKey
+                             : connector::lakehouse::common::HiveColumnHandle::
+                                   ColumnType::kRegular,
               outputType->childAt(i),
               outputType->childAt(i)));
     }
 
-    auto locationHandle = std::make_shared<connector::hive::LocationHandle>(
-        outputDirectoryPath_,
-        outputDirectoryPath_,
-        connector::hive::LocationHandle::TableType::kNew,
-        outputFileName_);
+    auto locationHandle =
+        std::make_shared<connector::lakehouse::common::LocationHandle>(
+            outputDirectoryPath_,
+            outputDirectoryPath_,
+            connector::lakehouse::common::LocationHandle::TableType::kNew,
+            outputFileName_);
 
     std::shared_ptr<HiveBucketProperty> bucketProperty;
     if (bucketCount_ != 0) {
@@ -345,15 +309,16 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
           outputType, bucketCount_, bucketedBy_, sortBy_);
     }
 
-    auto hiveHandle = std::make_shared<connector::hive::HiveInsertTableHandle>(
-        columnHandles,
-        locationHandle,
-        fileFormat_,
-        bucketProperty,
-        compressionKind_,
-        serdeParameters_,
-        options_,
-        ensureFiles_);
+    auto hiveHandle =
+        std::make_shared<connector::lakehouse::common::HiveInsertTableHandle>(
+            columnHandles,
+            locationHandle,
+            fileFormat_,
+            bucketProperty,
+            compressionKind_,
+            serdeParameters_,
+            options_,
+            ensureFiles_);
 
     insertHandle_ =
         std::make_shared<core::InsertTableHandle>(connectorId_, hiveHandle);
@@ -689,7 +654,7 @@ PlanBuilder& PlanBuilder::tableWrite(
     const std::unordered_map<std::string, std::string>& serdeParameters,
     const std::shared_ptr<dwio::common::WriterOptions>& options,
     const std::string& outputFileName,
-    const common::CompressionKind compressionKind,
+    const velox::common::CompressionKind compressionKind,
     const RowTypePtr& schema,
     const bool ensureFiles,
     const connector::CommitStrategy commitStrategy) {
@@ -744,7 +709,7 @@ std::string throwAggregateFunctionSignatureNotSupported(
         signatures) {
   std::stringstream error;
   error << "Aggregate function signature is not supported: "
-        << toString(name, types)
+        << exec::toString(name, types)
         << ". Supported signatures: " << toString(signatures) << ".";
   VELOX_USER_FAIL(error.str());
 }
@@ -1235,8 +1200,9 @@ PlanBuilder& PlanBuilder::expand(
               dynamic_cast<const core::ConstantExpr*>(untypedExpression.get());
           VELOX_CHECK_NOT_NULL(constantExpr);
           VELOX_CHECK(constantExpr->value().isNull());
-          projectExpr.push_back(std::make_shared<core::ConstantTypedExpr>(
-              expectedType, variant::null(expectedType->kind())));
+          projectExpr.push_back(
+              std::make_shared<core::ConstantTypedExpr>(
+                  expectedType, variant::null(expectedType->kind())));
         }
       }
     }
@@ -1543,7 +1509,7 @@ PlanBuilder& PlanBuilder::localPartition(
 }
 
 PlanBuilder& PlanBuilder::localPartitionByBucket(
-    const std::shared_ptr<connector::hive::HiveBucketProperty>&
+    const std::shared_ptr<connector::lakehouse::common::HiveBucketProperty>&
         bucketProperty) {
   VELOX_CHECK_NOT_NULL(planNode_, "LocalPartition cannot be the source node");
   std::vector<column_index_t> bucketChannels;
@@ -2090,7 +2056,7 @@ std::string throwWindowFunctionSignatureNotSupported(
     const std::vector<FunctionSignaturePtr>& signatures) {
   std::stringstream error;
   error << "Window function signature is not supported: "
-        << toString(name, types)
+        << exec::toString(name, types)
         << ". Supported signatures: " << toString(signatures) << ".";
   VELOX_USER_FAIL(error.str());
 }
@@ -2526,4 +2492,4 @@ core::TypedExprPtr PlanBuilder::inferTypes(
   return core::Expressions::inferTypes(
       untypedExpr, planNode_->outputType(), pool_);
 }
-} // namespace facebook::velox::exec::test
+} // namespace facebook::velox::connector::lakehouse::common::test

--- a/velox/connectors/lakehouse/common/tests/PlanBuilder.cpp
+++ b/velox/connectors/lakehouse/common/tests/PlanBuilder.cpp
@@ -1,0 +1,2529 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/core/FilterToExpression.h"
+#include "velox/duckdb/conversion/DuckParser.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/HashPartitionFunction.h"
+#include "velox/exec/RoundRobinPartitionFunction.h"
+#include "velox/exec/TableWriter.h"
+#include "velox/exec/WindowFunction.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprToSubfieldFilter.h"
+#include "velox/expression/FunctionCallToSpecialForm.h"
+#include "velox/expression/SignatureBinder.h"
+#include "velox/expression/VectorReaders.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/TypeResolver.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector;
+using namespace facebook::velox::connector::hive;
+
+namespace facebook::velox::exec::test {
+namespace {
+
+core::TypedExprPtr parseExpr(
+    const std::string& text,
+    const RowTypePtr& rowType,
+    const parse::ParseOptions& options,
+    memory::MemoryPool* pool) {
+  auto untyped = parse::parseExpr(text, options);
+  return core::Expressions::inferTypes(untyped, rowType, pool);
+}
+
+std::shared_ptr<HiveBucketProperty> buildHiveBucketProperty(
+    const RowTypePtr rowType,
+    int32_t bucketCount,
+    const std::vector<std::string>& bucketColumns,
+    const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortBy) {
+  std::vector<TypePtr> bucketTypes;
+  bucketTypes.reserve(bucketColumns.size());
+  for (const auto& bucketColumn : bucketColumns) {
+    bucketTypes.push_back(rowType->childAt(rowType->getChildIdx(bucketColumn)));
+  }
+  return std::make_shared<HiveBucketProperty>(
+      HiveBucketProperty::Kind::kHiveCompatible,
+      bucketCount,
+      bucketColumns,
+      bucketTypes,
+      sortBy);
+}
+} // namespace
+
+PlanBuilder& PlanBuilder::tableScan(
+    const RowTypePtr& outputType,
+    const std::vector<std::string>& subfieldFilters,
+    const std::string& remainingFilter,
+    const RowTypePtr& dataColumns,
+    const connector::ColumnHandleMap& assignments) {
+  return TableScanBuilder(*this)
+      .filtersAsNode(filtersAsNode_ ? planNodeIdGenerator_ : nullptr)
+      .outputType(outputType)
+      .assignments(assignments)
+      .dataColumns(dataColumns)
+      .subfieldFilters(subfieldFilters)
+      .remainingFilter(remainingFilter)
+      .endTableScan();
+}
+
+PlanBuilder& PlanBuilder::tableScan(
+    const std::string& tableName,
+    const RowTypePtr& outputType,
+    const std::unordered_map<std::string, std::string>& columnAliases,
+    const std::vector<std::string>& subfieldFilters,
+    const std::string& remainingFilter,
+    const RowTypePtr& dataColumns,
+    const connector::ColumnHandleMap& assignments) {
+  return TableScanBuilder(*this)
+      .filtersAsNode(filtersAsNode_ ? planNodeIdGenerator_ : nullptr)
+      .tableName(tableName)
+      .outputType(outputType)
+      .columnAliases(columnAliases)
+      .dataColumns(dataColumns)
+
+      .subfieldFilters(subfieldFilters)
+      .remainingFilter(remainingFilter)
+      .assignments(assignments)
+      .endTableScan();
+}
+
+PlanBuilder& PlanBuilder::tableScanWithPushDown(
+    const RowTypePtr& outputType,
+    const PushdownConfig& pushdownConfig,
+    const RowTypePtr& dataColumns,
+    const connector::ColumnHandleMap& assignments) {
+  return TableScanBuilder(*this)
+      .filtersAsNode(filtersAsNode_ ? planNodeIdGenerator_ : nullptr)
+      .outputType(outputType)
+      .assignments(assignments)
+      .dataColumns(dataColumns)
+      .subfieldFiltersMap(pushdownConfig.subfieldFiltersMap)
+      .remainingFilter(pushdownConfig.remainingFilter)
+      .endTableScan();
+}
+
+PlanBuilder& PlanBuilder::tpchTableScan(
+    tpch::Table table,
+    std::vector<std::string> columnNames,
+    double scaleFactor,
+    std::string_view connectorId,
+    const std::string& filter) {
+  connector::ColumnHandleMap assignmentsMap;
+  std::vector<TypePtr> outputTypes;
+
+  assignmentsMap.reserve(columnNames.size());
+  outputTypes.reserve(columnNames.size());
+
+  for (const auto& columnName : columnNames) {
+    assignmentsMap.emplace(
+        columnName,
+        std::make_shared<connector::tpch::TpchColumnHandle>(columnName));
+    outputTypes.emplace_back(resolveTpchColumn(table, columnName));
+  }
+  auto rowType = ROW(std::move(columnNames), std::move(outputTypes));
+
+  core::TypedExprPtr filterExpression;
+  if (!filter.empty()) {
+    auto expression = parse::parseExpr(filter, options_);
+    filterExpression =
+        core::Expressions::inferTypes(expression, rowType, pool_);
+  }
+
+  auto tableHandle = std::make_shared<connector::tpch::TpchTableHandle>(
+      std::string(connectorId),
+      table,
+      scaleFactor,
+      std::move(filterExpression));
+
+  return TableScanBuilder(*this)
+      .filtersAsNode(filtersAsNode_ ? planNodeIdGenerator_ : nullptr)
+      .outputType(rowType)
+      .tableHandle(tableHandle)
+      .assignments(assignmentsMap)
+      .endTableScan();
+}
+
+PlanBuilder::TableScanBuilder& PlanBuilder::TableScanBuilder::subfieldFilters(
+    std::vector<std::string> subfieldFilters) {
+  VELOX_CHECK(subfieldFiltersMap_.empty());
+
+  if (subfieldFilters.empty()) {
+    return *this;
+  }
+
+  // Parse subfield filters
+  auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), planBuilder_.pool_);
+  const RowTypePtr& parseType = dataColumns_ ? dataColumns_ : outputType_;
+
+  for (const auto& filter : subfieldFilters) {
+    auto untypedExpr = parse::parseExpr(filter, planBuilder_.options_);
+
+    // Parse directly to subfieldFiltersMap_
+    auto filterExpr = core::Expressions::inferTypes(
+        untypedExpr, parseType, planBuilder_.pool_);
+    auto [subfield, subfieldFilter] =
+        exec::toSubfieldFilter(filterExpr, &evaluator);
+
+    auto it = columnAliases_.find(subfield.toString());
+    if (it != columnAliases_.end()) {
+      subfield = common::Subfield(it->second);
+    }
+    VELOX_CHECK_EQ(
+        subfieldFiltersMap_.count(subfield),
+        0,
+        "Duplicate subfield: {}",
+        subfield.toString());
+
+    subfieldFiltersMap_[std::move(subfield)] = std::move(subfieldFilter);
+  }
+  return *this;
+}
+
+PlanBuilder::TableScanBuilder&
+PlanBuilder::TableScanBuilder::subfieldFiltersMap(
+    const common::SubfieldFilters& filtersMap) {
+  for (const auto& [k, v] : filtersMap) {
+    subfieldFiltersMap_[k.clone()] = v->clone();
+  }
+  return *this;
+}
+
+PlanBuilder::TableScanBuilder& PlanBuilder::TableScanBuilder::remainingFilter(
+    std::string remainingFilter) {
+  if (!remainingFilter.empty()) {
+    remainingFilter_ = parse::parseExpr(remainingFilter, planBuilder_.options_);
+  }
+  return *this;
+}
+
+namespace {
+void addConjunct(
+    const core::TypedExprPtr& conjunct,
+    core::TypedExprPtr& conjunction) {
+  if (!conjunction) {
+    conjunction = conjunct;
+  } else {
+    conjunction = std::make_shared<core::CallTypedExpr>(
+        BOOLEAN(),
+        std::vector<core::TypedExprPtr>{conjunction, conjunct},
+        "and");
+  }
+}
+} // namespace
+
+core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
+  VELOX_CHECK_NOT_NULL(outputType_, "outputType must be specified");
+  std::unordered_map<std::string, core::TypedExprPtr> typedMapping;
+  bool hasAssignments = !(assignments_.empty());
+  for (uint32_t i = 0; i < outputType_->size(); ++i) {
+    const auto& name = outputType_->nameOf(i);
+    const auto& type = outputType_->childAt(i);
+
+    std::string hiveColumnName = name;
+    auto it = columnAliases_.find(name);
+    if (it != columnAliases_.end()) {
+      hiveColumnName = it->second;
+      typedMapping.emplace(
+          name,
+          std::make_shared<core::FieldAccessTypedExpr>(type, hiveColumnName));
+    }
+
+    if (!hasAssignments) {
+      assignments_.insert(
+          {name,
+           std::make_shared<HiveColumnHandle>(
+               hiveColumnName,
+               HiveColumnHandle::ColumnType::kRegular,
+               type,
+               type)});
+    }
+  }
+
+  const RowTypePtr& parseType = dataColumns_ ? dataColumns_ : outputType_;
+
+  core::TypedExprPtr filterNodeExpr;
+
+  if (filtersAsNode_) {
+    for (const auto& [subfield, filter] : subfieldFiltersMap_) {
+      auto filterExpr = core::filterToExpr(
+          subfield, filter.get(), parseType, planBuilder_.pool_);
+
+      addConjunct(filterExpr, filterNodeExpr);
+    }
+
+    subfieldFiltersMap_.clear();
+  }
+
+  core::TypedExprPtr remainingFilterExpr;
+  if (remainingFilter_) {
+    remainingFilterExpr = core::Expressions::inferTypes(
+                              remainingFilter_, parseType, planBuilder_.pool_)
+                              ->rewriteInputNames(typedMapping);
+    if (filtersAsNode_) {
+      addConjunct(remainingFilterExpr, filterNodeExpr);
+      remainingFilterExpr = nullptr;
+    }
+  }
+
+  if (!tableHandle_) {
+    tableHandle_ = std::make_shared<HiveTableHandle>(
+        connectorId_,
+        tableName_,
+        true,
+        std::move(subfieldFiltersMap_),
+        remainingFilterExpr,
+        dataColumns_);
+  }
+  core::PlanNodePtr result = std::make_shared<core::TableScanNode>(
+      id, outputType_, tableHandle_, assignments_);
+
+  if (filtersAsNode_ && filterNodeExpr) {
+    auto filterId = planNodeIdGenerator_->next();
+    result =
+        std::make_shared<core::FilterNode>(filterId, filterNodeExpr, result);
+  }
+  return result;
+}
+
+core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
+  auto upstreamNode = planBuilder_.planNode();
+  VELOX_CHECK_NOT_NULL(upstreamNode, "TableWrite cannot be the source node");
+
+  // If outputType wasn't explicit specified, fallback to use the output of the
+  // upstream operator.
+  auto outputType = outputType_ ? outputType_ : upstreamNode->outputType();
+
+  // If insertHandle_ is not specified, build a HiveInsertTableHandle along with
+  // columnHandles, bucketProperty and locationHandle.
+  if (!insertHandle_) {
+    // Create column handles.
+    std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
+        columnHandles;
+    for (auto i = 0; i < outputType->size(); ++i) {
+      const auto column = outputType->nameOf(i);
+      const bool isPartitionKey =
+          std::find(partitionBy_.begin(), partitionBy_.end(), column) !=
+          partitionBy_.end();
+      columnHandles.push_back(
+          std::make_shared<connector::hive::HiveColumnHandle>(
+              column,
+              isPartitionKey
+                  ? connector::hive::HiveColumnHandle::ColumnType::kPartitionKey
+                  : connector::hive::HiveColumnHandle::ColumnType::kRegular,
+              outputType->childAt(i),
+              outputType->childAt(i)));
+    }
+
+    auto locationHandle = std::make_shared<connector::hive::LocationHandle>(
+        outputDirectoryPath_,
+        outputDirectoryPath_,
+        connector::hive::LocationHandle::TableType::kNew,
+        outputFileName_);
+
+    std::shared_ptr<HiveBucketProperty> bucketProperty;
+    if (bucketCount_ != 0) {
+      bucketProperty = buildHiveBucketProperty(
+          outputType, bucketCount_, bucketedBy_, sortBy_);
+    }
+
+    auto hiveHandle = std::make_shared<connector::hive::HiveInsertTableHandle>(
+        columnHandles,
+        locationHandle,
+        fileFormat_,
+        bucketProperty,
+        compressionKind_,
+        serdeParameters_,
+        options_,
+        ensureFiles_);
+
+    insertHandle_ =
+        std::make_shared<core::InsertTableHandle>(connectorId_, hiveHandle);
+  }
+
+  std::shared_ptr<core::AggregationNode> aggregationNode;
+  if (!aggregates_.empty()) {
+    auto aggregatesAndNames = planBuilder_.createAggregateExpressionsAndNames(
+        aggregates_, {}, core::AggregationNode::Step::kPartial);
+    aggregationNode = std::make_shared<core::AggregationNode>(
+        planBuilder_.nextPlanNodeId(),
+        core::AggregationNode::Step::kPartial,
+        std::vector<core::FieldAccessTypedExprPtr>{}, // groupingKeys
+        std::vector<core::FieldAccessTypedExprPtr>{}, // preGroupedKeys
+        aggregatesAndNames.names, // ignoreNullKeys
+        aggregatesAndNames.aggregates,
+        false,
+        upstreamNode);
+    VELOX_CHECK_EQ(
+        aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+  }
+
+  const auto writeNode = std::make_shared<core::TableWriteNode>(
+      id,
+      outputType,
+      outputType->names(),
+      aggregationNode,
+      insertHandle_,
+      false,
+      TableWriteTraits::outputType(aggregationNode),
+      commitStrategy_,
+      upstreamNode);
+  VELOX_CHECK(!writeNode->supportsBarrier());
+  return writeNode;
+}
+
+PlanBuilder& PlanBuilder::values(
+    const std::vector<RowVectorPtr>& values,
+    bool parallelizable,
+    size_t repeatTimes) {
+  VELOX_CHECK_NULL(planNode_, "Values must be the source node");
+  auto valuesCopy = values;
+  planNode_ = std::make_shared<core::ValuesNode>(
+      nextPlanNodeId(), std::move(valuesCopy), parallelizable, repeatTimes);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::traceScan(
+    const std::string& traceNodeDir,
+    uint32_t pipelineId,
+    std::vector<uint32_t> driverIds,
+    const RowTypePtr& outputType) {
+  planNode_ = std::make_shared<core::TraceScanNode>(
+      nextPlanNodeId(),
+      traceNodeDir,
+      pipelineId,
+      std::move(driverIds),
+      outputType);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::exchange(
+    const RowTypePtr& outputType,
+    VectorSerde::Kind serdeKind) {
+  VELOX_CHECK_NULL(planNode_, "Exchange must be the source node");
+  planNode_ = std::make_shared<core::ExchangeNode>(
+      nextPlanNodeId(), outputType, serdeKind);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+namespace {
+std::pair<
+    std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>,
+    std::vector<core::SortOrder>>
+parseOrderByClauses(
+    const std::vector<std::string>& keys,
+    const RowTypePtr& inputType,
+    memory::MemoryPool* pool) {
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> sortingKeys;
+  std::vector<core::SortOrder> sortingOrders;
+  for (const auto& key : keys) {
+    auto orderBy = parse::parseOrderByExpr(key);
+    auto typedExpr =
+        core::Expressions::inferTypes(orderBy.expr, inputType, pool);
+
+    auto sortingKey =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(typedExpr);
+    VELOX_CHECK_NOT_NULL(
+        sortingKey,
+        "ORDER BY clause must use a column name, not an expression: {}",
+        key);
+    sortingKeys.emplace_back(sortingKey);
+    sortingOrders.emplace_back(orderBy.ascending, orderBy.nullsFirst);
+  }
+
+  return {sortingKeys, sortingOrders};
+}
+} // namespace
+
+PlanBuilder& PlanBuilder::mergeExchange(
+    const RowTypePtr& outputType,
+    const std::vector<std::string>& keys,
+    VectorSerde::Kind serdeKind) {
+  VELOX_CHECK_NULL(planNode_, "MergeExchange must be the source node");
+  auto [sortingKeys, sortingOrders] =
+      parseOrderByClauses(keys, outputType, pool_);
+
+  planNode_ = std::make_shared<core::MergeExchangeNode>(
+      nextPlanNodeId(), outputType, sortingKeys, sortingOrders, serdeKind);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::optionalProject(
+    const std::vector<std::string>& optionalProjections) {
+  if (optionalProjections.empty()) {
+    return *this;
+  }
+  return project(optionalProjections);
+}
+
+PlanBuilder& PlanBuilder::projectExpressions(
+    const std::vector<std::shared_ptr<const core::IExpr>>& projections) {
+  std::vector<core::TypedExprPtr> expressions;
+  std::vector<std::string> projectNames;
+  for (auto i = 0; i < projections.size(); ++i) {
+    expressions.push_back(inferTypes(projections[i]));
+    if (projections[i]->alias().has_value()) {
+      projectNames.push_back(projections[i]->alias().value());
+    } else if (
+        auto fieldExpr =
+            dynamic_cast<const core::FieldAccessExpr*>(projections[i].get())) {
+      projectNames.push_back(fieldExpr->name());
+    } else {
+      projectNames.push_back(fmt::format("p{}", i));
+    }
+  }
+  planNode_ = std::make_shared<core::ProjectNode>(
+      nextPlanNodeId(),
+      std::move(projectNames),
+      std::move(expressions),
+      planNode_);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::projectExpressions(
+    const std::vector<std::shared_ptr<const core::ITypedExpr>>& projections) {
+  std::vector<core::TypedExprPtr> expressions;
+  std::vector<std::string> projectNames;
+  for (auto i = 0; i < projections.size(); ++i) {
+    expressions.push_back(projections[i]);
+    if (auto fieldExpr =
+            dynamic_cast<const core::FieldAccessExpr*>(projections[i].get())) {
+      projectNames.push_back(fieldExpr->name());
+    } else {
+      projectNames.push_back(fmt::format("p{}", i));
+    }
+  }
+  planNode_ = std::make_shared<core::ProjectNode>(
+      nextPlanNodeId(),
+      std::move(projectNames),
+      std::move(expressions),
+      planNode_);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::project(const std::vector<std::string>& projections) {
+  VELOX_CHECK_NOT_NULL(planNode_, "Project cannot be the source node");
+  std::vector<std::shared_ptr<const core::IExpr>> expressions;
+  expressions.reserve(projections.size());
+  for (auto i = 0; i < projections.size(); ++i) {
+    expressions.push_back(parse::parseExpr(projections[i], options_));
+  }
+  return projectExpressions(expressions);
+}
+
+PlanBuilder& PlanBuilder::parallelProject(
+    const std::vector<std::vector<std::string>>& projectionGroups,
+    const std::vector<std::string>& noLoadColumns) {
+  VELOX_CHECK_NOT_NULL(planNode_, "ParallelProject cannot be the source node");
+
+  std::vector<std::string> names;
+
+  std::vector<std::vector<core::TypedExprPtr>> exprGroups;
+  exprGroups.reserve(projectionGroups.size());
+
+  size_t i = 0;
+
+  for (const auto& group : projectionGroups) {
+    std::vector<core::TypedExprPtr> typedExprs;
+    typedExprs.reserve(group.size());
+
+    for (const auto& expr : group) {
+      const auto typedExpr = inferTypes(parse::parseExpr(expr, options_));
+      typedExprs.push_back(typedExpr);
+
+      if (auto fieldExpr =
+              dynamic_cast<const core::FieldAccessExpr*>(typedExpr.get())) {
+        names.push_back(fieldExpr->name());
+      } else {
+        names.push_back(fmt::format("p{}", i));
+      }
+
+      ++i;
+    }
+    exprGroups.push_back(std::move(typedExprs));
+  }
+
+  planNode_ = std::make_shared<core::ParallelProjectNode>(
+      nextPlanNodeId(),
+      std::move(names),
+      std::move(exprGroups),
+      noLoadColumns,
+      planNode_);
+
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::lazyDereference(
+    const std::vector<std::string>& projections) {
+  VELOX_CHECK_NOT_NULL(planNode_, "LazyDeference cannot be the source node");
+  std::vector<core::TypedExprPtr> expressions;
+  std::vector<std::string> projectNames;
+  for (auto i = 0; i < projections.size(); ++i) {
+    auto expr = inferTypes(parse::parseExpr(projections[i], options_));
+    expressions.push_back(expr);
+    if (auto* fieldExpr =
+            dynamic_cast<const core::FieldAccessExpr*>(expr.get())) {
+      projectNames.push_back(fieldExpr->name());
+    } else {
+      projectNames.push_back(fmt::format("p{}", i));
+    }
+  }
+  planNode_ = std::make_shared<core::LazyDereferenceNode>(
+      nextPlanNodeId(),
+      std::move(projectNames),
+      std::move(expressions),
+      planNode_);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::appendColumns(
+    const std::vector<std::string>& newColumns) {
+  VELOX_CHECK_NOT_NULL(planNode_, "Project cannot be the source node");
+  std::vector<std::string> allProjections = planNode_->outputType()->names();
+  for (const auto& column : newColumns) {
+    allProjections.push_back(column);
+  }
+
+  return project(allProjections);
+}
+
+PlanBuilder& PlanBuilder::optionalFilter(const std::string& optionalFilter) {
+  if (optionalFilter.empty()) {
+    return *this;
+  }
+  return filter(optionalFilter);
+}
+
+PlanBuilder& PlanBuilder::filter(const std::string& filter) {
+  VELOX_CHECK_NOT_NULL(planNode_, "Filter cannot be the source node");
+  auto expr = parseExpr(filter, planNode_->outputType(), options_, pool_);
+  planNode_ =
+      std::make_shared<core::FilterNode>(nextPlanNodeId(), expr, planNode_);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::tableWrite(
+    const std::string& outputDirectoryPath,
+    const dwio::common::FileFormat fileFormat,
+    const std::vector<std::string>& aggregates,
+    const std::shared_ptr<dwio::common::WriterOptions>& options,
+    const std::string& outputFileName) {
+  return TableWriterBuilder(*this)
+      .outputDirectoryPath(outputDirectoryPath)
+      .outputFileName(outputFileName)
+      .fileFormat(fileFormat)
+      .aggregates(aggregates)
+      .options(options)
+      .endTableWriter();
+}
+
+PlanBuilder& PlanBuilder::tableWrite(
+    const std::string& outputDirectoryPath,
+    const std::vector<std::string>& partitionBy,
+    const dwio::common::FileFormat fileFormat,
+    const std::vector<std::string>& aggregates,
+    const std::shared_ptr<dwio::common::WriterOptions>& options) {
+  return TableWriterBuilder(*this)
+      .outputDirectoryPath(outputDirectoryPath)
+      .partitionBy(partitionBy)
+      .fileFormat(fileFormat)
+      .aggregates(aggregates)
+      .options(options)
+      .endTableWriter();
+}
+
+PlanBuilder& PlanBuilder::tableWrite(
+    const std::string& outputDirectoryPath,
+    const std::vector<std::string>& partitionBy,
+    int32_t bucketCount,
+    const std::vector<std::string>& bucketedBy,
+    const dwio::common::FileFormat fileFormat,
+    const std::vector<std::string>& aggregates,
+    const std::shared_ptr<dwio::common::WriterOptions>& options) {
+  return TableWriterBuilder(*this)
+      .outputDirectoryPath(outputDirectoryPath)
+      .partitionBy(partitionBy)
+      .bucketCount(bucketCount)
+      .bucketedBy(bucketedBy)
+      .fileFormat(fileFormat)
+      .aggregates(aggregates)
+      .options(options)
+      .endTableWriter();
+}
+
+PlanBuilder& PlanBuilder::tableWrite(
+    const std::string& outputDirectoryPath,
+    const std::vector<std::string>& partitionBy,
+    int32_t bucketCount,
+    const std::vector<std::string>& bucketedBy,
+    const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortBy,
+    const dwio::common::FileFormat fileFormat,
+    const std::vector<std::string>& aggregates,
+    const std::string_view& connectorId,
+    const std::unordered_map<std::string, std::string>& serdeParameters,
+    const std::shared_ptr<dwio::common::WriterOptions>& options,
+    const std::string& outputFileName,
+    const common::CompressionKind compressionKind,
+    const RowTypePtr& schema,
+    const bool ensureFiles,
+    const connector::CommitStrategy commitStrategy) {
+  return TableWriterBuilder(*this)
+      .outputDirectoryPath(outputDirectoryPath)
+      .outputFileName(outputFileName)
+      .outputType(schema)
+      .partitionBy(partitionBy)
+      .bucketCount(bucketCount)
+      .bucketedBy(bucketedBy)
+      .sortBy(sortBy)
+      .fileFormat(fileFormat)
+      .aggregates(aggregates)
+      .connectorId(connectorId)
+      .serdeParameters(serdeParameters)
+      .options(options)
+      .compressionKind(compressionKind)
+      .ensureFiles(ensureFiles)
+      .commitStrategy(commitStrategy)
+      .endTableWriter();
+}
+
+PlanBuilder& PlanBuilder::tableWriteMerge(
+    const core::AggregationNodePtr& aggregationNode) {
+  planNode_ = std::make_shared<core::TableWriteMergeNode>(
+      nextPlanNodeId(),
+      TableWriteTraits::outputType(aggregationNode),
+      aggregationNode,
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+namespace {
+
+std::string throwAggregateFunctionDoesntExist(const std::string& name) {
+  std::stringstream error;
+  error << "Aggregate function doesn't exist: " << name << ".";
+  exec::aggregateFunctions().withRLock([&](const auto& functionsMap) {
+    if (functionsMap.empty()) {
+      error << " Registry of aggregate functions is empty. "
+               "Make sure to register some aggregate functions.";
+    }
+  });
+  VELOX_USER_FAIL(error.str());
+}
+
+std::string throwAggregateFunctionSignatureNotSupported(
+    const std::string& name,
+    const std::vector<TypePtr>& types,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>&
+        signatures) {
+  std::stringstream error;
+  error << "Aggregate function signature is not supported: "
+        << toString(name, types)
+        << ". Supported signatures: " << toString(signatures) << ".";
+  VELOX_USER_FAIL(error.str());
+}
+
+TypePtr resolveAggregateType(
+    const std::string& aggregateName,
+    core::AggregationNode::Step step,
+    const std::vector<TypePtr>& rawInputTypes,
+    bool nullOnFailure) {
+  if (auto signatures = exec::getAggregateFunctionSignatures(aggregateName)) {
+    for (const auto& signature : signatures.value()) {
+      exec::SignatureBinder binder(*signature, rawInputTypes);
+      if (binder.tryBind()) {
+        return binder.tryResolveType(
+            exec::isPartialOutput(step) ? signature->intermediateType()
+                                        : signature->returnType());
+      }
+    }
+
+    if (nullOnFailure) {
+      return nullptr;
+    }
+
+    throwAggregateFunctionSignatureNotSupported(
+        aggregateName, rawInputTypes, signatures.value());
+  }
+
+  // We may be parsing lambda expression used in a lambda aggregate function. In
+  // this case, 'aggregateName' would refer to a scalar function.
+  //
+  // TODO Enhance the parser to allow for specifying separate resolver for
+  // lambda expressions.
+  if (auto type =
+          exec::resolveTypeForSpecialForm(aggregateName, rawInputTypes)) {
+    return type;
+  }
+
+  if (auto type = parse::resolveScalarFunctionType(
+          aggregateName, rawInputTypes, true)) {
+    return type;
+  }
+
+  if (nullOnFailure) {
+    return nullptr;
+  }
+
+  throwAggregateFunctionDoesntExist(aggregateName);
+  return nullptr;
+}
+
+class AggregateTypeResolver {
+ public:
+  explicit AggregateTypeResolver(core::AggregationNode::Step step)
+      : step_(step), previousHook_(core::Expressions::getResolverHook()) {
+    core::Expressions::setTypeResolverHook(
+        [&](const auto& inputs, const auto& expr, bool nullOnFailure) {
+          return resolveType(inputs, expr, nullOnFailure);
+        });
+  }
+
+  ~AggregateTypeResolver() {
+    core::Expressions::setTypeResolverHook(previousHook_);
+  }
+
+  void setRawInputTypes(const std::vector<TypePtr>& types) {
+    rawInputTypes_ = types;
+  }
+
+ private:
+  TypePtr resolveType(
+      const std::vector<core::TypedExprPtr>& inputs,
+      const std::shared_ptr<const core::CallExpr>& expr,
+      bool nullOnFailure) const {
+    auto functionName = expr->name();
+
+    // Use raw input types (if available) to resolve intermediate and final
+    // result types.
+    if (exec::isRawInput(step_)) {
+      std::vector<TypePtr> types;
+      for (auto& input : inputs) {
+        types.push_back(input->type());
+      }
+
+      return resolveAggregateType(functionName, step_, types, nullOnFailure);
+    }
+
+    if (!rawInputTypes_.empty()) {
+      return resolveAggregateType(
+          functionName, step_, rawInputTypes_, nullOnFailure);
+    }
+
+    if (!nullOnFailure) {
+      VELOX_USER_FAIL(
+          "Cannot resolve aggregation function return type without raw input types: {}",
+          functionName);
+    }
+    return nullptr;
+  }
+
+  const core::AggregationNode::Step step_;
+  const core::Expressions::TypeResolverHook previousHook_;
+  std::vector<TypePtr> rawInputTypes_;
+};
+
+} // namespace
+
+core::PlanNodePtr PlanBuilder::createIntermediateOrFinalAggregation(
+    core::AggregationNode::Step step,
+    const core::AggregationNode* partialAggNode) {
+  // Create intermediate or final aggregation using same grouping keys and same
+  // aggregate function names.
+  const auto& partialAggregates = partialAggNode->aggregates();
+  const auto& groupingKeys = partialAggNode->groupingKeys();
+
+  auto numAggregates = partialAggregates.size();
+  auto numGroupingKeys = groupingKeys.size();
+
+  std::vector<core::AggregationNode::Aggregate> aggregates;
+  aggregates.reserve(numAggregates);
+  for (auto i = 0; i < numAggregates; i++) {
+    // Resolve final or intermediate aggregation result type using raw input
+    // types for the partial aggregation.
+    auto name = partialAggregates[i].call->name();
+    auto rawInputs = partialAggregates[i].call->inputs();
+
+    core::AggregationNode::Aggregate aggregate;
+    for (auto& rawInput : rawInputs) {
+      aggregate.rawInputTypes.push_back(rawInput->type());
+    }
+
+    auto type =
+        resolveAggregateType(name, step, aggregate.rawInputTypes, false);
+    std::vector<core::TypedExprPtr> inputs = {field(numGroupingKeys + i)};
+
+    // Add lambda inputs.
+    for (const auto& rawInput : rawInputs) {
+      if (rawInput->type()->kind() == TypeKind::FUNCTION) {
+        inputs.push_back(rawInput);
+      }
+    }
+
+    aggregate.call =
+        std::make_shared<core::CallTypedExpr>(type, std::move(inputs), name);
+    aggregates.emplace_back(aggregate);
+  }
+
+  auto aggregationNode = std::make_shared<core::AggregationNode>(
+      nextPlanNodeId(),
+      step,
+      groupingKeys,
+      partialAggNode->preGroupedKeys(),
+      partialAggNode->aggregateNames(),
+      aggregates,
+      partialAggNode->ignoreNullKeys(),
+      planNode_);
+  VELOX_CHECK_EQ(
+      aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+  return aggregationNode;
+}
+
+namespace {
+/// Checks that specified plan node is a partial or intermediate aggregation or
+/// local exchange over the same. Returns a pointer to core::AggregationNode.
+const core::AggregationNode* findPartialAggregation(
+    const core::PlanNode* planNode) {
+  const core::AggregationNode* aggNode;
+  if (auto exchange = dynamic_cast<const core::LocalPartitionNode*>(planNode)) {
+    aggNode = dynamic_cast<const core::AggregationNode*>(
+        exchange->sources()[0].get());
+  } else if (auto merge = dynamic_cast<const core::LocalMergeNode*>(planNode)) {
+    aggNode =
+        dynamic_cast<const core::AggregationNode*>(merge->sources()[0].get());
+  } else {
+    aggNode = dynamic_cast<const core::AggregationNode*>(planNode);
+  }
+  VELOX_CHECK_NOT_NULL(
+      aggNode,
+      "Current plan node must be one of: partial or intermediate aggregation, "
+      "local merge or exchange. Got: {}",
+      planNode->toString());
+  VELOX_CHECK(exec::isPartialOutput(aggNode->step()));
+  return aggNode;
+}
+} // namespace
+
+PlanBuilder& PlanBuilder::intermediateAggregation() {
+  const auto* aggNode = findPartialAggregation(planNode_.get());
+  VELOX_CHECK(exec::isRawInput(aggNode->step()));
+
+  auto step = core::AggregationNode::Step::kIntermediate;
+
+  planNode_ = createIntermediateOrFinalAggregation(step, aggNode);
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::finalAggregation() {
+  const auto* aggNode = findPartialAggregation(planNode_.get());
+
+  if (!exec::isRawInput(aggNode->step())) {
+    // If aggregation node is not the partial aggregation, keep looking again.
+    aggNode = findPartialAggregation(aggNode->sources()[0].get());
+    VELOX_CHECK_NOT_NULL(aggNode);
+  }
+
+  VELOX_CHECK(exec::isRawInput(aggNode->step()));
+  VELOX_CHECK(exec::isPartialOutput(aggNode->step()));
+
+  auto step = core::AggregationNode::Step::kFinal;
+
+  planNode_ = createIntermediateOrFinalAggregation(step, aggNode);
+  return *this;
+}
+
+PlanBuilder::AggregatesAndNames PlanBuilder::createAggregateExpressionsAndNames(
+    const std::vector<std::string>& aggregates,
+    const std::vector<std::string>& masks,
+    core::AggregationNode::Step step,
+    const std::vector<std::vector<TypePtr>>& rawInputTypes) {
+  if (step == core::AggregationNode::Step::kPartial ||
+      step == core::AggregationNode::Step::kSingle) {
+    VELOX_CHECK(
+        rawInputTypes.empty(),
+        "Do not provide raw inputs types for partial or single aggregation");
+  } else {
+    VELOX_CHECK_EQ(
+        aggregates.size(),
+        rawInputTypes.size(),
+        "Do provide raw inputs types for final or intermediate aggregation");
+  }
+
+  std::vector<core::AggregationNode::Aggregate> aggs;
+
+  AggregateTypeResolver resolver(step);
+  std::vector<std::string> names;
+  aggs.reserve(aggregates.size());
+  names.reserve(aggregates.size());
+
+  duckdb::ParseOptions options;
+  options.parseIntegerAsBigint = options_.parseIntegerAsBigint;
+
+  for (auto i = 0; i < aggregates.size(); i++) {
+    auto& aggregate = aggregates[i];
+
+    if (!rawInputTypes.empty()) {
+      resolver.setRawInputTypes(rawInputTypes[i]);
+    }
+
+    auto untypedExpr = duckdb::parseAggregateExpr(aggregate, options);
+
+    core::AggregationNode::Aggregate agg;
+
+    agg.call = std::dynamic_pointer_cast<const core::CallTypedExpr>(
+        inferTypes(untypedExpr.expr));
+
+    if (step == core::AggregationNode::Step::kPartial ||
+        step == core::AggregationNode::Step::kSingle) {
+      for (const auto& input : agg.call->inputs()) {
+        agg.rawInputTypes.push_back(input->type());
+      }
+    } else {
+      agg.rawInputTypes = rawInputTypes[i];
+    }
+
+    if (untypedExpr.maskExpr != nullptr) {
+      auto maskExpr =
+          std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+              inferTypes(untypedExpr.maskExpr));
+      VELOX_CHECK_NOT_NULL(
+          maskExpr,
+          "FILTER clause must use a column name, not an expression: {}",
+          aggregate);
+      agg.mask = maskExpr;
+    }
+
+    if (i < masks.size() && !masks[i].empty()) {
+      VELOX_CHECK_NULL(
+          agg.mask,
+          "Aggregation mask should be specified only once (either explicitly or using FILTER clause)");
+      agg.mask = field(masks[i]);
+    }
+
+    agg.distinct = untypedExpr.distinct;
+
+    if (!untypedExpr.orderBy.empty()) {
+      auto* entry = exec::getAggregateFunctionEntry(agg.call->name());
+      const auto& metadata = entry->metadata;
+      if (metadata.orderSensitive) {
+        VELOX_CHECK(
+            step == core::AggregationNode::Step::kSingle,
+            "Order sensitive aggregation over sorted inputs cannot be split "
+            "into partial and final: {}.",
+            aggregate);
+      }
+    }
+
+    for (const auto& orderBy : untypedExpr.orderBy) {
+      auto sortingKey =
+          std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+              inferTypes(orderBy.expr));
+      VELOX_CHECK_NOT_NULL(
+          sortingKey,
+          "ORDER BY clause must use a column name, not an expression: {}",
+          aggregate);
+
+      agg.sortingKeys.push_back(sortingKey);
+      agg.sortingOrders.emplace_back(orderBy.ascending, orderBy.nullsFirst);
+    }
+
+    aggs.emplace_back(agg);
+
+    if (untypedExpr.expr->alias().has_value()) {
+      names.push_back(untypedExpr.expr->alias().value());
+    } else {
+      names.push_back(fmt::format("a{}", i));
+    }
+  }
+
+  return {aggs, names};
+}
+
+PlanBuilder& PlanBuilder::aggregation(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& preGroupedKeys,
+    const std::vector<std::string>& aggregates,
+    const std::vector<std::string>& masks,
+    core::AggregationNode::Step step,
+    bool ignoreNullKeys,
+    const std::vector<std::vector<TypePtr>>& rawInputTypes) {
+  auto aggregatesAndNames = createAggregateExpressionsAndNames(
+      aggregates, masks, step, rawInputTypes);
+
+  // If the aggregationNode is over a GroupId, then global grouping sets
+  // need to be populated.
+  std::vector<vector_size_t> globalGroupingSets;
+  std::optional<core::FieldAccessTypedExprPtr> groupId;
+  if (auto groupIdNode =
+          dynamic_cast<const core::GroupIdNode*>(planNode_.get())) {
+    for (auto i = 0; i < groupIdNode->groupingSets().size(); i++) {
+      if (groupIdNode->groupingSets().at(i).empty()) {
+        globalGroupingSets.push_back(i);
+      }
+    }
+
+    if (!globalGroupingSets.empty()) {
+      // GroupId is the last column of the GroupIdNode.
+      groupId = field(groupIdNode->outputType()->names().back());
+    }
+  }
+
+  auto aggregationNode = std::make_shared<core::AggregationNode>(
+      nextPlanNodeId(),
+      step,
+      fields(groupingKeys),
+      fields(preGroupedKeys),
+      aggregatesAndNames.names,
+      aggregatesAndNames.aggregates,
+      globalGroupingSets,
+      groupId,
+      ignoreNullKeys,
+      planNode_);
+  VELOX_CHECK_EQ(
+      aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+  planNode_ = std::move(aggregationNode);
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::streamingAggregation(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregates,
+    const std::vector<std::string>& masks,
+    core::AggregationNode::Step step,
+    bool ignoreNullKeys) {
+  auto aggregatesAndNames =
+      createAggregateExpressionsAndNames(aggregates, masks, step);
+  auto aggregationNode = std::make_shared<core::AggregationNode>(
+      nextPlanNodeId(),
+      step,
+      fields(groupingKeys),
+      fields(groupingKeys),
+      aggregatesAndNames.names,
+      aggregatesAndNames.aggregates,
+      ignoreNullKeys,
+      planNode_);
+  VELOX_CHECK_EQ(
+      aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+  planNode_ = std::move(aggregationNode);
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::groupId(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::vector<std::string>>& groupingSets,
+    const std::vector<std::string>& aggregationInputs,
+    std::string groupIdName) {
+  std::vector<core::GroupIdNode::GroupingKeyInfo> groupingKeyInfos;
+  groupingKeyInfos.reserve(groupingKeys.size());
+  for (const auto& groupingKey : groupingKeys) {
+    auto untypedExpr = parse::parseExpr(groupingKey, options_);
+    const auto* fieldAccessExpr =
+        dynamic_cast<const core::FieldAccessExpr*>(untypedExpr.get());
+    VELOX_USER_CHECK(
+        fieldAccessExpr,
+        "Grouping key {} is not valid projection",
+        groupingKey);
+    std::string inputField = fieldAccessExpr->name();
+    std::string outputField = untypedExpr->alias().has_value()
+        ?
+        // This is a projection with a column alias with the format
+        // "input_col as output_col".
+        untypedExpr->alias().value()
+        :
+        // This is a projection without a column alias.
+        fieldAccessExpr->name();
+
+    core::GroupIdNode::GroupingKeyInfo keyInfos;
+    keyInfos.output = outputField;
+    keyInfos.input = field(inputField);
+    groupingKeyInfos.push_back(keyInfos);
+  }
+
+  planNode_ = std::make_shared<core::GroupIdNode>(
+      nextPlanNodeId(),
+      groupingSets,
+      std::move(groupingKeyInfos),
+      fields(aggregationInputs),
+      std::move(groupIdName),
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+namespace {
+core::PlanNodePtr createLocalMergeNode(
+    const core::PlanNodeId& id,
+    const std::vector<std::string>& keys,
+    std::vector<core::PlanNodePtr> sources,
+    memory::MemoryPool* pool) {
+  const auto& inputType = sources[0]->outputType();
+  auto [sortingKeys, sortingOrders] =
+      parseOrderByClauses(keys, inputType, pool);
+
+  return std::make_shared<core::LocalMergeNode>(
+      id, std::move(sortingKeys), std::move(sortingOrders), std::move(sources));
+}
+} // namespace
+
+PlanBuilder& PlanBuilder::localMerge(const std::vector<std::string>& keys) {
+  planNode_ = createLocalMergeNode(nextPlanNodeId(), keys, {planNode_}, pool_);
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::expand(
+    const std::vector<std::vector<std::string>>& projections) {
+  VELOX_CHECK(!projections.empty(), "projections must not be empty.");
+  const auto numColumns = projections[0].size();
+  const auto numRows = projections.size();
+  std::vector<std::string> aliases;
+  aliases.reserve(numColumns);
+
+  std::vector<std::vector<core::TypedExprPtr>> projectExprs;
+  projectExprs.reserve(projections.size());
+
+  for (auto i = 0; i < numRows; i++) {
+    std::vector<core::TypedExprPtr> projectExpr;
+    VELOX_CHECK_EQ(numColumns, projections[i].size());
+    for (auto j = 0; j < numColumns; j++) {
+      auto untypedExpression = parse::parseExpr(projections[i][j], options_);
+      auto typedExpression = inferTypes(untypedExpression);
+
+      if (i == 0) {
+        if (untypedExpression->alias().has_value()) {
+          aliases.push_back(untypedExpression->alias().value());
+        } else {
+          auto fieldExpr = dynamic_cast<const core::FieldAccessExpr*>(
+              untypedExpression.get());
+          VELOX_CHECK_NOT_NULL(fieldExpr);
+          aliases.push_back(fieldExpr->name());
+        }
+        projectExpr.push_back(typedExpression);
+      } else {
+        // The types of values in 2nd and subsequent rows must much types in the
+        //  1st row.
+        const auto& expectedType = projectExprs[0][j]->type();
+        if (typedExpression->type()->equivalent(*expectedType)) {
+          projectExpr.push_back(typedExpression);
+        } else {
+          auto constantExpr =
+              dynamic_cast<const core::ConstantExpr*>(untypedExpression.get());
+          VELOX_CHECK_NOT_NULL(constantExpr);
+          VELOX_CHECK(constantExpr->value().isNull());
+          projectExpr.push_back(std::make_shared<core::ConstantTypedExpr>(
+              expectedType, variant::null(expectedType->kind())));
+        }
+      }
+    }
+    projectExprs.push_back(projectExpr);
+  }
+
+  planNode_ = std::make_shared<core::ExpandNode>(
+      nextPlanNodeId(), projectExprs, std::move(aliases), planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::localMerge(
+    const std::vector<std::string>& keys,
+    std::vector<core::PlanNodePtr> sources) {
+  VELOX_CHECK_NULL(planNode_, "localMerge() must be the first call");
+  VELOX_CHECK_GE(
+      sources.size(), 1, "localMerge() requires at least one source");
+
+  planNode_ =
+      createLocalMergeNode(nextPlanNodeId(), keys, std::move(sources), pool_);
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::orderBy(
+    const std::vector<std::string>& keys,
+    bool isPartial) {
+  VELOX_CHECK_NOT_NULL(planNode_, "OrderBy cannot be the source node");
+  auto [sortingKeys, sortingOrders] =
+      parseOrderByClauses(keys, planNode_->outputType(), pool_);
+
+  planNode_ = std::make_shared<core::OrderByNode>(
+      nextPlanNodeId(), sortingKeys, sortingOrders, isPartial, planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::topN(
+    const std::vector<std::string>& keys,
+    int32_t count,
+    bool isPartial) {
+  VELOX_CHECK_NOT_NULL(planNode_, "TopN cannot be the source node");
+  auto [sortingKeys, sortingOrders] =
+      parseOrderByClauses(keys, planNode_->outputType(), pool_);
+  planNode_ = std::make_shared<core::TopNNode>(
+      nextPlanNodeId(),
+      sortingKeys,
+      sortingOrders,
+      count,
+      isPartial,
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::limit(int64_t offset, int64_t count, bool isPartial) {
+  planNode_ = std::make_shared<core::LimitNode>(
+      nextPlanNodeId(), offset, count, isPartial, planNode_);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::enforceSingleRow() {
+  planNode_ =
+      std::make_shared<core::EnforceSingleRowNode>(nextPlanNodeId(), planNode_);
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::assignUniqueId(
+    const std::string& idName,
+    const int32_t taskUniqueId) {
+  planNode_ = std::make_shared<core::AssignUniqueIdNode>(
+      nextPlanNodeId(), idName, taskUniqueId, planNode_);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+namespace {
+core::PartitionFunctionSpecPtr createPartitionFunctionSpec(
+    const RowTypePtr& inputType,
+    const std::vector<core::TypedExprPtr>& keys,
+    memory::MemoryPool* pool) {
+  if (keys.empty()) {
+    return std::make_shared<core::GatherPartitionFunctionSpec>();
+  } else {
+    std::vector<column_index_t> keyIndices;
+    keyIndices.reserve(keys.size());
+
+    std::vector<VectorPtr> constValues;
+    constValues.reserve(keys.size());
+
+    for (const auto& key : keys) {
+      if (auto field =
+              std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+                  key)) {
+        keyIndices.push_back(inputType->getChildIdx(field->name()));
+      } else if (
+          auto constant =
+              std::dynamic_pointer_cast<const core::ConstantTypedExpr>(key)) {
+        keyIndices.push_back(kConstantChannel);
+        constValues.push_back(constant->toConstantVector(pool));
+      } else {
+        VELOX_UNREACHABLE();
+      }
+    }
+    return std::make_shared<HashPartitionFunctionSpec>(
+        inputType, std::move(keyIndices), std::move(constValues));
+  }
+}
+
+RowTypePtr concat(const RowTypePtr& a, const RowTypePtr& b) {
+  std::vector<std::string> names = a->names();
+  std::vector<TypePtr> types = a->children();
+  names.insert(names.end(), b->names().begin(), b->names().end());
+  types.insert(types.end(), b->children().begin(), b->children().end());
+  return ROW(std::move(names), std::move(types));
+}
+
+RowTypePtr extract(
+    const RowTypePtr& type,
+    const std::vector<std::string>& childNames) {
+  std::vector<std::string> names = childNames;
+
+  std::vector<TypePtr> types;
+  types.reserve(childNames.size());
+  for (const auto& name : childNames) {
+    types.emplace_back(type->findChild(name));
+  }
+  return ROW(std::move(names), std::move(types));
+}
+
+// Rename columns in the given row type.
+RowTypePtr rename(
+    const RowTypePtr& type,
+    const std::vector<std::string>& newNames) {
+  VELOX_CHECK_EQ(
+      type->size(),
+      newNames.size(),
+      "Number of types and new type names should be the same");
+  std::vector<std::string> names{newNames};
+  std::vector<TypePtr> types{type->children()};
+  return ROW(std::move(names), std::move(types));
+}
+
+core::PlanNodePtr createLocalPartitionNode(
+    const core::PlanNodeId& planNodeId,
+    const std::vector<core::TypedExprPtr>& keys,
+    bool scaleWriter,
+    const std::vector<core::PlanNodePtr>& sources,
+    memory::MemoryPool* pool) {
+  auto partitionFunctionFactory =
+      createPartitionFunctionSpec(sources[0]->outputType(), keys, pool);
+  return std::make_shared<core::LocalPartitionNode>(
+      planNodeId,
+      keys.empty() ? core::LocalPartitionNode::Type::kGather
+                   : core::LocalPartitionNode::Type::kRepartition,
+      scaleWriter,
+      partitionFunctionFactory,
+      sources);
+}
+} // namespace
+
+PlanBuilder& PlanBuilder::partitionedOutput(
+    const std::vector<std::string>& keys,
+    int numPartitions,
+    const std::vector<std::string>& outputLayout,
+    VectorSerde::Kind serdeKind) {
+  return partitionedOutput(keys, numPartitions, false, outputLayout, serdeKind);
+}
+
+PlanBuilder& PlanBuilder::partitionedOutput(
+    const std::vector<std::string>& keys,
+    int numPartitions,
+    bool replicateNullsAndAny,
+    const std::vector<std::string>& outputLayout,
+    VectorSerde::Kind serdeKind) {
+  VELOX_CHECK_NOT_NULL(
+      planNode_, "PartitionedOutput cannot be the source node");
+
+  auto keyExprs = exprs(keys, planNode_->outputType());
+  return partitionedOutput(
+      keys,
+      numPartitions,
+      replicateNullsAndAny,
+      createPartitionFunctionSpec(planNode_->outputType(), keyExprs, pool_),
+      outputLayout,
+      serdeKind);
+}
+
+PlanBuilder& PlanBuilder::partitionedOutput(
+    const std::vector<std::string>& keys,
+    int numPartitions,
+    bool replicateNullsAndAny,
+    core::PartitionFunctionSpecPtr partitionFunctionSpec,
+    const std::vector<std::string>& outputLayout,
+    VectorSerde::Kind serdeKind) {
+  VELOX_CHECK_NOT_NULL(
+      planNode_, "PartitionedOutput cannot be the source node");
+  auto outputType = outputLayout.empty()
+      ? planNode_->outputType()
+      : extract(planNode_->outputType(), outputLayout);
+  planNode_ = std::make_shared<core::PartitionedOutputNode>(
+      nextPlanNodeId(),
+      core::PartitionedOutputNode::Kind::kPartitioned,
+      exprs(keys, planNode_->outputType()),
+      numPartitions,
+      replicateNullsAndAny,
+      std::move(partitionFunctionSpec),
+      outputType,
+      serdeKind,
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::partitionedOutputBroadcast(
+    const std::vector<std::string>& outputLayout,
+    VectorSerde::Kind serdeKind) {
+  VELOX_CHECK_NOT_NULL(
+      planNode_, "PartitionedOutput cannot be the source node");
+  auto outputType = outputLayout.empty()
+      ? planNode_->outputType()
+      : extract(planNode_->outputType(), outputLayout);
+  planNode_ = core::PartitionedOutputNode::broadcast(
+      nextPlanNodeId(), 1, outputType, serdeKind, planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::partitionedOutputArbitrary(
+    const std::vector<std::string>& outputLayout,
+    VectorSerde::Kind serdeKind) {
+  VELOX_CHECK_NOT_NULL(
+      planNode_, "PartitionedOutput cannot be the source node");
+  auto outputType = outputLayout.empty()
+      ? planNode_->outputType()
+      : extract(planNode_->outputType(), outputLayout);
+  planNode_ = core::PartitionedOutputNode::arbitrary(
+      nextPlanNodeId(), outputType, serdeKind, planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::localPartition(
+    const std::vector<std::string>& keys,
+    const std::vector<core::PlanNodePtr>& sources) {
+  VELOX_CHECK_NULL(planNode_, "localPartition() must be the first call");
+  planNode_ = createLocalPartitionNode(
+      nextPlanNodeId(),
+      exprs(keys, sources[0]->outputType()),
+      /*scaleWriter=*/false,
+      sources,
+      pool_);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::localPartition(const std::vector<std::string>& keys) {
+  planNode_ = createLocalPartitionNode(
+      nextPlanNodeId(),
+      exprs(keys, planNode_->outputType()),
+      /*scaleWriter=*/false,
+      {planNode_},
+      pool_);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::scaleWriterlocalPartition(
+    const std::vector<std::string>& keys) {
+  std::vector<column_index_t> keyIndices;
+  keyIndices.reserve(keys.size());
+  for (const auto& key : keys) {
+    keyIndices.push_back(planNode_->outputType()->getChildIdx(key));
+  }
+  auto hivePartitionFunctionFactory =
+      std::make_shared<HivePartitionFunctionSpec>(
+          1009, keyIndices, std::vector<VectorPtr>{});
+  planNode_ = std::make_shared<core::LocalPartitionNode>(
+      nextPlanNodeId(),
+      core::LocalPartitionNode::Type::kRepartition,
+      true,
+      hivePartitionFunctionFactory,
+      std::vector{planNode_});
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::localPartition(
+    int numBuckets,
+    const std::vector<column_index_t>& bucketChannels,
+    const std::vector<VectorPtr>& constValues) {
+  auto hivePartitionFunctionFactory =
+      std::make_shared<HivePartitionFunctionSpec>(
+          numBuckets, bucketChannels, constValues);
+  planNode_ = std::make_shared<core::LocalPartitionNode>(
+      nextPlanNodeId(),
+      core::LocalPartitionNode::Type::kRepartition,
+      /*scaleWriter=*/false,
+      std::move(hivePartitionFunctionFactory),
+      std::vector<core::PlanNodePtr>{planNode_});
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::localPartitionByBucket(
+    const std::shared_ptr<connector::hive::HiveBucketProperty>&
+        bucketProperty) {
+  VELOX_CHECK_NOT_NULL(planNode_, "LocalPartition cannot be the source node");
+  std::vector<column_index_t> bucketChannels;
+  for (const auto& bucketColumn : bucketProperty->bucketedBy()) {
+    bucketChannels.push_back(
+        planNode_->outputType()->getChildIdx(bucketColumn));
+  }
+  auto hivePartitionFunctionFactory =
+      std::make_shared<HivePartitionFunctionSpec>(
+          bucketProperty->bucketCount(),
+          bucketChannels,
+          std::vector<VectorPtr>{});
+  planNode_ = std::make_shared<core::LocalPartitionNode>(
+      nextPlanNodeId(),
+      core::LocalPartitionNode::Type::kRepartition,
+      /*scaleWriter=*/false,
+      std::move(hivePartitionFunctionFactory),
+      std::vector<core::PlanNodePtr>{planNode_});
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+namespace {
+core::PlanNodePtr createLocalPartitionRoundRobinNode(
+    const core::PlanNodeId& planNodeId,
+    bool scaleWriter,
+    const std::vector<core::PlanNodePtr>& sources) {
+  return std::make_shared<core::LocalPartitionNode>(
+      planNodeId,
+      core::LocalPartitionNode::Type::kRepartition,
+      scaleWriter,
+      std::make_shared<RoundRobinPartitionFunctionSpec>(),
+      sources);
+}
+} // namespace
+
+PlanBuilder& PlanBuilder::localPartitionRoundRobin(
+    const std::vector<core::PlanNodePtr>& sources) {
+  VELOX_CHECK_NULL(
+      planNode_, "localPartitionRoundRobin() must be the first call");
+  planNode_ = createLocalPartitionRoundRobinNode(
+      nextPlanNodeId(), /*scaleWriter=*/false, sources);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::localPartitionRoundRobin() {
+  planNode_ = createLocalPartitionRoundRobinNode(
+      nextPlanNodeId(), /*scaleWriter=*/false, {planNode_});
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::scaleWriterlocalPartitionRoundRobin() {
+  planNode_ = createLocalPartitionRoundRobinNode(
+      nextPlanNodeId(), /*scaleWriter=*/true, {planNode_});
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+namespace {
+class RoundRobinRowPartitionFunction : public core::PartitionFunction {
+ public:
+  explicit RoundRobinRowPartitionFunction(int numPartitions)
+      : numPartitions_{numPartitions} {}
+
+  std::optional<uint32_t> partition(
+      const RowVector& input,
+      std::vector<uint32_t>& partitions) override {
+    auto size = input.size();
+    partitions.resize(size);
+    for (auto i = 0; i < size; ++i) {
+      partitions[i] = counter_ % numPartitions_;
+      ++counter_;
+    }
+    return std::nullopt;
+  }
+
+ private:
+  const int numPartitions_;
+  uint32_t counter_{0};
+};
+
+class RoundRobinRowPartitionFunctionSpec : public core::PartitionFunctionSpec {
+ public:
+  std::unique_ptr<core::PartitionFunction> create(
+      int numPartitions,
+      bool /*localExchange*/) const override {
+    return std::make_unique<RoundRobinRowPartitionFunction>(numPartitions);
+  }
+
+  std::string toString() const override {
+    return "ROUND ROBIN ROW";
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = fmt::format("RoundRobinRowPartitionFunctionSpec");
+    return obj;
+  }
+
+  static core::PartitionFunctionSpecPtr deserialize(
+      const folly::dynamic& /*obj*/,
+      void* /*context*/) {
+    return std::make_shared<RoundRobinRowPartitionFunctionSpec>();
+  }
+};
+} // namespace
+
+PlanBuilder& PlanBuilder::localPartitionRoundRobinRow() {
+  planNode_ = std::make_shared<core::LocalPartitionNode>(
+      nextPlanNodeId(),
+      core::LocalPartitionNode::Type::kRepartition,
+      /*scaleWriter=*/false,
+      std::make_shared<RoundRobinRowPartitionFunctionSpec>(),
+      std::vector<core::PlanNodePtr>{planNode_});
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::hashJoin(
+    const std::vector<std::string>& leftKeys,
+    const std::vector<std::string>& rightKeys,
+    const core::PlanNodePtr& build,
+    const std::string& filter,
+    const std::vector<std::string>& outputLayout,
+    core::JoinType joinType,
+    bool nullAware) {
+  VELOX_CHECK_NOT_NULL(planNode_, "HashJoin cannot be the source node");
+  VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
+
+  auto leftType = planNode_->outputType();
+  auto rightType = build->outputType();
+  auto resultType = concat(leftType, rightType);
+  core::TypedExprPtr filterExpr;
+  if (!filter.empty()) {
+    filterExpr = parseExpr(filter, resultType, options_, pool_);
+  }
+
+  RowTypePtr outputType;
+  if (isLeftSemiProjectJoin(joinType) || isRightSemiProjectJoin(joinType)) {
+    std::vector<std::string> names = outputLayout;
+
+    // Last column in 'outputLayout' must be a boolean 'match'.
+    std::vector<TypePtr> types;
+    types.reserve(outputLayout.size());
+    for (auto i = 0; i < outputLayout.size() - 1; ++i) {
+      types.emplace_back(resultType->findChild(outputLayout[i]));
+    }
+    types.emplace_back(BOOLEAN());
+
+    outputType = ROW(std::move(names), std::move(types));
+  } else {
+    outputType = extract(resultType, outputLayout);
+  }
+
+  auto leftKeyFields = fields(leftType, leftKeys);
+  auto rightKeyFields = fields(rightType, rightKeys);
+
+  planNode_ = std::make_shared<core::HashJoinNode>(
+      nextPlanNodeId(),
+      joinType,
+      nullAware,
+      leftKeyFields,
+      rightKeyFields,
+      std::move(filterExpr),
+      std::move(planNode_),
+      build,
+      outputType);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::mergeJoin(
+    const std::vector<std::string>& leftKeys,
+    const std::vector<std::string>& rightKeys,
+    const core::PlanNodePtr& build,
+    const std::string& filter,
+    const std::vector<std::string>& outputLayout,
+    core::JoinType joinType) {
+  VELOX_CHECK_NOT_NULL(planNode_, "MergeJoin cannot be the source node");
+  VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
+
+  auto leftType = planNode_->outputType();
+  auto rightType = build->outputType();
+  auto resultType = concat(leftType, rightType);
+  core::TypedExprPtr filterExpr;
+  if (!filter.empty()) {
+    filterExpr = parseExpr(filter, resultType, options_, pool_);
+  }
+  auto outputType = extract(resultType, outputLayout);
+  auto leftKeyFields = fields(leftType, leftKeys);
+  auto rightKeyFields = fields(rightType, rightKeys);
+
+  planNode_ = std::make_shared<core::MergeJoinNode>(
+      nextPlanNodeId(),
+      joinType,
+      leftKeyFields,
+      rightKeyFields,
+      std::move(filterExpr),
+      std::move(planNode_),
+      build,
+      outputType);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::nestedLoopJoin(
+    const core::PlanNodePtr& right,
+    const std::vector<std::string>& outputLayout,
+    core::JoinType joinType) {
+  return nestedLoopJoin(right, "", outputLayout, joinType);
+}
+
+PlanBuilder& PlanBuilder::nestedLoopJoin(
+    const core::PlanNodePtr& right,
+    const std::string& joinCondition,
+    const std::vector<std::string>& outputLayout,
+    core::JoinType joinType) {
+  VELOX_CHECK_NOT_NULL(planNode_, "NestedLoopJoin cannot be the source node");
+  auto resultType = concat(planNode_->outputType(), right->outputType());
+  if (isLeftSemiProjectJoin(joinType)) {
+    resultType = concat(resultType, ROW({"match"}, {BOOLEAN()}));
+  }
+
+  auto outputType = extract(resultType, outputLayout);
+
+  core::TypedExprPtr joinConditionExpr{};
+  if (!joinCondition.empty()) {
+    joinConditionExpr = parseExpr(joinCondition, resultType, options_, pool_);
+  }
+
+  planNode_ = std::make_shared<core::NestedLoopJoinNode>(
+      nextPlanNodeId(),
+      joinType,
+      std::move(joinConditionExpr),
+      std::move(planNode_),
+      right,
+      outputType);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+namespace {
+core::TypedExprPtr removeCastTypedExpr(const core::TypedExprPtr& expr) {
+  core::TypedExprPtr convertedTypedExpr = expr;
+  while (auto castTypedExpr =
+             std::dynamic_pointer_cast<const core::CastTypedExpr>(
+                 convertedTypedExpr)) {
+    VELOX_CHECK_EQ(castTypedExpr->inputs().size(), 1);
+    convertedTypedExpr = castTypedExpr->inputs()[0];
+  }
+  return convertedTypedExpr;
+}
+
+template <TypeKind SrcKind, TypeKind DstKind>
+core::TypedExprPtr castConstantArrayConditionInput(
+    const core::ConstantTypedExprPtr& constantExpr) {
+  if (SrcKind == DstKind) {
+    return constantExpr;
+  }
+
+  auto srcVector = constantExpr->valueVector();
+  BaseVector::flattenVector(srcVector);
+  auto* srcArrayVector = srcVector->asChecked<velox::ArrayVector>();
+  VELOX_CHECK_EQ(srcArrayVector->size(), 1);
+  using SrcCppType = typename velox::TypeTraits<SrcKind>::NativeType;
+  auto* srcValueVector = srcArrayVector->elements()->asFlatVector<SrcCppType>();
+
+  const auto dstType = createScalarType(DstKind);
+  auto dstValueVector = BaseVector::create(
+      dstType, srcValueVector->size(), srcArrayVector->pool());
+  using DstCppType = typename velox::TypeTraits<DstKind>::NativeType;
+  auto* dstFlatValueVector =
+      dstValueVector->template asFlatVector<DstCppType>();
+
+  velox::DecodedVector decodedSrcValueVector{*srcValueVector};
+  velox::exec::VectorReader<SrcCppType> srcValueReader{&decodedSrcValueVector};
+  for (auto row = 0; row < srcValueVector->size(); ++row) {
+    const auto value = srcValueReader[row];
+    dstFlatValueVector->set(row, static_cast<DstCppType>(value));
+  }
+  auto dstArrayVector = std::make_shared<ArrayVector>(
+      srcArrayVector->pool(),
+      ARRAY(dstType),
+      nullptr,
+      1,
+      srcArrayVector->offsets(),
+      srcArrayVector->sizes(),
+      dstValueVector);
+  return std::make_shared<core::ConstantTypedExpr>(dstArrayVector);
+}
+
+template <TypeKind SrcKind, TypeKind DstKind>
+core::TypedExprPtr castConstantConditionInput(
+    const core::ConstantTypedExprPtr& constantExpr) {
+  if (SrcKind == DstKind) {
+    return constantExpr;
+  }
+  const auto dstType = createScalarType(DstKind);
+  return std::make_shared<core::ConstantTypedExpr>(
+      dstType,
+      static_cast<typename TypeTraits<DstKind>::NativeType>(
+          constantExpr->value().value<SrcKind>()));
+}
+
+template <TypeKind Kind>
+core::TypedExprPtr castIndexConditionInputExpr(const core::TypedExprPtr& expr) {
+  core::TypedExprPtr convertedTypedExpr = removeCastTypedExpr(expr);
+  if (std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+          convertedTypedExpr)) {
+    VELOX_CHECK(
+        convertedTypedExpr->type()->kind() == Kind ||
+        std::dynamic_pointer_cast<const ArrayType>(convertedTypedExpr->type())
+                ->elementType()
+                ->kind() == Kind);
+    return convertedTypedExpr;
+  }
+
+  const auto constantTypedExpr =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
+          convertedTypedExpr);
+  VELOX_CHECK_NOT_NULL(constantTypedExpr, "{}", expr->toString());
+
+  if (constantTypedExpr->type()->isArray()) {
+    const auto arrayType =
+        std::dynamic_pointer_cast<const ArrayType>(constantTypedExpr->type());
+    if (arrayType->elementType()->kind() == Kind) {
+      return constantTypedExpr;
+    }
+    switch (arrayType->elementType()->kind()) {
+      case TypeKind::INTEGER:
+        return castConstantArrayConditionInput<TypeKind::INTEGER, Kind>(
+            constantTypedExpr);
+      case TypeKind::BIGINT:
+        return castConstantArrayConditionInput<TypeKind::BIGINT, Kind>(
+            constantTypedExpr);
+      case TypeKind::SMALLINT:
+        return castConstantArrayConditionInput<TypeKind::SMALLINT, Kind>(
+            constantTypedExpr);
+      default:
+        VELOX_UNSUPPORTED(
+            "Incompatible condition input type: {}, index column kind: {}",
+            constantTypedExpr->type()->toString(),
+            Kind);
+    }
+  }
+
+  if (constantTypedExpr->type()->kind() == Kind) {
+    return convertedTypedExpr;
+  }
+
+  switch (constantTypedExpr->type()->kind()) {
+    case TypeKind::INTEGER:
+      return castConstantConditionInput<TypeKind::INTEGER, Kind>(
+          constantTypedExpr);
+    case TypeKind::BIGINT:
+      return castConstantConditionInput<TypeKind::BIGINT, Kind>(
+          constantTypedExpr);
+    case TypeKind::SMALLINT:
+      return castConstantConditionInput<TypeKind::SMALLINT, Kind>(
+          constantTypedExpr);
+    default:
+      VELOX_UNSUPPORTED(
+          "Incompatible condition input type: {}, index column kind: {}",
+          constantTypedExpr->type()->toString(),
+          Kind);
+  }
+}
+
+core::TypedExprPtr castIndexConditionInputExpr(
+    const core::TypedExprPtr& expr,
+    const TypePtr& indexType) {
+  switch (indexType->kind()) {
+    case TypeKind::INTEGER:
+      return castIndexConditionInputExpr<TypeKind::INTEGER>(expr);
+    case TypeKind::BIGINT:
+      return castIndexConditionInputExpr<TypeKind::BIGINT>(expr);
+    case TypeKind::SMALLINT:
+      return castIndexConditionInputExpr<TypeKind::SMALLINT>(expr);
+    default:
+      VELOX_UNSUPPORTED("Unsupported index column kind: {}", expr->toString());
+  }
+}
+} // namespace
+
+// static
+core::IndexLookupConditionPtr PlanBuilder::parseIndexJoinCondition(
+    const std::string& joinCondition,
+    const RowTypePtr& rowType,
+    memory::MemoryPool* pool) {
+  const auto joinConditionExpr =
+      parseExpr(joinCondition, rowType, parse::ParseOptions{}, pool);
+  const auto typedCallExpr =
+      std::dynamic_pointer_cast<const core::CallTypedExpr>(joinConditionExpr);
+  VELOX_CHECK_NOT_NULL(typedCallExpr);
+  if (typedCallExpr->name() == "contains") {
+    VELOX_CHECK_EQ(typedCallExpr->inputs().size(), 2);
+    const auto keyColumnExpr =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+            removeCastTypedExpr(typedCallExpr->inputs()[1]));
+    VELOX_CHECK_NOT_NULL(
+        keyColumnExpr, "{}", typedCallExpr->inputs()[1]->toString());
+    return std::make_shared<core::InIndexLookupCondition>(
+        keyColumnExpr,
+        castIndexConditionInputExpr(
+            typedCallExpr->inputs()[0], keyColumnExpr->type()));
+  }
+
+  if (typedCallExpr->name() == "between") {
+    VELOX_CHECK_EQ(typedCallExpr->inputs().size(), 3);
+    const auto keyColumnExpr =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+            removeCastTypedExpr(typedCallExpr->inputs()[0]));
+    VELOX_CHECK_NOT_NULL(
+        keyColumnExpr, "{}", typedCallExpr->inputs()[0]->toString());
+    return std::make_shared<core::BetweenIndexLookupCondition>(
+        keyColumnExpr,
+        castIndexConditionInputExpr(
+            typedCallExpr->inputs()[1], keyColumnExpr->type()),
+        castIndexConditionInputExpr(
+            typedCallExpr->inputs()[2], keyColumnExpr->type()));
+  }
+
+  if (typedCallExpr->name() == "eq") {
+    VELOX_CHECK_EQ(typedCallExpr->inputs().size(), 2);
+    const auto keyColumnExpr =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+            removeCastTypedExpr(typedCallExpr->inputs()[0]));
+    VELOX_CHECK_NOT_NULL(
+        keyColumnExpr, "{}", typedCallExpr->inputs()[0]->toString());
+    return std::make_shared<core::EqualIndexLookupCondition>(
+        keyColumnExpr,
+        castIndexConditionInputExpr(
+            typedCallExpr->inputs()[1], keyColumnExpr->type()));
+  }
+  VELOX_USER_FAIL(
+      "Invalid index join condition: {}, and we only support in, between, and equal conditions",
+      joinCondition);
+}
+
+PlanBuilder& PlanBuilder::indexLookupJoin(
+    const std::vector<std::string>& leftKeys,
+    const std::vector<std::string>& rightKeys,
+    const core::TableScanNodePtr& right,
+    const std::vector<std::string>& joinConditions,
+    bool includeMatchColumn,
+    const std::vector<std::string>& outputLayout,
+    core::JoinType joinType) {
+  VELOX_CHECK_NOT_NULL(planNode_, "indexLookupJoin cannot be the source node");
+  auto inputType = concat(planNode_->outputType(), right->outputType());
+  if (includeMatchColumn) {
+    auto names = inputType->names();
+    names.push_back(outputLayout.back());
+    auto types = inputType->children();
+    types.push_back(BOOLEAN());
+    inputType = ROW(std::move(names), std::move(types));
+  }
+  auto outputType = extract(inputType, outputLayout);
+  auto leftKeyFields = fields(planNode_->outputType(), leftKeys);
+  auto rightKeyFields = fields(right->outputType(), rightKeys);
+
+  std::vector<core::IndexLookupConditionPtr> joinConditionPtrs{};
+  joinConditionPtrs.reserve(joinConditions.size());
+  for (const auto& joinCondition : joinConditions) {
+    joinConditionPtrs.push_back(
+        parseIndexJoinCondition(joinCondition, inputType, pool_));
+  }
+
+  planNode_ = std::make_shared<core::IndexLookupJoinNode>(
+      nextPlanNodeId(),
+      joinType,
+      std::move(leftKeyFields),
+      std::move(rightKeyFields),
+      std::move(joinConditionPtrs),
+      includeMatchColumn,
+      std::move(planNode_),
+      right,
+      std::move(outputType));
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::unnest(
+    const std::vector<std::string>& replicateColumns,
+    const std::vector<std::string>& unnestColumns,
+    const std::optional<std::string>& ordinalColumn,
+    const std::optional<std::string>& emptyUnnestValueName) {
+  VELOX_CHECK_NOT_NULL(planNode_, "Unnest cannot be the source node");
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
+      replicateFields;
+  replicateFields.reserve(replicateColumns.size());
+  for (const auto& name : replicateColumns) {
+    replicateFields.emplace_back(field(name));
+  }
+
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> unnestFields;
+  unnestFields.reserve(unnestColumns.size());
+  for (const auto& name : unnestColumns) {
+    unnestFields.emplace_back(field(name));
+  }
+
+  std::vector<std::string> unnestNames;
+  for (const auto& name : unnestColumns) {
+    auto input = planNode_->outputType()->findChild(name);
+    if (input->isArray()) {
+      unnestNames.push_back(name + "_e");
+    } else if (input->isMap()) {
+      unnestNames.push_back(name + "_k");
+      unnestNames.push_back(name + "_v");
+    } else {
+      VELOX_NYI(
+          "Unsupported type of unnest variable. Expected ARRAY or MAP, but got {}.",
+          input->toString());
+    }
+  }
+
+  planNode_ = std::make_shared<core::UnnestNode>(
+      nextPlanNodeId(),
+      replicateFields,
+      unnestFields,
+      unnestNames,
+      ordinalColumn,
+      emptyUnnestValueName,
+      planNode_);
+  VELOX_CHECK(planNode_->supportsBarrier());
+  return *this;
+}
+
+namespace {
+std::string throwWindowFunctionDoesntExist(const std::string& name) {
+  std::stringstream error;
+  error << "Window function doesn't exist: " << name << ".";
+  if (exec::windowFunctions().empty()) {
+    error << " Registry of window functions is empty. "
+             "Make sure to register some window functions.";
+  }
+  VELOX_USER_FAIL(error.str());
+}
+
+std::string throwWindowFunctionSignatureNotSupported(
+    const std::string& name,
+    const std::vector<TypePtr>& types,
+    const std::vector<FunctionSignaturePtr>& signatures) {
+  std::stringstream error;
+  error << "Window function signature is not supported: "
+        << toString(name, types)
+        << ". Supported signatures: " << toString(signatures) << ".";
+  VELOX_USER_FAIL(error.str());
+}
+
+TypePtr resolveWindowType(
+    const std::string& windowFunctionName,
+    const std::vector<TypePtr>& inputTypes,
+    bool nullOnFailure) {
+  if (auto signatures = exec::getWindowFunctionSignatures(windowFunctionName)) {
+    for (const auto& signature : signatures.value()) {
+      exec::SignatureBinder binder(*signature, inputTypes);
+      if (binder.tryBind()) {
+        return binder.tryResolveType(signature->returnType());
+      }
+    }
+
+    if (nullOnFailure) {
+      return nullptr;
+    }
+    throwWindowFunctionSignatureNotSupported(
+        windowFunctionName, inputTypes, signatures.value());
+  }
+
+  if (nullOnFailure) {
+    return nullptr;
+  }
+  throwWindowFunctionDoesntExist(windowFunctionName);
+  return nullptr;
+}
+
+class WindowTypeResolver {
+ public:
+  explicit WindowTypeResolver()
+      : previousHook_(core::Expressions::getResolverHook()) {
+    core::Expressions::setTypeResolverHook(
+        [&](const auto& inputs, const auto& expr, bool nullOnFailure) {
+          return resolveType(inputs, expr, nullOnFailure);
+        });
+  }
+
+  ~WindowTypeResolver() {
+    core::Expressions::setTypeResolverHook(previousHook_);
+  }
+
+ private:
+  TypePtr resolveType(
+      const std::vector<core::TypedExprPtr>& inputs,
+      const std::shared_ptr<const core::CallExpr>& expr,
+      bool nullOnFailure) const {
+    std::vector<TypePtr> types;
+    for (auto& input : inputs) {
+      types.push_back(input->type());
+    }
+
+    const auto& functionName = expr->name();
+
+    return resolveWindowType(functionName, types, nullOnFailure);
+  }
+
+  const core::Expressions::TypeResolverHook previousHook_;
+};
+
+const core::WindowNode::Frame createWindowFrame(
+    const duckdb::IExprWindowFrame& windowFrame,
+    const TypePtr& inputRow,
+    memory::MemoryPool* pool) {
+  core::WindowNode::Frame frame;
+  frame.type = (windowFrame.type == duckdb::WindowType::kRows)
+      ? core::WindowNode::WindowType::kRows
+      : core::WindowNode::WindowType::kRange;
+
+  auto boundTypeConversion =
+      [](duckdb::BoundType boundType) -> core::WindowNode::BoundType {
+    switch (boundType) {
+      case duckdb::BoundType::kCurrentRow:
+        return core::WindowNode::BoundType::kCurrentRow;
+      case duckdb::BoundType::kFollowing:
+        return core::WindowNode::BoundType::kFollowing;
+      case duckdb::BoundType::kPreceding:
+        return core::WindowNode::BoundType::kPreceding;
+      case duckdb::BoundType::kUnboundedFollowing:
+        return core::WindowNode::BoundType::kUnboundedFollowing;
+      case duckdb::BoundType::kUnboundedPreceding:
+        return core::WindowNode::BoundType::kUnboundedPreceding;
+    }
+    VELOX_UNREACHABLE();
+  };
+  frame.startType = boundTypeConversion(windowFrame.startType);
+  frame.startValue = windowFrame.startValue
+      ? core::Expressions::inferTypes(windowFrame.startValue, inputRow, pool)
+      : nullptr;
+  frame.endType = boundTypeConversion(windowFrame.endType);
+  frame.endValue = windowFrame.endValue
+      ? core::Expressions::inferTypes(windowFrame.endValue, inputRow, pool)
+      : nullptr;
+  return frame;
+}
+
+std::vector<core::FieldAccessTypedExprPtr> parsePartitionKeys(
+    const duckdb::IExprWindowFunction& windowExpr,
+    const std::string& windowString,
+    const TypePtr& inputRow,
+    memory::MemoryPool* pool) {
+  std::vector<core::FieldAccessTypedExprPtr> partitionKeys;
+  for (const auto& partitionKey : windowExpr.partitionBy) {
+    auto typedExpr =
+        core::Expressions::inferTypes(partitionKey, inputRow, pool);
+    auto typedPartitionKey =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(typedExpr);
+    VELOX_CHECK_NOT_NULL(
+        typedPartitionKey,
+        "PARTITION BY clause must use a column name, not an expression: {}",
+        windowString);
+    partitionKeys.emplace_back(typedPartitionKey);
+  }
+  return partitionKeys;
+}
+
+std::pair<
+    std::vector<core::FieldAccessTypedExprPtr>,
+    std::vector<core::SortOrder>>
+parseOrderByKeys(
+    const duckdb::IExprWindowFunction& windowExpr,
+    const std::string& windowString,
+    const TypePtr& inputRow,
+    memory::MemoryPool* pool) {
+  std::vector<core::FieldAccessTypedExprPtr> sortingKeys;
+  std::vector<core::SortOrder> sortingOrders;
+
+  for (const auto& orderBy : windowExpr.orderBy) {
+    auto typedExpr =
+        core::Expressions::inferTypes(orderBy.expr, inputRow, pool);
+    auto sortingKey =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(typedExpr);
+    VELOX_CHECK_NOT_NULL(
+        sortingKey,
+        "ORDER BY clause must use a column name, not an expression: {}",
+        windowString);
+    sortingKeys.emplace_back(sortingKey);
+    sortingOrders.emplace_back(orderBy.ascending, orderBy.nullsFirst);
+  }
+  return {sortingKeys, sortingOrders};
+}
+
+bool equalFieldAccessTypedExprPtrList(
+    const std::vector<core::FieldAccessTypedExprPtr>& lhs,
+    const std::vector<core::FieldAccessTypedExprPtr>& rhs) {
+  return std::equal(
+      lhs.begin(),
+      lhs.end(),
+      rhs.begin(),
+      [](const core::FieldAccessTypedExprPtr& e1,
+         const core::FieldAccessTypedExprPtr& e2) {
+        return e1->name() == e2->name();
+      });
+}
+
+bool equalSortOrderList(
+    const std::vector<core::SortOrder>& lhs,
+    const std::vector<core::SortOrder>& rhs) {
+  return std::equal(
+      lhs.begin(),
+      lhs.end(),
+      rhs.begin(),
+      [](const core::SortOrder& s1, const core::SortOrder& s2) {
+        return s1.isAscending() == s2.isAscending() &&
+            s1.isNullsFirst() == s2.isNullsFirst();
+      });
+}
+
+} // namespace
+
+PlanBuilder& PlanBuilder::window(
+    const std::vector<std::string>& windowFunctions,
+    bool inputSorted) {
+  VELOX_CHECK_NOT_NULL(planNode_, "Window cannot be the source node");
+  VELOX_CHECK_GT(
+      windowFunctions.size(),
+      0,
+      "Window Node requires at least one window function.");
+
+  std::vector<core::FieldAccessTypedExprPtr> partitionKeys;
+  std::vector<core::FieldAccessTypedExprPtr> sortingKeys;
+  std::vector<core::SortOrder> sortingOrders;
+  std::vector<core::WindowNode::Function> windowNodeFunctions;
+  std::vector<std::string> windowNames;
+
+  bool first = true;
+  auto inputType = planNode_->outputType();
+  int i = 0;
+
+  auto errorOnMismatch = [&](const std::string& windowString,
+                             const std::string& mismatchTypeString) -> void {
+    std::stringstream error;
+    error << "Window function invocations " << windowString << " and "
+          << windowFunctions[0] << " do not match " << mismatchTypeString
+          << " clauses.";
+    VELOX_USER_FAIL(error.str());
+  };
+
+  WindowTypeResolver windowResolver;
+  facebook::velox::duckdb::ParseOptions options;
+  options.parseIntegerAsBigint = options_.parseIntegerAsBigint;
+  for (const auto& windowString : windowFunctions) {
+    const auto& windowExpr = duckdb::parseWindowExpr(windowString, options);
+    // All window function SQL strings in the list are expected to have the same
+    // PARTITION BY and ORDER BY clauses. Validate this assumption.
+    if (first) {
+      partitionKeys =
+          parsePartitionKeys(windowExpr, windowString, inputType, pool_);
+      auto sortPair =
+          parseOrderByKeys(windowExpr, windowString, inputType, pool_);
+      sortingKeys = sortPair.first;
+      sortingOrders = sortPair.second;
+      first = false;
+    } else {
+      auto latestPartitionKeys =
+          parsePartitionKeys(windowExpr, windowString, inputType, pool_);
+      auto [latestSortingKeys, latestSortingOrders] =
+          parseOrderByKeys(windowExpr, windowString, inputType, pool_);
+
+      if (!equalFieldAccessTypedExprPtrList(
+              partitionKeys, latestPartitionKeys)) {
+        errorOnMismatch(windowString, "PARTITION BY");
+      }
+
+      if (!equalFieldAccessTypedExprPtrList(sortingKeys, latestSortingKeys)) {
+        errorOnMismatch(windowString, "ORDER BY");
+      }
+
+      if (!equalSortOrderList(sortingOrders, latestSortingOrders)) {
+        errorOnMismatch(windowString, "ORDER BY");
+      }
+    }
+
+    auto windowCall = std::dynamic_pointer_cast<const core::CallTypedExpr>(
+        core::Expressions::inferTypes(
+            windowExpr.functionCall, planNode_->outputType(), pool_));
+    windowNodeFunctions.push_back(
+        {std::move(windowCall),
+         createWindowFrame(windowExpr.frame, planNode_->outputType(), pool_),
+         windowExpr.ignoreNulls});
+    if (windowExpr.functionCall->alias().has_value()) {
+      windowNames.push_back(windowExpr.functionCall->alias().value());
+    } else {
+      windowNames.push_back(fmt::format("w{}", i++));
+    }
+  }
+
+  planNode_ = std::make_shared<core::WindowNode>(
+      nextPlanNodeId(),
+      partitionKeys,
+      sortingKeys,
+      sortingOrders,
+      windowNames,
+      windowNodeFunctions,
+      inputSorted,
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::window(
+    const std::vector<std::string>& windowFunctions) {
+  return window(windowFunctions, false);
+}
+
+PlanBuilder& PlanBuilder::streamingWindow(
+    const std::vector<std::string>& windowFunctions) {
+  return window(windowFunctions, true);
+}
+
+PlanBuilder& PlanBuilder::rowNumber(
+    const std::vector<std::string>& partitionKeys,
+    std::optional<int32_t> limit,
+    const bool generateRowNumber) {
+  std::optional<std::string> rowNumberColumnName;
+  if (generateRowNumber) {
+    rowNumberColumnName = "row_number";
+  }
+  planNode_ = std::make_shared<core::RowNumberNode>(
+      nextPlanNodeId(),
+      fields(partitionKeys),
+      rowNumberColumnName,
+      limit,
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::topNRank(
+    std::string_view function,
+    const std::vector<std::string>& partitionKeys,
+    const std::vector<std::string>& sortingKeys,
+    int32_t limit,
+    bool generateRowNumber) {
+  VELOX_CHECK_NOT_NULL(planNode_, "TopNRowNumber cannot be the source node");
+  auto [sortingFields, sortingOrders] =
+      parseOrderByClauses(sortingKeys, planNode_->outputType(), pool_);
+  std::optional<std::string> rowNumberColumnName;
+  if (generateRowNumber) {
+    rowNumberColumnName = "row_number";
+  }
+  planNode_ = std::make_shared<core::TopNRowNumberNode>(
+      nextPlanNodeId(),
+      core::TopNRowNumberNode::rankFunctionFromName(function),
+      fields(partitionKeys),
+      sortingFields,
+      sortingOrders,
+      rowNumberColumnName,
+      limit,
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::topNRowNumber(
+    const std::vector<std::string>& partitionKeys,
+    const std::vector<std::string>& sortingKeys,
+    int32_t limit,
+    bool generateRowNumber) {
+  return topNRank(
+      "row_number", partitionKeys, sortingKeys, limit, generateRowNumber);
+}
+
+PlanBuilder& PlanBuilder::markDistinct(
+    std::string markerKey,
+    const std::vector<std::string>& distinctKeys) {
+  VELOX_CHECK_NOT_NULL(planNode_, "MarkDistinct cannot be the source node");
+  planNode_ = std::make_shared<core::MarkDistinctNode>(
+      nextPlanNodeId(),
+      std::move(markerKey),
+      fields(planNode_->outputType(), distinctKeys),
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+core::PlanNodeId PlanBuilder::nextPlanNodeId() {
+  return planNodeIdGenerator_->next();
+}
+
+// static
+std::shared_ptr<const core::FieldAccessTypedExpr> PlanBuilder::field(
+    const RowTypePtr& inputType,
+    const std::string& name) {
+  auto index = inputType->getChildIdx(name);
+  return field(inputType, index);
+}
+
+// static
+std::shared_ptr<const core::FieldAccessTypedExpr> PlanBuilder::field(
+    const RowTypePtr& inputType,
+    column_index_t index) {
+  auto name = inputType->names()[index];
+  auto type = inputType->childAt(index);
+  return std::make_shared<core::FieldAccessTypedExpr>(type, name);
+}
+
+// static
+std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
+PlanBuilder::fields(
+    const RowTypePtr& inputType,
+    const std::vector<std::string>& names) {
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields;
+  for (const auto& name : names) {
+    fields.push_back(field(inputType, name));
+  }
+  return fields;
+}
+
+// static
+std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
+PlanBuilder::fields(
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& indices) {
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields;
+  for (auto& index : indices) {
+    fields.push_back(field(inputType, index));
+  }
+  return fields;
+}
+
+std::shared_ptr<const core::FieldAccessTypedExpr> PlanBuilder::field(
+    column_index_t index) {
+  VELOX_CHECK_NOT_NULL(planNode_);
+  return field(planNode_->outputType(), index);
+}
+
+std::shared_ptr<const core::FieldAccessTypedExpr> PlanBuilder::field(
+    const std::string& name) {
+  VELOX_CHECK_NOT_NULL(planNode_);
+  return field(planNode_->outputType(), name);
+}
+
+std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
+PlanBuilder::fields(const std::vector<std::string>& names) {
+  VELOX_CHECK_NOT_NULL(planNode_);
+  return fields(planNode_->outputType(), names);
+}
+
+std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
+PlanBuilder::fields(const std::vector<column_index_t>& indices) {
+  VELOX_CHECK_NOT_NULL(planNode_);
+  return fields(planNode_->outputType(), indices);
+}
+
+std::vector<core::TypedExprPtr> PlanBuilder::exprs(
+    const std::vector<std::string>& expressions,
+    const RowTypePtr& inputType) {
+  std::vector<core::TypedExprPtr> typedExpressions;
+  for (auto& expr : expressions) {
+    auto typedExpression = core::Expressions::inferTypes(
+        parse::parseExpr(expr, options_), inputType, pool_);
+
+    if (dynamic_cast<const core::FieldAccessTypedExpr*>(
+            typedExpression.get())) {
+      typedExpressions.push_back(typedExpression);
+    } else if (dynamic_cast<const core::ConstantTypedExpr*>(
+                   typedExpression.get())) {
+      typedExpressions.push_back(typedExpression);
+    } else {
+      VELOX_FAIL("Expected field name or constant: {}", expr);
+    }
+  }
+
+  return typedExpressions;
+}
+
+core::TypedExprPtr PlanBuilder::inferTypes(
+    const std::shared_ptr<const core::IExpr>& untypedExpr) {
+  VELOX_CHECK_NOT_NULL(planNode_);
+  return core::Expressions::inferTypes(
+      untypedExpr, planNode_->outputType(), pool_);
+}
+} // namespace facebook::velox::exec::test

--- a/velox/connectors/lakehouse/common/tests/PlanBuilder.h
+++ b/velox/connectors/lakehouse/common/tests/PlanBuilder.h
@@ -16,11 +16,11 @@
 
 #pragma once
 
-#include <velox/core/Expressions.h>
-#include <velox/core/ITypedExpr.h>
-#include <velox/core/PlanFragment.h>
-#include <velox/core/PlanNode.h>
-#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/lakehouse/common/HiveDataSink.h"
+#include "velox/core/Expressions.h"
+#include "velox/core/ITypedExpr.h"
+#include "velox/core/PlanFragment.h"
+#include "velox/core/PlanNode.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/IExpr.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
@@ -29,10 +29,10 @@ namespace facebook::velox::tpch {
 enum class Table : uint8_t;
 }
 
-namespace facebook::velox::exec::test {
+namespace facebook::velox::connector::lakehouse::common::test {
 
 struct PushdownConfig {
-  common::SubfieldFilters subfieldFiltersMap;
+  velox::common::SubfieldFilters subfieldFiltersMap;
   std::string remainingFilter;
 };
 
@@ -257,7 +257,7 @@ class PlanBuilder {
 
     // @param subfieldFiltersMap A map of Subfield to Filters.
     TableScanBuilder& subfieldFiltersMap(
-        const common::SubfieldFilters& filtersMap);
+        const velox::common::SubfieldFilters& filtersMap);
 
     /// @param subfieldFilter A single SQL expression to be applied to an
     /// individual column.
@@ -333,7 +333,7 @@ class PlanBuilder {
     std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator_;
 
     // SubfieldFilters object containing filters to apply.
-    common::SubfieldFilters subfieldFiltersMap_;
+    velox::common::SubfieldFilters subfieldFiltersMap_;
   };
 
   /// Start a TableScanBuilder.
@@ -419,8 +419,8 @@ class PlanBuilder {
 
     /// @param sortBy Specifies the sort by columns.
     TableWriterBuilder& sortBy(
-        std::vector<std::shared_ptr<const connector::hive::HiveSortingColumn>>
-            sortBy) {
+        std::vector<std::shared_ptr<
+            const connector::lakehouse::common::HiveSortingColumn>> sortBy) {
       sortBy_ = std::move(sortBy);
       return *this;
     }
@@ -448,7 +448,7 @@ class PlanBuilder {
     /// @param compressionKind Compression scheme to use for writing the
     /// output data files.
     TableWriterBuilder& compressionKind(
-        common::CompressionKind compressionKind) {
+        velox::common::CompressionKind compressionKind) {
       compressionKind_ = compressionKind;
       return *this;
     }
@@ -490,14 +490,16 @@ class PlanBuilder {
     int32_t bucketCount_{0};
     std::vector<std::string> bucketedBy_;
     std::vector<std::string> aggregates_;
-    std::vector<std::shared_ptr<const connector::hive::HiveSortingColumn>>
+    std::vector<
+        std::shared_ptr<const connector::lakehouse::common::HiveSortingColumn>>
         sortBy_;
 
     std::unordered_map<std::string, std::string> serdeParameters_;
     std::shared_ptr<dwio::common::WriterOptions> options_;
 
     dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
-    common::CompressionKind compressionKind_{common::CompressionKind_NONE};
+    velox::common::CompressionKind compressionKind_{
+        velox::common::CompressionKind_NONE};
 
     bool ensureFiles_{false};
     connector::CommitStrategy commitStrategy_{
@@ -726,8 +728,8 @@ class PlanBuilder {
       const std::vector<std::string>& partitionBy,
       int32_t bucketCount,
       const std::vector<std::string>& bucketedBy,
-      const std::vector<
-          std::shared_ptr<const connector::hive::HiveSortingColumn>>& sortBy,
+      const std::vector<std::shared_ptr<
+          const connector::lakehouse::common::HiveSortingColumn>>& sortBy,
       const dwio::common::FileFormat fileFormat =
           dwio::common::FileFormat::DWRF,
       const std::vector<std::string>& aggregates = {},
@@ -735,7 +737,8 @@ class PlanBuilder {
       const std::unordered_map<std::string, std::string>& serdeParameters = {},
       const std::shared_ptr<dwio::common::WriterOptions>& options = nullptr,
       const std::string& outputFileName = "",
-      const common::CompressionKind = common::CompressionKind_NONE,
+      const velox::common::CompressionKind =
+          velox::common::CompressionKind_NONE,
       const RowTypePtr& schema = nullptr,
       const bool ensureFiles = false,
       const connector::CommitStrategy commitStrategy =
@@ -1097,7 +1100,7 @@ class PlanBuilder {
   /// A convenience method to add a LocalPartitionNode with a single source (the
   /// current plan node) and hive bucket property.
   PlanBuilder& localPartitionByBucket(
-      const std::shared_ptr<connector::hive::HiveBucketProperty>&
+      const std::shared_ptr<connector::lakehouse::common::HiveBucketProperty>&
           bucketProperty);
 
   /// Add a LocalPartitionNode to partition the input using batch-level
@@ -1498,4 +1501,4 @@ class PlanBuilder {
   memory::MemoryPool* pool_;
   bool filtersAsNode_{false};
 };
-} // namespace facebook::velox::exec::test
+} // namespace facebook::velox::connector::lakehouse::common::test

--- a/velox/connectors/lakehouse/common/tests/PlanBuilder.h
+++ b/velox/connectors/lakehouse/common/tests/PlanBuilder.h
@@ -1,0 +1,1501 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <velox/core/Expressions.h>
+#include <velox/core/ITypedExpr.h>
+#include <velox/core/PlanFragment.h>
+#include <velox/core/PlanNode.h>
+#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/IExpr.h"
+#include "velox/parse/PlanNodeIdGenerator.h"
+
+namespace facebook::velox::tpch {
+enum class Table : uint8_t;
+}
+
+namespace facebook::velox::exec::test {
+
+struct PushdownConfig {
+  common::SubfieldFilters subfieldFiltersMap;
+  std::string remainingFilter;
+};
+
+/// A builder class with fluent API for building query plans. Plans are built
+/// bottom up starting with the source node (table scan or similar). Expressions
+/// and orders can be specified using SQL. See filter, project and orderBy
+/// methods for details.
+///
+/// For example, to build a query plan for a leaf fragment of a simple query
+///     SELECT a, sum(b) FROM t GROUP BY 1
+///
+///     auto plan = PlanBuilder()
+///         .tableScan(ROW({"a", "b"}, {INTEGER(), DOUBLE()}))
+///         .partialAggregation({"a"}, {"sum(b)"})
+///         .planNode();
+///
+/// Here, we use default PlanNodeIdGenerator that starts from zero, hence, table
+/// scan node ID will be "0". You'll need to use this ID when adding splits.
+///
+/// A join query plan would be a bit more complex:
+///     SELECT t.a, u.b FROM t, u WHERE t.key = u.key
+///
+///     auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+///     core::PlanNodeId tScanId; // ID of the table scan node for 't'.
+///     core::PlanNodeId uScanId; // ID of the table scan node for 'u'.
+///     auto plan = PlanBuilder(planNodeIdGenerator)
+///         .tableScan(ROW({"key", "a"}, {INTEGER(), BIGINT()}))
+///         .capturePlanNodeId(tScanId)
+///         .hashJoin(
+///             {"key"},
+///             {"key"},
+///             PlanBuilder(planNodeIdGenerator)
+///                 .tableScan(ROW({"key", "b"}, {INTEGER(), DOUBLE()})))
+///                 .capturePlanNodeId(uScanId)
+///                 .planNode(),
+///             "", // no extra join filter
+///             {"a", "b"})
+///         .planNode();
+///
+/// We use two builders, one for the right-side and another for the left-side
+/// of the join. To ensure plan node IDs are unique in the final plan, we use
+/// the same instance of PlanNodeIdGenerator with both builders. We also use
+/// capturePlanNodeId method to capture the IDs of the table scan nodes for
+/// 't' and 'u'. We need these to add splits.
+class PlanBuilder {
+ public:
+  /// Constructor taking an instance of PlanNodeIdGenerator and a memory pool.
+  ///
+  /// The memory pool is used when parsing expressions containing complex-type
+  /// literals, e.g. arrays, maps or structs. The memory pool can be empty if
+  /// such expressions are not used in the plan.
+  ///
+  /// When creating tree-shaped plans, e.g. join queries, use the same instance
+  /// of PlanNodeIdGenerator for all builders to ensure unique plan node IDs
+  /// across the plan.
+  explicit PlanBuilder(
+      std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator,
+      memory::MemoryPool* pool = nullptr)
+      : planNodeIdGenerator_{std::move(planNodeIdGenerator)}, pool_{pool} {}
+
+  /// Constructor with no required parameters suitable for creating
+  /// straight-line (e.g. no joins) query plans.
+  explicit PlanBuilder(memory::MemoryPool* pool = nullptr)
+      : PlanBuilder(std::make_shared<core::PlanNodeIdGenerator>(), pool) {}
+
+  /// Constructor that allows an initial plane node to be specified for testing
+  /// this is useful when testing additional connectors that do not rely on the
+  /// table scan node supported below.
+  PlanBuilder(
+      core::PlanNodePtr initialPlanNode,
+      std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator,
+      memory::MemoryPool* pool = nullptr)
+      : planNode_(std::move(initialPlanNode)),
+        planNodeIdGenerator_{std::move(planNodeIdGenerator)},
+        pool_{pool} {}
+
+  virtual ~PlanBuilder() = default;
+
+  static constexpr const std::string_view kHiveDefaultConnectorId{"test-hive"};
+  static constexpr const std::string_view kTpchDefaultConnectorId{"test-tpch"};
+
+  ///
+  /// TableScan
+  ///
+
+  /// Add a TableScanNode to scan a Hive table.
+  ///
+  /// @param outputType List of column names and types to read from the table.
+  /// @param subfieldFilters A list of SQL expressions for the range filters to
+  /// apply to individual columns. Supported filters are: column <= value,
+  /// column < value, column >= value, column > value, column = value, column IN
+  /// (v1, v2,.. vN), column < v1 OR column >= v2.
+  /// @param remainingFilter SQL expression for the additional conjunct. May
+  /// include multiple columns and SQL functions. The remainingFilter is AND'ed
+  /// with all the subfieldFilters.
+  /// @param dataColumns can be different from 'outputType' for the purposes
+  /// of testing queries using missing columns. It is used, if specified, for
+  /// parseExpr call and as 'dataColumns' for the TableHandle. You supply more
+  /// types (for all columns) in this argument as opposed to 'outputType', where
+  /// you define the output types only. See 'missingColumns' test in
+  /// 'TableScanTest'.
+  /// @param assignments Optional ColumnHandles.
+  PlanBuilder& tableScan(
+      const RowTypePtr& outputType,
+      const std::vector<std::string>& subfieldFilters = {},
+      const std::string& remainingFilter = "",
+      const RowTypePtr& dataColumns = nullptr,
+      const connector::ColumnHandleMap& assignments = {});
+
+  /// Add a TableScanNode to scan a Hive table.
+  ///
+  /// @param tableName The name of the table to scan.
+  /// @param outputType List of column names and types to read from the table.
+  /// @param columnAliases Optional aliases for the column names. The key is the
+  /// alias (name in 'outputType'), value is the name in the files.
+  /// @param subfieldFilters A list of SQL expressions for the range filters to
+  /// apply to individual columns. Should use column name aliases, not column
+  /// names in the files. Supported filters are: column <= value, column <
+  /// value, column >= value, column > value, column = value, column IN (v1,
+  /// v2,.. vN), column < v1 OR column >= v2.
+  /// @param remainingFilter SQL expression for the additional conjunct. May
+  /// include multiple columns and SQL functions. Should use column name
+  /// aliases, not column names in the files. The remainingFilter is AND'ed
+  /// with all the subfieldFilters.
+  /// @param dataColumns can be different from 'outputType' for the purposes
+  /// of testing queries using missing columns. It is used, if specified, for
+  /// parseExpr call and as 'dataColumns' for the TableHandle. You supply more
+  /// types (for all columns) in this argument as opposed to 'outputType', where
+  /// you define the output types only. See 'missingColumns' test in
+  /// 'TableScanTest'.
+  PlanBuilder& tableScan(
+      const std::string& tableName,
+      const RowTypePtr& outputType,
+      const std::unordered_map<std::string, std::string>& columnAliases = {},
+      const std::vector<std::string>& subfieldFilters = {},
+      const std::string& remainingFilter = "",
+      const RowTypePtr& dataColumns = nullptr,
+      const connector::ColumnHandleMap& assignments = {});
+
+  /// Add a TableScanNode to scan a Hive table with direct SubfieldFilters.
+  ///
+  /// @param outputType List of column names and types to read from the table.
+  /// @param PushdownConfig Contains pushdown configs for the table scan.
+  /// @param dataColumns Optional data columns that may differ from outputType.
+  /// @param assignments Optional ColumnHandles.
+
+  PlanBuilder& tableScanWithPushDown(
+      const RowTypePtr& outputType,
+      const PushdownConfig& pushdownConfig,
+      const RowTypePtr& dataColumns = nullptr,
+      const connector::ColumnHandleMap& assignments = {});
+
+  /// Add a TableScanNode to scan a TPC-H table.
+  ///
+  /// @param tpchTableHandle The handle that specifies the target TPC-H table
+  /// and scale factor.
+  /// @param columnNames The columns to be returned from that table.
+  /// @param scaleFactor The TPC-H scale factor.
+  /// @param connectorId The TPC-H connector id.
+  /// @param filter Optional SQL expression to filter the data at the connector
+  /// level.
+  PlanBuilder& tpchTableScan(
+      tpch::Table table,
+      std::vector<std::string> columnNames,
+      double scaleFactor = 1,
+      std::string_view connectorId = kTpchDefaultConnectorId,
+      const std::string& filter = "");
+
+  /// Helper class to build a custom TableScanNode.
+  /// Uses a planBuilder instance to get the next plan id, memory pool, and
+  /// parse options.
+  ///
+  /// Uses the hive connector by default. Specify outputType, tableHandle, and
+  /// assignments for other connectors. If these three are specified, all other
+  /// builder arguments will be ignored.
+  class TableScanBuilder {
+   public:
+    TableScanBuilder(PlanBuilder& builder) : planBuilder_(builder) {}
+
+    /// @param tableName The name of the table to scan.
+    TableScanBuilder& tableName(std::string tableName) {
+      tableName_ = std::move(tableName);
+      return *this;
+    }
+
+    /// if 'idGenerator' is non-nullptr, produces filters that would be pushed
+    /// down into the scan as a separate FilterNode instead. 'idGenerator'
+    /// produces the id for the filterNode.
+    TableScanBuilder& filtersAsNode(
+        std::shared_ptr<core::PlanNodeIdGenerator> idGenerator) {
+      filtersAsNode_ = idGenerator != nullptr;
+      planNodeIdGenerator_ = idGenerator;
+      return *this;
+    }
+
+    /// @param connectorId The id of the connector to scan.
+    TableScanBuilder& connectorId(std::string connectorId) {
+      connectorId_ = std::move(connectorId);
+      return *this;
+    }
+
+    /// @param outputType List of column names and types to read from the table.
+    /// This property is required.
+    TableScanBuilder& outputType(RowTypePtr outputType) {
+      outputType_ = std::move(outputType);
+      return *this;
+    }
+
+    /// @param subfieldFilters A list of SQL expressions to apply to individual
+    /// columns. These are range filters that can be efficiently applied as data
+    /// is read/decoded. Supported filters are:
+    ///
+    /// >  column <= value
+    /// >  column < value
+    /// >  column >= value
+    /// >  column > value
+    /// >  column = value
+    /// >  column IN (v1, v2,.. vN)
+    /// >  column < v1
+    /// >  column >= v2
+    TableScanBuilder& subfieldFilters(std::vector<std::string> subfieldFilters);
+
+    // @param subfieldFiltersMap A map of Subfield to Filters.
+    TableScanBuilder& subfieldFiltersMap(
+        const common::SubfieldFilters& filtersMap);
+
+    /// @param subfieldFilter A single SQL expression to be applied to an
+    /// individual column.
+    TableScanBuilder& subfieldFilter(std::string subfieldFilter) {
+      return subfieldFilters({std::move(subfieldFilter)});
+    }
+
+    /// @param remainingFilter SQL expression for the additional conjunct. May
+    /// include multiple columns and SQL functions. The remainingFilter is
+    /// AND'ed with all the subfieldFilters.
+    TableScanBuilder& remainingFilter(std::string remainingFilter);
+
+    /// @param dataColumns can be different from 'outputType' for the purposes
+    /// of testing queries using missing columns. It is used, if specified, for
+    /// parseExpr call and as 'dataColumns' for the TableHandle. You supply more
+    /// types (for all columns) in this argument as opposed to 'outputType',
+    /// where you define the output types only. See 'missingColumns' test in
+    /// 'TableScanTest'.
+    TableScanBuilder& dataColumns(RowTypePtr dataColumns) {
+      dataColumns_ = std::move(dataColumns);
+      return *this;
+    }
+
+    /// @param columnAliases Optional aliases for the column names. The key is
+    /// the alias (name in 'outputType'), value is the name in the files.
+    TableScanBuilder& columnAliases(
+        std::unordered_map<std::string, std::string> columnAliases) {
+      columnAliases_ = std::move(columnAliases);
+      return *this;
+    }
+
+    /// @param tableHandle Optional tableHandle. Other builder arguments such as
+    /// the `subfieldFilters` and `remainingFilter` will be ignored.
+    TableScanBuilder& tableHandle(
+        connector::ConnectorTableHandlePtr tableHandle) {
+      tableHandle_ = std::move(tableHandle);
+      return *this;
+    }
+
+    /// @param assignments Optional ColumnHandles.
+    /// outputType names should match the keys in the 'assignments' map. The
+    /// 'assignments' map may contain more columns than 'outputType' if some
+    /// columns are only used by pushed-down filters.
+    TableScanBuilder& assignments(connector::ColumnHandleMap assignments) {
+      assignments_ = std::move(assignments);
+      return *this;
+    }
+
+    /// Stop the TableScanBuilder.
+    PlanBuilder& endTableScan() {
+      planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
+      return planBuilder_;
+    }
+
+   private:
+    /// Build the plan node TableScanNode.
+    core::PlanNodePtr build(core::PlanNodeId id);
+
+    PlanBuilder& planBuilder_;
+    std::string tableName_{"hive_table"};
+    std::string connectorId_{kHiveDefaultConnectorId};
+    RowTypePtr outputType_;
+    core::ExprPtr remainingFilter_;
+    RowTypePtr dataColumns_;
+    std::unordered_map<std::string, std::string> columnAliases_;
+    connector::ConnectorTableHandlePtr tableHandle_;
+    connector::ColumnHandleMap assignments_;
+
+    // produce filters as a FilterNode instead of pushdown.
+    bool filtersAsNode_{false};
+
+    // Generates the id of a FilterNode if 'filtersAsNode_'.
+    std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator_;
+
+    // SubfieldFilters object containing filters to apply.
+    common::SubfieldFilters subfieldFiltersMap_;
+  };
+
+  /// Start a TableScanBuilder.
+  TableScanBuilder& startTableScan() {
+    tableScanBuilder_.reset(new TableScanBuilder(*this));
+    return *tableScanBuilder_;
+  }
+
+  ///
+  /// TableWriter
+  ///
+
+  /// Helper class to build a custom TableWriteNode.
+  /// Uses a planBuilder instance to get the next plan id, memory pool, and
+  /// upstream node (the node that will produce the data).
+  ///
+  /// Uses the Hive connector by default.
+  class TableWriterBuilder {
+   public:
+    explicit TableWriterBuilder(PlanBuilder& builder) : planBuilder_(builder) {}
+
+    /// @param outputType The schema that will be written to the output file. It
+    /// may reference a subset or change the order of columns from the input
+    /// (upstream operator output).
+    TableWriterBuilder& outputType(RowTypePtr outputType) {
+      outputType_ = std::move(outputType);
+      return *this;
+    }
+
+    /// @param outputDirectoryPath Path in which output files will be created.
+    TableWriterBuilder& outputDirectoryPath(std::string outputDirectoryPath) {
+      outputDirectoryPath_ = std::move(outputDirectoryPath);
+      return *this;
+    }
+
+    /// @param outputFileName File name of the output (optional). If specified
+    /// (non-empty), use it instead of generating the file name in Velox. Should
+    /// only be specified in non-bucketing write.
+    TableWriterBuilder& outputFileName(std::string outputFileName) {
+      outputFileName_ = std::move(outputFileName);
+      return *this;
+    }
+
+    /// @param connectorId The id of the connector to write to.
+    TableWriterBuilder& connectorId(std::string_view connectorId) {
+      connectorId_ = connectorId;
+      return *this;
+    }
+
+    /// @param insertHandle TableInsertHandle (optional). Other builder
+    /// arguments such as the `connectorId`, `outputDirectoryPath`, `fileFormat`
+    /// and so on will be ignored.
+    TableWriterBuilder& insertHandle(
+        std::shared_ptr<core::InsertTableHandle> insertHandle) {
+      insertHandle_ = std::move(insertHandle);
+      return *this;
+    }
+
+    /// @param partitionBy Specifies the partition key columns.
+    TableWriterBuilder& partitionBy(std::vector<std::string> partitionBy) {
+      partitionBy_ = std::move(partitionBy);
+      return *this;
+    }
+
+    /// @param bucketCount Specifies the bucket count.
+    TableWriterBuilder& bucketCount(int32_t count) {
+      bucketCount_ = count;
+      return *this;
+    }
+
+    /// @param bucketedBy Specifies the bucket by columns.
+    TableWriterBuilder& bucketedBy(std::vector<std::string> bucketedBy) {
+      bucketedBy_ = std::move(bucketedBy);
+      return *this;
+    }
+
+    /// @param aggregates Aggregations for column statistics collection during
+    /// write.
+    TableWriterBuilder& aggregates(std::vector<std::string> aggregates) {
+      aggregates_ = std::move(aggregates);
+      return *this;
+    }
+
+    /// @param sortBy Specifies the sort by columns.
+    TableWriterBuilder& sortBy(
+        std::vector<std::shared_ptr<const connector::hive::HiveSortingColumn>>
+            sortBy) {
+      sortBy_ = std::move(sortBy);
+      return *this;
+    }
+
+    /// @param serdeParameters Additional parameters passed to the writer.
+    TableWriterBuilder& serdeParameters(
+        std::unordered_map<std::string, std::string> serdeParameters) {
+      serdeParameters_ = std::move(serdeParameters);
+      return *this;
+    }
+
+    /// @param Option objects passed to the writer.
+    TableWriterBuilder& options(
+        std::shared_ptr<dwio::common::WriterOptions> options) {
+      options_ = std::move(options);
+      return *this;
+    }
+
+    /// @param fileFormat File format to use for the written data.
+    TableWriterBuilder& fileFormat(dwio::common::FileFormat fileFormat) {
+      fileFormat_ = fileFormat;
+      return *this;
+    }
+
+    /// @param compressionKind Compression scheme to use for writing the
+    /// output data files.
+    TableWriterBuilder& compressionKind(
+        common::CompressionKind compressionKind) {
+      compressionKind_ = compressionKind;
+      return *this;
+    }
+
+    /// @param ensureFiles When set the Task will always output a file, even if
+    /// it's empty.
+    TableWriterBuilder& ensureFiles(bool ensureFiles) {
+      ensureFiles_ = ensureFiles;
+      return *this;
+    }
+
+    /// Specifies commitStrategy for writing to the connector.
+    /// @param commitStrategy The commit strategy to use for the table write
+    /// operation.
+    TableWriterBuilder& commitStrategy(
+        connector::CommitStrategy commitStrategy) {
+      commitStrategy_ = commitStrategy;
+      return *this;
+    }
+
+    /// Stop the TableWriterBuilder.
+    PlanBuilder& endTableWriter() {
+      planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
+      return planBuilder_;
+    }
+
+   private:
+    /// Build the plan node TableWriteNode.
+    core::PlanNodePtr build(core::PlanNodeId id);
+
+    PlanBuilder& planBuilder_;
+    RowTypePtr outputType_;
+    std::string outputDirectoryPath_;
+    std::string outputFileName_;
+    std::string connectorId_{kHiveDefaultConnectorId};
+    std::shared_ptr<core::InsertTableHandle> insertHandle_;
+
+    std::vector<std::string> partitionBy_;
+    int32_t bucketCount_{0};
+    std::vector<std::string> bucketedBy_;
+    std::vector<std::string> aggregates_;
+    std::vector<std::shared_ptr<const connector::hive::HiveSortingColumn>>
+        sortBy_;
+
+    std::unordered_map<std::string, std::string> serdeParameters_;
+    std::shared_ptr<dwio::common::WriterOptions> options_;
+
+    dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
+    common::CompressionKind compressionKind_{common::CompressionKind_NONE};
+
+    bool ensureFiles_{false};
+    connector::CommitStrategy commitStrategy_{
+        connector::CommitStrategy::kNoCommit};
+  };
+
+  /// Start a TableWriterBuilder.
+  TableWriterBuilder& startTableWriter() {
+    tableWriterBuilder_.reset(new TableWriterBuilder(*this));
+    return *tableWriterBuilder_;
+  }
+
+  /// Add a ValuesNode using specified data.
+  ///
+  /// @param values The data to use.
+  /// @param parallelizable If true, ValuesNode can run multi-threaded, in which
+  /// case it will produce duplicate data from each thread, e.g. each thread
+  /// will return all the data in 'values'. Useful for testing.
+  /// @param repeatTimes The number of times data is produced as input. If
+  /// greater than one, each RowVector will produce data as input `repeatTimes`.
+  /// For example, in case `values` has 3 vectors {v1, v2, v3} and repeatTimes
+  /// is 2, the input produced will be {v1, v2, v3, v1, v2, v3}. Useful for
+  /// testing.
+  PlanBuilder& values(
+      const std::vector<RowVectorPtr>& values,
+      bool parallelizable = false,
+      size_t repeatTimes = 1);
+
+  PlanBuilder& filtersAsNode(bool filtersAsNode) {
+    filtersAsNode_ = filtersAsNode;
+    return *this;
+  }
+
+  /// Adds a QueryReplayNode for query tracing.
+  ///
+  /// @param traceNodeDir The trace directory for a given plan node.
+  /// @param pipelineId The pipeline id for the traced operator instantiated
+  /// from the given plan node.
+  /// @param driverIds The target driver ID list for replay. The replaying
+  /// operator uses its driver instance id as the list index to get the traced
+  /// driver id for replay.
+  /// @param outputType The type of the tracing data.
+  PlanBuilder& traceScan(
+      const std::string& traceNodeDir,
+      uint32_t pipelineId,
+      std::vector<uint32_t> driverIds,
+      const RowTypePtr& outputType);
+
+  /// Add an ExchangeNode.
+  ///
+  /// Use capturePlanNodeId method to capture the node ID needed for adding
+  /// splits.
+  ///
+  /// @param outputType The type of the data coming in and out of the exchange.
+  /// @param serdekind The kind of seralized data format.
+  PlanBuilder& exchange(
+      const RowTypePtr& outputType,
+      VectorSerde::Kind serdekind);
+
+  /// Add a MergeExchangeNode using specified ORDER BY clauses.
+  ///
+  /// For example,
+  ///
+  ///     .mergeExchange(outputRowType, {"a", "b DESC", "c ASC NULLS FIRST"})
+  ///
+  /// By default, uses ASC NULLS LAST sort order, e.g. column "a" above will use
+  /// ASC NULLS LAST and column "b" will use DESC NULLS LAST.
+  PlanBuilder& mergeExchange(
+      const RowTypePtr& outputType,
+      const std::vector<std::string>& keys,
+      VectorSerde::Kind serdekind);
+
+  /// Add a ProjectNode using specified SQL expressions.
+  ///
+  /// For example,
+  ///
+  ///     .project({"a + b", "c * 3"})
+  ///
+  /// The names of the projections can be specified using SQL statement AS:
+  ///
+  ///     .project({"a + b AS sum_ab", "c * 3 AS triple_c"})
+  ///
+  /// If AS statement is not used, the names of the projections will be
+  /// generated as p0, p1, p2, etc. Names of columns projected as is will be
+  /// preserved.
+  ///
+  /// For example,
+  ///
+  ///     project({"a + b AS sum_ab", "c", "d * 7")
+  ///
+  /// will produce projected columns named sum_ab, c and p2.
+  PlanBuilder& project(const std::vector<std::string>& projections);
+
+  /// Add a ParallelProjectNode using groups of independent SQL expressions.
+  ///
+  /// @param projectionGroups One or more groups of expressions that depend on
+  /// disjunct sets of inputs.
+  /// @param noLoadColumn Optional columns to pass through as is without
+  /// loading. These columns must be distinct from the set of columns used in
+  /// 'projectionGroups'.
+  PlanBuilder& parallelProject(
+      const std::vector<std::vector<std::string>>& projectionGroups,
+      const std::vector<std::string>& noLoadColumns = {});
+
+  /// Add a LazyDereferenceNode to the plan.
+  /// @param projections Same format as in `project`, but can only contain
+  /// field/subfield accesses.
+  PlanBuilder& lazyDereference(const std::vector<std::string>& projections);
+
+  /// Add a ProjectNode to keep all existing columns and append more columns
+  /// using specified expressions.
+  /// @param newColumns A list of one or more expressions to use for computing
+  /// additional columns.
+  PlanBuilder& appendColumns(const std::vector<std::string>& newColumns);
+
+  /// Variation of project that takes untyped expressions.  Used for access
+  /// deeply nested types, in which case Duck DB often fails to parse or infer
+  /// the type.
+  PlanBuilder& projectExpressions(
+      const std::vector<core::ExprPtr>& projections);
+
+  PlanBuilder& projectExpressions(
+      const std::vector<core::TypedExprPtr>& projections);
+
+  /// Similar to project() except 'optionalProjections' could be empty and the
+  /// function will skip creating a ProjectNode in that case.
+  PlanBuilder& optionalProject(
+      const std::vector<std::string>& optionalProjections);
+
+  /// Add a FilterNode using specified SQL expression.
+  ///
+  /// @param filter SQL expression of type boolean.
+  PlanBuilder& filter(const std::string& filter);
+
+  /// Similar to filter() except 'optionalFilter' could be empty and the
+  /// function will skip creating a FilterNode in that case.
+  PlanBuilder& optionalFilter(const std::string& optionalFilter);
+
+  /// Adds a TableWriteNode to write all input columns into an un-partitioned
+  /// un-bucketed Hive table without compression.
+  ///
+  /// @param outputDirectoryPath Path to a directory to write data to.
+  /// @param fileFormat File format to use for the written data.
+  /// @param aggregates Aggregations for column statistics collection during
+  /// @param polymorphic options object to be passed to the writer.
+  /// write, supported aggregation types vary for different column types.
+  /// @param outputFileName Optional file name of the output. If specified
+  /// (non-empty), use it instead of generating the file name in Velox. Should
+  /// only be specified in non-bucketing write.
+  /// For example:
+  /// Boolean: count, countIf.
+  /// NumericType/Date/Timestamp: min, max, approx_distinct, count.
+  /// Varchar: count, approx_distinct, sum_data_size_for_stats,
+  /// max_data_size_for_stats.
+  PlanBuilder& tableWrite(
+      const std::string& outputDirectoryPath,
+      const dwio::common::FileFormat fileFormat =
+          dwio::common::FileFormat::DWRF,
+      const std::vector<std::string>& aggregates = {},
+      const std::shared_ptr<dwio::common::WriterOptions>& options = nullptr,
+      const std::string& outputFileName = "");
+
+  /// Adds a TableWriteNode to write all input columns into a partitioned Hive
+  /// table without compression.
+  ///
+  /// @param outputDirectoryPath Path to a directory to write data to.
+  /// @param partitionBy Specifies the partition key columns.
+  /// @param fileFormat File format to use for the written data.
+  /// @param aggregates Aggregations for column statistics collection during
+  /// write.
+  /// @param polymorphic options object to be passed to the writer.
+  PlanBuilder& tableWrite(
+      const std::string& outputDirectoryPath,
+      const std::vector<std::string>& partitionBy,
+      const dwio::common::FileFormat fileFormat =
+          dwio::common::FileFormat::DWRF,
+      const std::vector<std::string>& aggregates = {},
+      const std::shared_ptr<dwio::common::WriterOptions>& options = nullptr);
+
+  /// Adds a TableWriteNode to write all input columns into a non-sorted
+  /// bucketed Hive table without compression.
+  ///
+  /// @param outputDirectoryPath Path to a directory to write data to.
+  /// @param partitionBy Specifies the partition key columns.
+  /// @param bucketCount Specifies the bucket count.
+  /// @param bucketedBy Specifies the bucket by columns.
+  /// @param fileFormat File format to use for the written data.
+  /// @param aggregates Aggregations for column statistics collection during
+  /// write.
+  /// @param polymorphic options object to be passed to the writer.
+  PlanBuilder& tableWrite(
+      const std::string& outputDirectoryPath,
+      const std::vector<std::string>& partitionBy,
+      int32_t bucketCount,
+      const std::vector<std::string>& bucketedBy,
+      const dwio::common::FileFormat fileFormat =
+          dwio::common::FileFormat::DWRF,
+      const std::vector<std::string>& aggregates = {},
+      const std::shared_ptr<dwio::common::WriterOptions>& options = nullptr);
+
+  /// Adds a TableWriteNode to write all input columns into a sorted bucket Hive
+  /// table without compression.
+  ///
+  /// @param outputDirectoryPath Path to a directory to write data to.
+  /// @param partitionBy Specifies the partition key columns.
+  /// @param bucketCount Specifies the bucket count.
+  /// @param bucketedBy Specifies the bucket by columns.
+  /// @param sortBy Specifies the sort by columns.
+  /// @param fileFormat File format to use for the written data.
+  /// @param aggregates Aggregations for column statistics collection during
+  /// write.
+  /// @param connectorId Name used to register the connector.
+  /// @param serdeParameters Additional parameters passed to the writer.
+  /// @param Option objects passed to the writer.
+  /// @param outputFileName Optional file name of the output. If specified
+  /// (non-empty), use it instead of generating the file name in Velox. Should
+  /// only be specified in non-bucketing write.
+  /// @param compressionKind Compression scheme to use for writing the
+  /// output data files.
+  /// @param schema Output schema to be passed to the writer. By default use the
+  /// output of the previous operator.
+  /// @param ensureFiles When this option is set the HiveDataSink will always
+  /// create a file even if there is no data.
+  PlanBuilder& tableWrite(
+      const std::string& outputDirectoryPath,
+      const std::vector<std::string>& partitionBy,
+      int32_t bucketCount,
+      const std::vector<std::string>& bucketedBy,
+      const std::vector<
+          std::shared_ptr<const connector::hive::HiveSortingColumn>>& sortBy,
+      const dwio::common::FileFormat fileFormat =
+          dwio::common::FileFormat::DWRF,
+      const std::vector<std::string>& aggregates = {},
+      const std::string_view& connectorId = kHiveDefaultConnectorId,
+      const std::unordered_map<std::string, std::string>& serdeParameters = {},
+      const std::shared_ptr<dwio::common::WriterOptions>& options = nullptr,
+      const std::string& outputFileName = "",
+      const common::CompressionKind = common::CompressionKind_NONE,
+      const RowTypePtr& schema = nullptr,
+      const bool ensureFiles = false,
+      const connector::CommitStrategy commitStrategy =
+          connector::CommitStrategy::kNoCommit);
+
+  /// Add a TableWriteMergeNode.
+  PlanBuilder& tableWriteMerge(
+      const core::AggregationNodePtr& aggregationNode = nullptr);
+
+  /// Add an AggregationNode representing partial aggregation with the
+  /// specified grouping keys, aggregates and optional masks.
+  ///
+  /// Aggregates are specified as function calls over unmodified input columns,
+  /// e.g. sum(a), avg(b), min(c). SQL statement AS can be used to specify names
+  /// for the aggregation result columns. In the absence of AS statement, result
+  /// columns are named a0, a1, a2, etc.
+  ///
+  /// For example,
+  ///
+  ///     partialAggregation({}, {"min(a) AS min_a", "max(b)"})
+  ///
+  /// will produce output columns min_a and a1, while
+  ///
+  ///     partialAggregation({"k1", "k2"}, {"min(a) AS min_a", "max(b)"})
+  ///
+  /// will produce output columns k1, k2, min_a and a1, assuming the names of
+  /// the first two input columns are k1 and k2.
+  PlanBuilder& partialAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks = {}) {
+    return aggregation(
+        groupingKeys,
+        {},
+        aggregates,
+        masks,
+        core::AggregationNode::Step::kPartial,
+        false);
+  }
+
+  /// Add final aggregation plan node to match the current partial aggregation
+  /// node. Should be called directly after partialAggregation() method or
+  /// directly after intermediateAggregation() that follows
+  /// partialAggregation(). Can be called also if there is a local exchange
+  /// after partial or intermediate aggregation.
+  PlanBuilder& finalAggregation();
+
+  /// Add final aggregation plan node using specified grouping keys, aggregate
+  /// expressions and their types.
+  ///
+  /// @param rawInputTypes Raw input types for the aggregate functions.
+  PlanBuilder& finalAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::vector<TypePtr>>& rawInputTypes) {
+    return aggregation(
+        groupingKeys,
+        {},
+        aggregates,
+        {},
+        core::AggregationNode::Step::kFinal,
+        false,
+        rawInputTypes);
+  }
+
+  /// Add intermediate aggregation plan node to match the current partial
+  /// aggregation node. Should be called directly after partialAggregation()
+  /// method. Can be called also if there is a local exchange after partial
+  /// aggregation.
+  PlanBuilder& intermediateAggregation();
+
+  /// Add intermediate aggregation plan node using specified grouping keys,
+  /// aggregate expressions and their types.
+  PlanBuilder& intermediateAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates) {
+    return aggregation(
+        groupingKeys,
+        {},
+        aggregates,
+        {},
+        core::AggregationNode::Step::kIntermediate,
+        false);
+  }
+
+  /// Add a single aggregation plan node using specified grouping keys and
+  /// aggregate expressions. See 'partialAggregation' method for the supported
+  /// types of aggregate expressions.
+  PlanBuilder& singleAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks = {}) {
+    return aggregation(
+        groupingKeys,
+        {},
+        aggregates,
+        masks,
+        core::AggregationNode::Step::kSingle,
+        false);
+  }
+
+  /// Add an AggregationNode using specified grouping keys,
+  /// aggregate expressions and masks. See 'partialAggregation' method for the
+  /// supported types of aggregate expressions.
+  ///
+  /// @param groupingKeys A list of grouping keys. Can be empty for global
+  /// aggregations.
+  /// @param aggregates A list of aggregate expressions. Must contain at least
+  /// one expression.
+  /// @param masks An optional list of boolean input columns to use as masks for
+  /// the aggregates. Can be empty or have fewer elements than 'aggregates' or
+  /// have some elements being empty strings. Non-empty elements must refer to a
+  /// boolean input column, which will be used to mask a corresponding
+  /// aggregate, e.g. aggregate will skip rows where 'mask' column is false.
+  /// @param step Aggregation step: partial, final, intermediate or single.
+  /// @param ignoreNullKeys Boolean indicating whether to skip input rows where
+  /// one of the grouping keys is null.
+  PlanBuilder& aggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks,
+      core::AggregationNode::Step step,
+      bool ignoreNullKeys) {
+    return aggregation(
+        groupingKeys, {}, aggregates, masks, step, ignoreNullKeys);
+  }
+
+  /// Same as above, but also allows to specify a subset of grouping keys on
+  /// which the input is pre-grouped or clustered. Pre-grouped keys enable
+  /// streaming or partially streaming aggregation algorithms which use less
+  /// memory and CPU then hash aggregation. The caller is responsible
+  /// that input data is indeed clustered on the specified keys. If that's not
+  /// the case, the query may return incorrect results.
+  PlanBuilder& aggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& preGroupedKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks,
+      core::AggregationNode::Step step,
+      bool ignoreNullKeys) {
+    return aggregation(
+        groupingKeys,
+        preGroupedKeys,
+        aggregates,
+        masks,
+        step,
+        ignoreNullKeys,
+        {});
+  }
+
+  /// A convenience method to create partial aggregation plan node for the case
+  /// where input is clustered on all grouping keys.
+  PlanBuilder& partialStreamingAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks = {}) {
+    return streamingAggregation(
+        groupingKeys,
+        aggregates,
+        masks,
+        core::AggregationNode::Step::kPartial,
+        false);
+  }
+
+  /// A convenience method to create final aggregation plan node for the case
+  /// where input is clustered on all grouping keys.
+  PlanBuilder& finalStreamingAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates) {
+    return streamingAggregation(
+        groupingKeys,
+        aggregates,
+        {},
+        core::AggregationNode::Step::kFinal,
+        false);
+  }
+
+  /// Add an AggregationNode assuming input is clustered on all grouping keys.
+  PlanBuilder& streamingAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks,
+      core::AggregationNode::Step step,
+      bool ignoreNullKeys);
+
+  /// Add a GroupIdNode using the specified grouping keys, grouping sets,
+  /// aggregation inputs and a groupId column name.
+  /// The grouping keys can specify aliases if an input column is mapped
+  /// to an output column with a different name.
+  /// e.g. Grouping keys {"k1", "k1 as k2"} means there are 2 grouping keys:
+  /// the input column k1 and output column k2 which is an alias of column k1.
+  /// Grouping sets using above grouping keys use the output column aliases.
+  /// e.g. Grouping sets in the above case could be {{"k1"}, {"k2"}, {}}
+  /// The GroupIdNode output columns have grouping keys in the order specified
+  /// in groupingKeys variable.
+  PlanBuilder& groupId(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::vector<std::string>>& groupingSets,
+      const std::vector<std::string>& aggregationInputs,
+      std::string groupIdName = "group_id");
+
+  /// Add an ExpandNode using specified projections. See comments for
+  /// ExpandNode class for description of this plan node.
+  ///
+  /// @param projections A list of projection expressions. Each expression is
+  /// either a column name, null or non-null constant.
+  ///
+  /// For example,
+  ///
+  ///     .expand(
+  ///            {{"k1", "null:: bigint k2", "a", "b", "0 as gid"}, //
+  ///            Column name will be extracted from the first projection. If the
+  ///            column is null, it is also necessary to specify the column
+  ///            type.
+  ///             {"k1", "null", "a", "b", "1"},
+  ///             {"null", "null", "a", "b", "2"}})
+  ///
+  ///
+  PlanBuilder& expand(const std::vector<std::vector<std::string>>& projections);
+
+  /// Add a LocalMergeNode using specified ORDER BY clauses.
+  ///
+  /// For example,
+  ///
+  ///     .localMerge({"a", "b DESC", "c ASC NULLS FIRST"})
+  ///
+  /// By default, uses ASC NULLS LAST sort order, e.g. column "a" above will use
+  /// ASC NULLS LAST and column "b" will use DESC NULLS LAST.
+  PlanBuilder& localMerge(
+      const std::vector<std::string>& keys,
+      std::vector<core::PlanNodePtr> sources);
+
+  /// A convenience method to add a LocalMergeNode with a single source (the
+  /// current plan node).
+  PlanBuilder& localMerge(const std::vector<std::string>& keys);
+
+  /// Adds an OrderByNode using specified ORDER BY clauses.
+  ///
+  /// For example,
+  ///
+  ///     .orderBy({"a", "b DESC", "c ASC NULLS FIRST"})
+  ///
+  /// By default, uses ASC NULLS LAST sort order, e.g. column "a" above will use
+  /// ASC NULLS LAST and column "b" will use DESC NULLS LAST.
+  PlanBuilder& orderBy(const std::vector<std::string>& keys, bool isPartial);
+
+  /// Add a TopNNode using specified N and ORDER BY clauses.
+  ///
+  /// For example,
+  ///
+  ///     .topN({"a", "b DESC", "c ASC NULLS FIRST"}, 10, true)
+  ///
+  /// By default, uses ASC NULLS LAST sort order, e.g. column "a" above will use
+  /// ASC NULLS LAST and column "b" will use DESC NULLS LAST.
+  PlanBuilder&
+  topN(const std::vector<std::string>& keys, int32_t count, bool isPartial);
+
+  /// Add a LimitNode.
+  ///
+  /// @param offset Offset, i.e. number of rows of input to skip.
+  /// @param count Maximum number of rows to produce after skipping 'offset'
+  /// rows.
+  /// @param isPartial Boolean indicating whether the limit node is partial or
+  /// final. Partial limit can run multi-threaded. Final limit must run
+  /// single-threaded.
+  PlanBuilder& limit(int64_t offset, int64_t count, bool isPartial);
+
+  /// Add an EnforceSingleRowNode to ensure input has at most one row at
+  /// runtime.
+  PlanBuilder& enforceSingleRow();
+
+  /// Add an AssignUniqueIdNode to add a column with query-scoped unique value
+  /// per row.
+  ///
+  /// @param idName The name of output column that contains the unique ID.
+  /// Column type is assumed as BIGINT.
+  /// @param taskUniqueId ID of the Task that will be used to run the query
+  /// plan. The ID must be unique across all the tasks of a single query. Tasks
+  /// may possibly run on different machines.
+  PlanBuilder& assignUniqueId(
+      const std::string& idName = "unique",
+      const int32_t taskUniqueId = 1);
+
+  /// Add a PartitionedOutputNode to hash-partition the input on the specified
+  /// keys using exec::HashPartitionFunction.
+  ///
+  /// @param keys Partitioning keys. May be empty, in which case all input will
+  /// be places in a single partition.
+  /// @param numPartitions Number of partitions. Must be greater than or equal
+  /// to 1. Keys must not be empty if greater than 1.
+  /// @param replicateNullsAndAny Boolean indicating whether to replicate one
+  /// arbitrary entry and all entries with null keys to all partitions. Used to
+  /// implement proper ANTI join semantics in a distributed execution
+  /// environment.
+  /// @param outputLayout Optional output layout in case it is different then
+  /// the input. Output columns may appear in different order from the input,
+  /// some input columns may be missing in the output, some columns may be
+  /// duplicated in the output.
+  PlanBuilder& partitionedOutput(
+      const std::vector<std::string>& keys,
+      int numPartitions,
+      bool replicateNullsAndAny,
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+
+  /// Same as above, but assumes 'replicateNullsAndAny' is false.
+  PlanBuilder& partitionedOutput(
+      const std::vector<std::string>& keys,
+      int numPartitions,
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+
+  /// Same as above, but allows to provide custom partition function.
+  PlanBuilder& partitionedOutput(
+      const std::vector<std::string>& keys,
+      int numPartitions,
+      bool replicateNullsAndAny,
+      core::PartitionFunctionSpecPtr partitionFunctionSpec,
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+
+  /// Adds a PartitionedOutputNode to broadcast the input data.
+  ///
+  /// @param outputLayout Optional output layout in case it is different then
+  /// the input. Output columns may appear in different order from the input,
+  /// some input columns may be missing in the output, some columns may be
+  /// duplicated in the output.
+  PlanBuilder& partitionedOutputBroadcast(
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+
+  /// Adds a PartitionedOutputNode to put data into arbitrary buffer.
+  PlanBuilder& partitionedOutputArbitrary(
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+
+  /// Adds a LocalPartitionNode to hash-partition the input on the specified
+  /// keys using exec::HashPartitionFunction. Number of partitions is determined
+  /// at runtime based on parallelism of the downstream pipeline.
+  ///
+  /// @param keys Partitioning keys. May be empty, in which case all input will
+  /// be places in a single partition.
+  /// @param sources One or more plan nodes that produce input data.
+  PlanBuilder& localPartition(
+      const std::vector<std::string>& keys,
+      const std::vector<core::PlanNodePtr>& sources);
+
+  /// A convenience method to add a LocalPartitionNode with a single source (the
+  /// current plan node).
+  PlanBuilder& localPartition(const std::vector<std::string>& keys);
+
+  /// A convenience method to add a LocalPartitionNode with hive partition
+  /// function.
+  PlanBuilder& localPartition(
+      int numBuckets,
+      const std::vector<column_index_t>& channels,
+      const std::vector<VectorPtr>& constValues);
+
+  /// A convenience method to add a LocalPartitionNode with a single source (the
+  /// current plan node) and hive bucket property.
+  PlanBuilder& localPartitionByBucket(
+      const std::shared_ptr<connector::hive::HiveBucketProperty>&
+          bucketProperty);
+
+  /// Add a LocalPartitionNode to partition the input using batch-level
+  /// round-robin. Number of partitions is determined at runtime based on
+  /// parallelism of the downstream pipeline.
+  ///
+  /// @param sources One or more plan nodes that produce input data.
+  PlanBuilder& localPartitionRoundRobin(
+      const std::vector<core::PlanNodePtr>& sources);
+
+  /// A convenience method to add a LocalPartitionNode with a single source (the
+  /// current plan node).
+  PlanBuilder& localPartitionRoundRobin();
+
+  /// A convenience method to add a LocalPartitionNode for scale writer with
+  /// hash partitioning.
+  PlanBuilder& scaleWriterlocalPartition(const std::vector<std::string>& keys);
+
+  /// A convenience method to add a LocalPartitionNode for scale writer with
+  /// round-robin partitioning.
+  PlanBuilder& scaleWriterlocalPartitionRoundRobin();
+
+  /// Add a LocalPartitionNode to partition the input using row-wise
+  /// round-robin. Number of partitions is determined at runtime based on
+  /// parallelism of the downstream pipeline.
+  PlanBuilder& localPartitionRoundRobinRow();
+
+  /// Add a HashJoinNode to join two inputs using one or more join keys and an
+  /// optional filter.
+  ///
+  /// @param leftKeys Join keys from the probe side, the preceding plan node.
+  /// Cannot be empty.
+  /// @param rightKeys Join keys from the build side, the plan node specified in
+  /// 'build' parameter. The number and types of left and right keys must be the
+  /// same.
+  /// @param build Plan node for the build side. Typically, to reduce memory
+  /// usage, the smaller input is placed on the build-side.
+  /// @param filter Optional SQL expression for the additional join filter. Can
+  /// use columns from both probe and build sides of the join.
+  /// @param outputLayout Output layout consisting of columns from probe and
+  /// build sides.
+  /// @param joinType Type of the join: inner, left, right, full, semi, or anti.
+  /// @param nullAware Applies to semi and anti joins. Indicates whether the
+  /// join follows IN (null-aware) or EXISTS (regular) semantic.
+  PlanBuilder& hashJoin(
+      const std::vector<std::string>& leftKeys,
+      const std::vector<std::string>& rightKeys,
+      const core::PlanNodePtr& build,
+      const std::string& filter,
+      const std::vector<std::string>& outputLayout,
+      core::JoinType joinType = core::JoinType::kInner,
+      bool nullAware = false);
+
+  /// Add a MergeJoinNode to join two inputs using one or more join keys and an
+  /// optional filter. The caller is responsible to ensure that inputs are
+  /// sorted in ascending order on the join keys. If that's not the case, the
+  /// query may produce incorrect results.
+  ///
+  /// See hashJoin method for the description of the parameters.
+  PlanBuilder& mergeJoin(
+      const std::vector<std::string>& leftKeys,
+      const std::vector<std::string>& rightKeys,
+      const core::PlanNodePtr& build,
+      const std::string& filter,
+      const std::vector<std::string>& outputLayout,
+      core::JoinType joinType = core::JoinType::kInner);
+
+  /// Add a NestedLoopJoinNode to join two inputs using filter as join
+  /// condition to perform equal/non-equal join. Only supports inner/outer
+  /// joins.
+  ///
+  /// @param right Right-side input. Typically, to reduce memory usage, the
+  /// smaller input is placed on the right-side.
+  /// @param joinCondition SQL expression as the join condition. Can
+  /// use columns from both probe and build sides of the join.
+  /// @param outputLayout Output layout consisting of columns from probe and
+  /// build sides.
+  /// @param joinType Type of the join: inner, left, right, full.
+  PlanBuilder& nestedLoopJoin(
+      const core::PlanNodePtr& right,
+      const std::string& joinCondition,
+      const std::vector<std::string>& outputLayout,
+      core::JoinType joinType = core::JoinType::kInner);
+
+  /// Add a NestedLoopJoinNode to produce a cross product of the inputs. First
+  /// input comes from the preceding plan node. Second input is specified in
+  /// 'right' parameter.
+  ///
+  /// @param right Right-side input. Typically, to reduce memory usage, the
+  /// smaller input is placed on the right-side.
+  /// @param outputLayout Output layout consisting of columns from left and
+  /// right sides.
+  PlanBuilder& nestedLoopJoin(
+      const core::PlanNodePtr& right,
+      const std::vector<std::string>& outputLayout,
+      core::JoinType joinType = core::JoinType::kInner);
+
+  static core::IndexLookupConditionPtr parseIndexJoinCondition(
+      const std::string& joinCondition,
+      const RowTypePtr& rowType,
+      memory::MemoryPool* pool);
+
+  /// Add an IndexLoopJoinNode to join two inputs using one or more join keys
+  /// plus optional join conditions. First input comes from the preceding plan
+  /// node. Second input is specified in 'right' parameter and must be a
+  /// table source with the connector table handle with index lookup support.
+  ///
+  /// @param right The right input source with index lookup support.
+  /// @param joinConditions SQL expressions as the join conditions. Each join
+  /// condition must use columns from both sides. For the right side, it can
+  /// only use one index column. Currently we support "in" and "between" join
+  /// conditions:
+  /// "in" condition is written as SQL expression as "contains(a, b)" where "b"
+  /// is the index column from right side and "a" is the condition column from
+  /// left side. "b" has type T and "a" has type ARRAT(T).
+  /// "between" condition is written as SQL expression as "a between b and c"
+  /// where "a" is the index column from right side and "b", "c" are either
+  /// condition column from left side or a constant but at least one of them
+  /// must not be constant. They all have the same type.
+  /// @param joinType Type of the join supported: inner, left.
+  /// @param includeMatchColumn if true, 'outputLayout' should include a boolean
+  /// column at the end to indicate if a join output row has a match or not.
+  /// This only applies for left join.
+  ///
+  /// See hashJoin method for the description of the other parameters.
+  PlanBuilder& indexLookupJoin(
+      const std::vector<std::string>& leftKeys,
+      const std::vector<std::string>& rightKeys,
+      const core::TableScanNodePtr& right,
+      const std::vector<std::string>& joinConditions,
+      bool includeMatchColumn,
+      const std::vector<std::string>& outputLayout,
+      core::JoinType joinType = core::JoinType::kInner);
+
+  /// Add an UnnestNode to unnest one or more columns of type array or map.
+  ///
+  /// The output will contain 'replicatedColumns' followed by unnested columns,
+  /// followed by an optional ordinality column.
+  ///
+  /// Array columns are unnested into a single column whose name is generated by
+  /// appending '_e' suffix to the array column name.
+  ///
+  /// Map columns are unnested into two columns whoes names are generated by
+  /// appending '_k' and '_v' suffixes to the map column name.
+  ///
+  /// @param replicateColumns A subset of input columns to include in the output
+  /// unmodified.
+  /// @param unnestColumns A subset of input columns to unnest. These columns
+  /// must be of type array or map.
+  /// @param ordinalColumn An optional name for the 'ordinal' column to produce.
+  /// This column contains the index of the element of the unnested array or
+  /// map. If not specified, the output will not contain this column.
+  /// @param emptyUnnestValueName An optional name for the
+  /// 'emptyUnnestValue' column to produce. This column contains a boolean
+  /// indicating if the output row has empty unnest value or not. If not
+  /// specified, the output will not contain this column and the unnest operator
+  /// also skips producing output rows with empty unnest value.
+  PlanBuilder& unnest(
+      const std::vector<std::string>& replicateColumns,
+      const std::vector<std::string>& unnestColumns,
+      const std::optional<std::string>& ordinalColumn = std::nullopt,
+      const std::optional<std::string>& emptyUnnestValueName = std::nullopt);
+
+  /// Add a WindowNode to compute one or more windowFunctions.
+  /// @param windowFunctions A list of one or more window function SQL like
+  /// strings to be computed by this windowNode.
+  /// A window function SQL string looks like :
+  /// "name(parameters) OVER (PARTITION BY partition_keys ORDER BY
+  /// sorting_keys [ROWS|RANGE BETWEEN [UNBOUNDED PRECEDING | x PRECEDING |
+  /// CURRENT ROW] AND [UNBOUNDED FOLLOWING | x FOLLOWING | CURRENT ROW]] AS
+  /// columnName"
+  /// The PARTITION BY and ORDER BY clauses are optional. An empty PARTITION
+  /// list means all the table rows are in a single partition.
+  /// An empty ORDER BY list means the window functions will be computed over
+  /// all the rows in the partition in a random order. Also, the default frame
+  /// if unspecified is RANGE OVER UNBOUNDED PRECEDING AND CURRENT ROW.
+  /// Some examples of window function strings are as follows:
+  /// "first_value(c) over (partition by a order by b) as d"
+  /// "first_value(c) over (partition by a) as d"
+  /// "first_value(c) over ()"
+  /// "row_number() over (order by b) as a"
+  /// "row_number() over (partition by a order by b
+  ///  rows between a + 10 preceding and 10 following)"
+  PlanBuilder& window(const std::vector<std::string>& windowFunctions);
+
+  /// Adds WindowNode to compute window functions over pre-sorted inputs.
+  /// All functions must use same partition by and sorting keys and input must
+  /// be already sorted on these.
+  PlanBuilder& streamingWindow(const std::vector<std::string>& windowFunctions);
+
+  /// Add a RowNumberNode to compute single row_number window function with an
+  /// optional limit and no sorting.
+  PlanBuilder& rowNumber(
+      const std::vector<std::string>& partitionKeys,
+      std::optional<int32_t> limit = std::nullopt,
+      bool generateRowNumber = true);
+
+  /// Add a TopNRowNumberNode to compute row_number
+  /// function with a limit applied to sorted partitions.
+  PlanBuilder& topNRowNumber(
+      const std::vector<std::string>& partitionKeys,
+      const std::vector<std::string>& sortingKeys,
+      int32_t limit,
+      bool generateRowNumber);
+
+  /// Add a TopNRowNumberNode to compute row_number, rank or dense_rank window
+  /// function with a limit applied to sorted partitions.
+  PlanBuilder& topNRank(
+      std::string_view function,
+      const std::vector<std::string>& partitionKeys,
+      const std::vector<std::string>& sortingKeys,
+      int32_t limit,
+      bool generateRowNumber);
+
+  /// Add a MarkDistinctNode to compute aggregate mask channel
+  /// @param markerKey Name of output mask channel
+  /// @param distinctKeys List of columns to be marked distinct.
+  PlanBuilder& markDistinct(
+      std::string markerKey,
+      const std::vector<std::string>& distinctKeys);
+
+  /// Stores the latest plan node ID into the specified variable. Useful for
+  /// capturing IDs of the leaf plan nodes (table scans, exchanges, etc.) to use
+  /// when adding splits at runtime.
+  PlanBuilder& capturePlanNodeId(core::PlanNodeId& id) {
+    VELOX_CHECK_NOT_NULL(planNode_);
+    id = planNode_->id();
+    return *this;
+  }
+
+  /// Captures the id for the latest TableScanNode. this is useful when using
+  /// filtersAsNode(), where a table scan can have a filter over it.
+  PlanBuilder& captureScanNodeId(core::PlanNodeId& id) {
+    auto node = planNode_;
+    for (;;) {
+      VELOX_CHECK_NOT_NULL(node);
+      if (dynamic_cast<const core::TableScanNode*>(node.get())) {
+        id = node->id();
+        return *this;
+      }
+      node = node->sources()[0];
+    }
+  }
+
+  /// Stores the latest plan node into the specified variable. Useful for
+  /// capturing intermediate plan nodes without interrupting the build flow.
+  template <typename T = core::PlanNode>
+  PlanBuilder& capturePlanNode(std::shared_ptr<const T>& planNode) {
+    VELOX_CHECK_NOT_NULL(planNode_);
+    planNode = std::dynamic_pointer_cast<const T>(planNode_);
+    VELOX_CHECK_NOT_NULL(planNode);
+    return *this;
+  }
+
+  /// Return the latest plan node, e.g. the root node of the plan
+  /// tree. The DistributedPlanBuilder override additionally moves stage
+  /// information to a parent PlanBuilder.
+  const core::PlanNodePtr& planNode() const {
+    return planNode_;
+  }
+
+  /// Return tha latest plan node wrapped in core::PlanFragment struct.
+  core::PlanFragment planFragment() const {
+    return core::PlanFragment{planNode_};
+  }
+
+  /// Add a user-defined PlanNode as the root of the plan. 'func' takes
+  /// the current root of the plan and returns the new root.
+  PlanBuilder& addNode(
+      std::function<core::PlanNodePtr(std::string nodeId, core::PlanNodePtr)>
+          func) {
+    planNode_ = func(nextPlanNodeId(), planNode_);
+    return *this;
+  }
+
+  /// Set parsing options
+  PlanBuilder& setParseOptions(const parse::ParseOptions& options) {
+    options_ = options;
+    return *this;
+  }
+
+  /// In a DistributedPlanBuilder, introduces a shuffle boundary. The plan so
+  /// far is shuffled and subsequent nodes consume the shuffle. Arguments are as
+  /// in partitionedOutput().
+  virtual PlanBuilder& shufflePartitioned(
+      const std::vector<std::string>& keys,
+      int numPartitions,
+      bool replicateNullsAndAny,
+      const std::vector<std::string>& outputLayout = {}) {
+    VELOX_UNSUPPORTED("Needs DistributedPlanBuilder");
+  }
+
+  /// In a DistributedPlanBuilder, returns an Exchange on top of the plan built
+  /// so far and couples it to the current stage in the enclosing builder.
+  /// Arguments are as in shuffle().
+  virtual core::PlanNodePtr shufflePartitionedResult(
+      const std::vector<std::string>& keys,
+      int numPartitions,
+      bool replicateNullsAndAny,
+      const std::vector<std::string>& outputLayout = {}) {
+    VELOX_UNSUPPORTED("Needs DistributedPlanBuilder");
+  }
+
+  /// In a DistributedPlanBuilder, returns an Exchange on top of the plan built
+  /// so far that ends with a broadcast PartitionedOutput node, and couples the
+  /// Exchange to the current stage in the enclosing builder.
+  virtual core::PlanNodePtr shuffleBroadcastResult() {
+    VELOX_UNSUPPORTED("Needs DistributedPlanBuilder");
+  }
+
+ protected:
+  // Users who create custom operators might want to extend the PlanBuilder to
+  // customize extended plan builders. Those functions are needed in such
+  // extensions.
+  core::PlanNodeId nextPlanNodeId();
+
+  std::shared_ptr<const core::ITypedExpr> inferTypes(
+      const core::ExprPtr& untypedExpr);
+
+  std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator() const {
+    return planNodeIdGenerator_;
+  }
+
+  memory::MemoryPool* pool() const {
+    return pool_;
+  }
+
+ private:
+  std::shared_ptr<const core::FieldAccessTypedExpr> field(column_index_t index);
+
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields(
+      const std::vector<column_index_t>& indices);
+
+  std::shared_ptr<const core::FieldAccessTypedExpr> field(
+      const std::string& name);
+
+  std::vector<core::TypedExprPtr> exprs(
+      const std::vector<std::string>& expressions,
+      const RowTypePtr& inputType);
+
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields(
+      const std::vector<std::string>& names);
+
+  static std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields(
+      const RowTypePtr& inputType,
+      const std::vector<std::string>& names);
+
+  static std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields(
+      const RowTypePtr& inputType,
+      const std::vector<column_index_t>& indices);
+
+  static std::shared_ptr<const core::FieldAccessTypedExpr> field(
+      const RowTypePtr& inputType,
+      column_index_t index);
+
+  static std::shared_ptr<const core::FieldAccessTypedExpr> field(
+      const RowTypePtr& inputType,
+      const std::string& name);
+
+  core::PlanNodePtr createIntermediateOrFinalAggregation(
+      core::AggregationNode::Step step,
+      const core::AggregationNode* partialAggNode);
+
+  struct AggregatesAndNames {
+    std::vector<core::AggregationNode::Aggregate> aggregates;
+    std::vector<std::string> names;
+  };
+
+  AggregatesAndNames createAggregateExpressionsAndNames(
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks,
+      core::AggregationNode::Step step,
+      const std::vector<std::vector<TypePtr>>& rawInputTypes = {});
+
+  PlanBuilder& aggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& preGroupedKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks,
+      core::AggregationNode::Step step,
+      bool ignoreNullKeys,
+      const std::vector<std::vector<TypePtr>>& rawInputTypes);
+
+  /// Create WindowNode based on whether input is sorted and then compute the
+  /// window functions.
+  PlanBuilder& window(
+      const std::vector<std::string>& windowFunctions,
+      bool inputSorted);
+
+ protected:
+  core::PlanNodePtr planNode_;
+  parse::ParseOptions options_;
+  std::shared_ptr<TableScanBuilder> tableScanBuilder_;
+  std::shared_ptr<TableWriterBuilder> tableWriterBuilder_;
+
+ private:
+  std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator_;
+  memory::MemoryPool* pool_;
+  bool filtersAsNode_{false};
+};
+} // namespace facebook::velox::exec::test

--- a/velox/connectors/lakehouse/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/lakehouse/iceberg/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(velox_lakehouse_iceberg_reader_benchmark_lib
             IcebergSplitReaderBenchmark.cpp)
 target_link_libraries(
   velox_lakehouse_iceberg_reader_benchmark_lib
+  velox_lakehouse_common_test_lib
   velox_exec_test_lib
   velox_exec
   velox_connector_lakehouse_common
@@ -36,8 +37,7 @@ if(VELOX_ENABLE_BENCHMARKS)
     ${TEST_LINK_LIBS})
 endif()
 
-if(NOT VELOX_DISABLE_GOOGLETEST)
-
+if(VELOX_BUILD_TESTING AND (NOT VELOX_DISABLE_GOOGLETEST))
   add_executable(
     velox_lakehouse_iceberg_test
     IcebergInsertTest.cpp
@@ -50,6 +50,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
   target_link_libraries(
     velox_lakehouse_iceberg_test
     velox_lakehouse_iceberg_reader_benchmark_lib
+    velox_lakehouse_common_test_lib
     velox_connector_lakehouse_common
     velox_lakehouse_iceberg_splitreader
     velox_lakehouse_hive_partition_function

--- a/velox/connectors/lakehouse/iceberg/tests/IcebergInsertTest.cpp
+++ b/velox/connectors/lakehouse/iceberg/tests/IcebergInsertTest.cpp
@@ -17,8 +17,8 @@
 #include <folly/init/Init.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/lakehouse/common/tests/PlanBuilder.h"
 #include "velox/connectors/lakehouse/iceberg/tests/IcebergTestBase.h"
-#include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace facebook::velox::connector::lakehouse::iceberg::test {
 class IcebergInsertTest : public IcebergTestBase {
@@ -54,7 +54,7 @@ TEST_F(IcebergInsertTest, testIcebergTableWrite) {
   createDuckDbTable(vectors);
   auto splits = createSplitsForDirectory(dataPath);
   ASSERT_EQ(splits.size(), commitTasks.size());
-  auto plan = exec::test::PlanBuilder().tableScan(rowType_).planNode();
+  auto plan = common::test::PlanBuilder().tableScan(rowType_).planNode();
   assertQuery(plan, splits, fmt::format("SELECT * FROM tmp"));
 }
 
@@ -134,7 +134,7 @@ TEST_F(IcebergInsertTest, testSingleColumnAsPartition) {
              rowType_->childAt(colIndex),
              rowType_->childAt(colIndex))});
 
-    auto plan = exec::test::PlanBuilder(pool_.get())
+    auto plan = common::test::PlanBuilder(pool_.get())
                     .tableScan(rowType_, {}, "", nullptr, assignments)
                     .planNode();
 
@@ -257,7 +257,7 @@ TEST_F(IcebergInsertTest, testColumnCombinationsAsPartition) {
                name, columnType, rowType_->childAt(i), rowType_->childAt(i))});
     }
 
-    auto plan = exec::test::PlanBuilder(pool_.get())
+    auto plan = common::test::PlanBuilder(pool_.get())
                     .tableScan(rowType_, {}, "", nullptr, assignments)
                     .planNode();
 

--- a/velox/connectors/lakehouse/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/lakehouse/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -329,9 +329,11 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
           "");
 
   common::FileHandleFactory fileHandleFactory(
-      std::make_unique<SimpleLRUCache<common::FileHandleKey, common::FileHandle>>(
+      std::make_unique<
+          SimpleLRUCache<common::FileHandleKey, common::FileHandle>>(
           hiveConfig->numCacheFileHandles()),
-      std::make_unique<common::FileHandleGenerator>(connectorSessionProperties_));
+      std::make_unique<common::FileHandleGenerator>(
+          connectorSessionProperties_));
 
   suspender.dismiss();
 

--- a/velox/connectors/lakehouse/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/lakehouse/iceberg/tests/IcebergTestBase.cpp
@@ -140,8 +140,9 @@ IcebergTestBase::createIcebergInsertTableHandle(
         break;
       }
     }
-    columnHandles.push_back(std::make_shared<common::HiveColumnHandle>(
-        columnName, columnType, rowType->childAt(i), rowType->childAt(i)));
+    columnHandles.push_back(
+        std::make_shared<common::HiveColumnHandle>(
+            columnName, columnType, rowType->childAt(i), rowType->childAt(i)));
   }
 
   auto locationHandle = std::make_shared<common::LocationHandle>(
@@ -220,18 +221,19 @@ IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
                           ->openFileForRead(filePath);
     const auto fileSize = file->size();
 
-    splits.push_back(std::make_shared<iceberg::HiveIcebergSplit>(
-        kHiveConnectorId,
-        filePath,
-        fileFormat_,
-        0,
-        fileSize,
-        partitionKeys,
-        std::nullopt,
-        customSplitInfo,
-        nullptr,
-        /*cacheable=*/true,
-        std::vector<IcebergDeleteFile>()));
+    splits.push_back(
+        std::make_shared<iceberg::HiveIcebergSplit>(
+            kHiveConnectorId,
+            filePath,
+            fileFormat_,
+            0,
+            fileSize,
+            partitionKeys,
+            std::nullopt,
+            customSplitInfo,
+            nullptr,
+            /*cacheable=*/true,
+            std::vector<IcebergDeleteFile>()));
   }
 
   return splits;

--- a/velox/connectors/lakehouse/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/lakehouse/iceberg/tests/IcebergTestBase.h
@@ -18,9 +18,9 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/connectors/lakehouse/common/tests/HiveConnectorTestBase.h"
 #include "velox/connectors/lakehouse/iceberg/IcebergDataSink.h"
 #include "velox/connectors/lakehouse/iceberg/IcebergSplit.h"
-#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #ifdef VELOX_ENABLE_PARQUET
@@ -30,7 +30,7 @@
 
 namespace facebook::velox::connector::lakehouse::iceberg::test {
 
-class IcebergTestBase : public exec::test::HiveConnectorTestBase {
+class IcebergTestBase : public common::test::HiveConnectorTestBase {
  protected:
   void SetUp() override;
 


### PR DESCRIPTION
This PR contains 2 commits:
1. Iceberg tests depend on HiveConnectorTestBase and PlanBuilder,
    which lives in exec module. They depend on Hive and provides
    functions like creating Hive splits, creating TableScan nodes,
    etc. To make IcebergReadTest work, we need to make a copy of
    them and adapt them to use the Hive copy in lakehouse/common.
    Then lakehouse/common/tests/HiveConnectorTestBase  will be
    generalized to LakehouseConnectorTestBase that serves as the
    base of Iceberg tests and other lakehouse connector tests in
    future refactor commits.
2. Modify the copied files to make Iceberg tests work.

After this PR velox_lakehouse_iceberg_test is able to run successfully.