### PR TITLE
Fix unsupported bison syntax with bison 3.0.4

### DIFF
--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -7,7 +7,7 @@
 %require "3.0.4"
 %language "C++"
 
-%define api.parser.class {Parser}
+%define parser_class_name {Parser}
 %define api.namespace {facebook::velox::exec}
 %define api.value.type variant
 %parse-param {Scanner* scanner}


### PR DESCRIPTION
To fix the Gluten build error `%define variable 'api.parser.class' is not used`.

Upstream PR: https://github.com/facebookincubator/velox/pull/14961