### PR TITLE
fix: Use explicit cmake dependency for fastfloat instead of implicit from folly

### DIFF
--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -14,8 +14,8 @@
 project(Folly)
 cmake_minimum_required(VERSION 3.28)
 
-velox_set_source(fastfloat)
-velox_resolve_dependency(fastfloat CONFIG REQUIRED)
+velox_set_source(FastFloat)
+velox_resolve_dependency(FastFloat CONFIG REQUIRED)
 
 set(VELOX_FOLLY_BUILD_VERSION v2025.04.28.00)
 set(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,6 +618,9 @@ endif()
 velox_set_source(simdjson)
 velox_resolve_dependency(simdjson 3.13.0)
 
+velox_set_source(FastFloat)
+velox_resolve_dependency(FastFloat)
+
 velox_set_source(folly)
 velox_resolve_dependency(folly)
 

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -75,6 +75,7 @@ velox_link_libraries(
   velox_presto_types
   velox_functions_util
   Folly::folly
+  FastFloat::fast_float
   stemmer::stemmer
 )
 


### PR DESCRIPTION
…from folly