### PR TITLE
Pushdown integer upcasts to source operators in LocalPlanner

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -623,7 +623,8 @@ class Connector {
       const RowTypePtr& outputType,
       const ConnectorTableHandlePtr& tableHandle,
       const connector::ColumnHandleMap& columnHandles,
-      ConnectorQueryCtx* connectorQueryCtx) = 0;
+      ConnectorQueryCtx* connectorQueryCtx,
+      bool pushdownCasts = false) = 0;
 
   /// Returns true if addSplit of DataSource can use 'dataSource' from
   /// ConnectorSplit in addSplit(). If so, TableScan can preload splits

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -436,7 +436,8 @@ class ConnectorQueryCtx {
       const std::string& sessionTimezone,
       bool adjustTimestampToTimezone = false,
       folly::CancellationToken cancellationToken = {},
-      std::shared_ptr<filesystems::TokenProvider> tokenProvider = {})
+      std::shared_ptr<filesystems::TokenProvider> tokenProvider = {},
+      bool isLegacyCast = false)
       : operatorPool_(operatorPool),
         connectorPool_(connectorPool),
         sessionProperties_(sessionProperties),
@@ -452,7 +453,8 @@ class ConnectorQueryCtx {
         sessionTimezone_(sessionTimezone),
         adjustTimestampToTimezone_(adjustTimestampToTimezone),
         cancellationToken_(std::move(cancellationToken)),
-        fsTokenProvider_(std::move(tokenProvider)) {
+        fsTokenProvider_(std::move(tokenProvider)),
+        isLegacyCast_(isLegacyCast) {
     VELOX_CHECK_NOT_NULL(sessionProperties);
   }
 
@@ -527,6 +529,10 @@ class ConnectorQueryCtx {
     return adjustTimestampToTimezone_;
   }
 
+  bool isLegacyCast() const {
+    return isLegacyCast_;
+  }
+
   /// Returns the cancellation token associated with this task.
   const folly::CancellationToken& cancellationToken() const {
     return cancellationToken_;
@@ -572,6 +578,7 @@ class ConnectorQueryCtx {
   bool selectiveNimbleReaderEnabled_{false};
   core::QueryConfig::RowSizeTrackingMode rowSizeTrackingEnabled_{
       core::QueryConfig::RowSizeTrackingMode::ENABLED_FOR_ALL};
+  bool isLegacyCast_;
 };
 
 class Connector;

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -111,7 +111,8 @@ class FuzzerConnector final : public Connector {
       const RowTypePtr& outputType,
       const ConnectorTableHandlePtr& tableHandle,
       const connector::ColumnHandleMap& /*columnHandles*/,
-      ConnectorQueryCtx* connectorQueryCtx) override final {
+      ConnectorQueryCtx* connectorQueryCtx,
+      bool pushdownCasts = false) override final {
     return std::make_unique<FuzzerDataSource>(
         outputType, tableHandle, connectorQueryCtx->memoryPool());
   }

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -38,7 +38,7 @@ velox_add_library(
 
 velox_link_libraries(
   velox_hive_connector
-  PRIVATE velox_common_io velox_connector velox_dwio_catalog_fbhive velox_hive_partition_function
+  PRIVATE velox_common_io velox_connector velox_dwio_catalog_fbhive velox_key_encoder velox_hive_partition_function
 )
 
 velox_add_library(velox_hive_partition_function HivePartitionFunction.cpp)

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -58,7 +58,8 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
     const RowTypePtr& outputType,
     const ConnectorTableHandlePtr& tableHandle,
     const ColumnHandleMap& columnHandles,
-    ConnectorQueryCtx* connectorQueryCtx) {
+    ConnectorQueryCtx* connectorQueryCtx,
+    bool pushdownCasts) {
   return std::make_unique<HiveDataSource>(
       outputType,
       tableHandle,
@@ -66,7 +67,8 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
       &fileHandleFactory_,
       ioExecutor_,
       connectorQueryCtx,
-      hiveConfig_);
+      hiveConfig_,
+      pushdownCasts);
 }
 
 std::unique_ptr<DataSink> HiveConnector::createDataSink(
@@ -215,6 +217,57 @@ void HivePartitionFunctionSpec::registerSerDe() {
   auto& registry = DeserializationWithContextRegistryForSharedPtr();
   registry.Register(
       "HivePartitionFunctionSpec", HivePartitionFunctionSpec::deserialize);
+}
+
+std::shared_ptr<core::PartitionFunctionSpec>
+HivePartitionFunctionSpec::rewriteInputType(
+    const RowTypePtr& oldInputType,
+    const RowTypePtr& newInputType) const {
+  // If the layout is identical, no change.
+  if (*oldInputType == *newInputType) {
+    return nullptr;
+  }
+
+  std::vector<column_index_t> newChannels;
+  newChannels.reserve(channels_.size());
+  bool changed = false;
+
+  for (auto channel : channels_) {
+    VELOX_CHECK_LT(
+        channel,
+        oldInputType->size(),
+        "Hive bucket channel index {} is out of bounds for old input type {}",
+        channel,
+        oldInputType->toString());
+
+    const auto& name = oldInputType->nameOf(channel);
+    auto newIndexOpt = newInputType->getChildIdxIfExists(name);
+    VELOX_USER_CHECK(
+        newIndexOpt.has_value(),
+        "Failed to find Hive bucket column '{}' in LocalPartition new input type {}",
+        name,
+        newInputType->toString());
+
+    auto newIndex = static_cast<column_index_t>(*newIndexOpt);
+    newChannels.push_back(newIndex);
+    if (newIndex != channel) {
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return nullptr;
+  }
+
+  // If we don't have a bucketToPartition map yet, keep using the "late binding"
+  // constructor. Otherwise preserve the bucketToPartition_.
+  if (bucketToPartition_.empty()) {
+    return std::make_shared<HivePartitionFunctionSpec>(
+        numBuckets_, std::move(newChannels), constValues_);
+  }
+
+  return std::make_shared<HivePartitionFunctionSpec>(
+      numBuckets_, bucketToPartition_, std::move(newChannels), constValues_);
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -42,7 +42,8 @@ class HiveConnector : public Connector {
       const RowTypePtr& outputType,
       const ConnectorTableHandlePtr& tableHandle,
       const connector::ColumnHandleMap& columnHandles,
-      ConnectorQueryCtx* connectorQueryCtx) override;
+      ConnectorQueryCtx* connectorQueryCtx,
+      bool pushdownCasts = false) override;
 
   bool supportsSplitPreload() const override {
     return true;
@@ -150,6 +151,10 @@ class HivePartitionFunctionSpec : public core::PartitionFunctionSpec {
       void* context);
 
   static void registerSerDe();
+
+  std::shared_ptr<core::PartitionFunctionSpec> rewriteInputType(
+      const RowTypePtr& oldInputType,
+      const RowTypePtr& newInputType) const override;
 
  private:
   const int numBuckets_;

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -25,6 +25,7 @@
 #include "velox/connectors/hive/HiveConfig.h"
 
 #include "velox/expression/FieldReference.h"
+#include "velox/expression/PrestoCastHooks.h"
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -457,8 +458,53 @@ std::optional<RowVectorPtr> HiveDataSource::next(
       VELOX_CHECK(index.has_value());
       auto originalColumn = rowVector->childAt(*index);
 
+//      VLOG(2) << "Copying values for upcast column: Original type: "
+//              << originalColumn->type()->toString()
+//              << ", Upcast type:" << columnType->toString();
       child = BaseVector::create(columnType, originalColumn->size(), pool_);
-      child->copy(originalColumn.get(), 0, 0, originalColumn->size());
+      if (isIntegral(columnType) && isIntegral(originalColumn->type())) {
+        child->copy(originalColumn.get(), 0, 0, originalColumn->size());
+      }
+      else if (originalColumn->type()->isDate() && columnType->isTimestamp()) {
+        auto targetChildFlatVector = child->asFlatVector<Timestamp>();
+        const velox::DecodedVector decodedOriginalVector(*originalColumn);
+        static const int64_t kMillisPerDay{86'400'000};
+        const tz::TimeZone* timeZone = nullptr;
+
+        if (connectorQueryCtx_->adjustTimestampToTimezone()) {
+          const auto sessionTzName = connectorQueryCtx_->sessionTimezone();
+          if (!sessionTzName.empty()) {
+            timeZone = tz::locateZone(sessionTzName);
+          }
+        }
+
+        for (vector_size_t j = 0; j < originalColumn->size(); ++j) {
+          const auto decodedIndex = decodedOriginalVector.index(j);
+          VLOG(2) << "Copying value at index " << j;
+          VLOG(2) << "DateToTimestamp: Value at index " << j << " is " << decodedOriginalVector.valueAt<int32_t>(decodedIndex);
+          auto timestamp = Timestamp::fromMillis(
+              decodedOriginalVector.valueAt<int32_t>(decodedIndex) * kMillisPerDay);
+          if (timeZone) {
+            VLOG(2) << "Timezone is " << timeZone->name();
+            timestamp.toGMT(*timeZone);
+          }
+          targetChildFlatVector->set(j, timestamp);
+        }
+      }
+      else if (originalColumn->type()->isVarchar() && columnType->isTimestamp()) {
+        const exec::PrestoCastHooks hooks(connectorQueryCtx_->isLegacyCast(),
+                                          connectorQueryCtx_->adjustTimestampToTimezone(),
+                                          connectorQueryCtx_->sessionTimezone());
+        auto targetChildFlatVector = child->asFlatVector<Timestamp>();
+        const velox::DecodedVector decodedOriginalVector(*originalColumn);
+
+        for (vector_size_t j = 0; j < originalColumn->size(); ++j) {
+          const auto decodedIndex = decodedOriginalVector.index(j);
+          VLOG(2) << "Copying value at index " << j;
+          VLOG(2) << "StringToTimestamp: Value at index " << j << " is " << decodedOriginalVector.valueAt<StringView>(decodedIndex);
+          targetChildFlatVector->set(j, hooks.castStringToTimestamp(decodedOriginalVector.valueAt<StringView>(decodedIndex)).value());
+        }
+      }
     } else {
       auto columnHandleIt = assignments_.find(columnName);
       VELOX_CHECK(

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -56,14 +56,17 @@ HiveDataSource::HiveDataSource(
     FileHandleFactory* fileHandleFactory,
     folly::Executor* ioExecutor,
     const ConnectorQueryCtx* connectorQueryCtx,
-    const std::shared_ptr<HiveConfig>& hiveConfig)
-    : fileHandleFactory_(fileHandleFactory),
+    const std::shared_ptr<HiveConfig>& hiveConfig,
+    bool pushdownCasts)
+    : assignments_(assignments),
+      fileHandleFactory_(fileHandleFactory),
       ioExecutor_(ioExecutor),
       connectorQueryCtx_(connectorQueryCtx),
       hiveConfig_(hiveConfig),
       pool_(connectorQueryCtx->memoryPool()),
       outputType_(outputType),
-      expressionEvaluator_(connectorQueryCtx->expressionEvaluator()) {
+      expressionEvaluator_(connectorQueryCtx->expressionEvaluator()),
+      pushdownCasts_(pushdownCasts){
   hiveTableHandle_ = checkedPointerCast<const HiveTableHandle>(tableHandle);
 
   folly::F14FastMap<std::string_view, const HiveColumnHandle*> columnHandles;
@@ -96,22 +99,45 @@ HiveDataSource::HiveDataSource(
   }
 
   std::vector<std::string> readColumnNames;
-  auto readColumnTypes = outputType_->children();
-  for (const auto& outputName : outputType_->names()) {
-    auto it = assignments.find(outputName);
-    VELOX_CHECK(
-        it != assignments.end(),
-        "ColumnHandle is missing for output column: {}",
-        outputName);
+  std::vector<TypePtr> readColumnTypes;
+  std::vector<std::string> readColumnNamesWithoutUpcasts;
+  std::vector<TypePtr> readColumnTypesWithoutUpcasts;
 
+  // outputType_ contains the upcast columns if pushdownCasts_ is true.
+  for (int i = 0; i < outputType_->size(); ++i) {
+    auto columnName = outputType_->nameOf(i); // e.g. order_id_21_upcast
+    auto& columnType = outputType_->childAt(i);
+
+    auto originalColumnName = columnName;
+    if (pushdownCasts_ && columnName.ends_with("_upcast")) {
+      originalColumnName =
+          columnName.substr(0, columnName.size() - strlen("_upcast"));
+    }
+
+    // Get the ColumnHandle name. This is the name without aliasing. e.g.
+    // originalColumnName="order_id_21", and columnHandleName="order_id"
+    auto it = assignments_.find(originalColumnName);
+    VELOX_CHECK(
+        it != assignments_.end(),
+        "ColumnHandle is missing for output column: {}",
+        columnName);
     auto* handle = static_cast<const HiveColumnHandle*>(it->second.get());
-    readColumnNames.push_back(handle->name());
+    auto columnHandleName = handle->name();
+
+    readColumnNames.push_back(columnHandleName);
+    readColumnTypes.push_back(columnType);
+
+    if (!pushdownCasts_ || !columnName.ends_with("_upcast")) {
+      readColumnNamesWithoutUpcasts.push_back(columnHandleName);
+      readColumnTypesWithoutUpcasts.push_back(columnType);
+    }
+
     for (auto& subfield : handle->requiredSubfields()) {
       VELOX_USER_CHECK_EQ(
           getColumnName(subfield),
           handle->name(),
           "Required subfield does not match column name");
-      subfields_[handle->name()].push_back(&subfield);
+      subfields_[columnHandleName].push_back(&subfield);
     }
     columnPostProcessors_.push_back(handle->postProcessor());
   }
@@ -153,9 +179,14 @@ HiveDataSource::HiveDataSource(
       }
       // Remaining filter may reference columns that are not used otherwise,
       // e.g. are not being projected out and are not used in range filters.
-      // Make sure to add these columns to readerOutputType_.
+      // Make sure to add these columns to readerOutputTypeWithoutUpcasts_.
       readColumnNames.push_back(input->field());
       readColumnTypes.push_back(input->type());
+
+      if (!pushdownCasts_ || !input->field().ends_with("_upcast")) {
+        readColumnNamesWithoutUpcasts.push_back(input->field());
+        readColumnTypesWithoutUpcasts.push_back(input->type());
+      }
     }
     remainingFilterSubfields_ = remainingFilterExpr->extractSubfields();
     if (VLOG_IS_ON(1)) {
@@ -180,8 +211,12 @@ HiveDataSource::HiveDataSource(
 
   readerOutputType_ =
       ROW(std::move(readColumnNames), std::move(readColumnTypes));
+  // NO upcast columns
+  readerOutputTypeWithoutUpcasts_ =
+      ROW(std::move(readColumnNamesWithoutUpcasts),
+          std::move(readColumnTypesWithoutUpcasts));
   scanSpec_ = makeScanSpec(
-      readerOutputType_,
+      readerOutputTypeWithoutUpcasts_,
       subfields_,
       filters_,
       /*indexColumns=*/{},
@@ -208,7 +243,7 @@ std::unique_ptr<SplitReader> HiveDataSource::createSplitReader() {
       &partitionKeys_,
       connectorQueryCtx_,
       hiveConfig_,
-      readerOutputType_,
+      readerOutputTypeWithoutUpcasts_,
       ioStatistics_,
       ioStats_,
       fileHandleFactory_,
@@ -233,11 +268,12 @@ std::vector<column_index_t> HiveDataSource::setupBucketConversion() {
     if (subfields_.erase(handle->name()) > 0) {
       rebuildScanSpec = true;
     }
-    auto index = readerOutputType_->getChildIdxIfExists(handle->name());
+    auto index =
+        readerOutputTypeWithoutUpcasts_->getChildIdxIfExists(handle->name());
     if (!index.has_value()) {
       if (names.empty()) {
-        names = readerOutputType_->names();
-        types = readerOutputType_->children();
+        names = readerOutputTypeWithoutUpcasts_->names();
+        types = readerOutputTypeWithoutUpcasts_->children();
       }
       index = names.size();
       names.push_back(handle->name());
@@ -248,11 +284,11 @@ std::vector<column_index_t> HiveDataSource::setupBucketConversion() {
     bucketChannels.push_back(*index);
   }
   if (!names.empty()) {
-    readerOutputType_ = ROW(std::move(names), std::move(types));
+    readerOutputTypeWithoutUpcasts_ = ROW(std::move(names), std::move(types));
   }
   if (rebuildScanSpec) {
     auto newScanSpec = makeScanSpec(
-        readerOutputType_,
+        readerOutputTypeWithoutUpcasts_,
         subfields_,
         filters_,
         /*indexColumns=*/{},
@@ -275,7 +311,8 @@ void HiveDataSource::setupRowIdColumn() {
   auto* rowId = scanSpec_->childByName(*specialColumns_.rowId);
   VELOX_CHECK_NOT_NULL(rowId);
   auto& rowIdType =
-      readerOutputType_->findChild(*specialColumns_.rowId)->asRow();
+      readerOutputTypeWithoutUpcasts_->findChild(*specialColumns_.rowId)
+          ->asRow();
   auto rowGroupId = split_->getFileName();
   rowId->childByName(rowIdType.nameOf(1))
       ->setConstantValue<StringView>(
@@ -299,8 +336,6 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
       "Previous split has not been processed yet. Call next to process the split.");
   split_ = checkedPointerCast<HiveConnectorSplit>(split);
 
-  VLOG(1) << "Adding split " << split_->toString();
-
   if (splitReader_) {
     splitReader_.reset();
   }
@@ -322,7 +357,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   // so we initialize it beforehand.
   splitReader_->configureReaderOptions(randomSkip_);
   splitReader_->prepareSplit(metadataFilter_, runtimeStats_);
-  readerOutputType_ = splitReader_->readerOutputType();
+  readerOutputTypeWithoutUpcasts_ = splitReader_->readerOutputType();
 }
 
 std::optional<RowVectorPtr> HiveDataSource::next(
@@ -341,14 +376,16 @@ std::optional<RowVectorPtr> HiveDataSource::next(
 
   // Bucket conversion or delta update could add extra column to reader output.
   auto needsExtraColumn = [&] {
-    return output_->asUnchecked<RowVector>()->childrenSize() <
-        readerOutputType_->size();
+    return outputWithoutUpcasts_->asUnchecked<RowVector>()->childrenSize() <
+        readerOutputTypeWithoutUpcasts_->size();
   };
-  if (!output_ || needsExtraColumn()) {
-    output_ = BaseVector::create(readerOutputType_, 0, pool_);
+  if (!outputWithoutUpcasts_ || needsExtraColumn()) {
+    outputWithoutUpcasts_ =
+        BaseVector::create(readerOutputTypeWithoutUpcasts_, 0, pool_);
   }
 
-  const auto rowsScanned = splitReader_->next(size, output_);
+  // Read only the real columns, not the upcast columns.
+  const auto rowsScanned = splitReader_->next(size, outputWithoutUpcasts_);
   completedRows_ += rowsScanned;
   if (rowsScanned == 0) {
     splitReader_->updateRuntimeStats(runtimeStats_);
@@ -357,14 +394,15 @@ std::optional<RowVectorPtr> HiveDataSource::next(
   }
 
   VELOX_CHECK(
-      !output_->mayHaveNulls(), "Top-level row vector cannot have nulls");
-  auto rowsRemaining = output_->size();
+      !outputWithoutUpcasts_->mayHaveNulls(),
+      "Top-level row vector cannot have nulls");
+  auto rowsRemaining = outputWithoutUpcasts_->size();
   if (rowsRemaining == 0) {
     // no rows passed the pushed down filters.
     return getEmptyOutput();
   }
 
-  auto rowVector = std::dynamic_pointer_cast<RowVector>(output_);
+  auto rowVector = std::dynamic_pointer_cast<RowVector>(outputWithoutUpcasts_);
 
   // In case there is a remaining filter that excludes some but not all
   // rows, collect the indices of the passing rows. If there is no filter,
@@ -394,12 +432,49 @@ std::optional<RowVectorPtr> HiveDataSource::next(
   std::vector<VectorPtr> outputColumns;
   outputColumns.reserve(outputType_->size());
   for (int i = 0; i < outputType_->size(); ++i) {
-    auto& child = rowVector->childAt(i);
-    if (remainingIndices) {
-      // Disable dictionary values caching in expression eval so that we
-      // don't need to reallocate the result for every batch.
-      child->disableMemo();
+    std::shared_ptr<BaseVector> child;
+    // find the upcast columns and add them to outputWithoutUpcasts_
+    const auto& columnName = outputType_->nameOf(i);
+    // outputType_ includes the upcast columns,
+    const auto& columnType = outputType_->childAt(i);
+
+    if (columnName.ends_with("_upcast")) {
+      auto originalOutputName =
+          columnName.substr(0, columnName.size() - strlen("_upcast"));
+      auto columnHandleIt = assignments_.find(originalOutputName);
+      VELOX_CHECK(
+          columnHandleIt != assignments_.end(),
+          "Cannot find column handle for upcast column: {} original: {}",
+          columnName,
+          originalOutputName);
+      auto columnHandleName =
+          static_cast<const HiveColumnHandle*>(columnHandleIt->second.get())
+              ->name();
+
+      //  rowVector does not have the upcast columns.
+      auto index = readerOutputTypeWithoutUpcasts_->getChildIdxIfExists(
+          columnHandleName);
+      VELOX_CHECK(index.has_value());
+      auto originalColumn = rowVector->childAt(*index);
+
+      child = BaseVector::create(columnType, originalColumn->size(), pool_);
+      child->copy(originalColumn.get(), 0, 0, originalColumn->size());
+    } else {
+      auto columnHandleIt = assignments_.find(columnName);
+      VELOX_CHECK(
+          columnHandleIt != assignments_.end(),
+          "Cannot find column handle for upcast column: {} original: {}",
+          columnName,
+          columnName);
+      auto columnHandleName =
+          static_cast<const HiveColumnHandle*>(columnHandleIt->second.get())
+              ->name();
+      auto index =
+          readerOutputTypeWithoutUpcasts_->getChildIdxIfExists(columnHandleName);
+      VELOX_CHECK(index.has_value());
+      child = rowVector->childAt(*index);
     }
+
     auto column = exec::wrapChild(rowsRemaining, remainingIndices, child);
     if (columnPostProcessors_[i]) {
       columnPostProcessors_[i](column);
@@ -556,7 +631,8 @@ void HiveDataSource::setFromDataSource(
   runtimeStats_.skippedSplits += source->runtimeStats_.skippedSplits;
   runtimeStats_.processedSplits += source->runtimeStats_.processedSplits;
   runtimeStats_.skippedSplitBytes += source->runtimeStats_.skippedSplitBytes;
-  readerOutputType_ = std::move(source->readerOutputType_);
+  readerOutputTypeWithoutUpcasts_ =
+      std::move(source->readerOutputTypeWithoutUpcasts_);
   source->scanSpec_->moveAdaptationFrom(*scanSpec_);
   scanSpec_ = std::move(source->scanSpec_);
   metadataFilter_ = std::move(source->metadataFilter_);
@@ -619,7 +695,7 @@ std::shared_ptr<wave::WaveDataSource> HiveDataSource::toWaveDataSource() {
     waveDataSource_ = waveDelegateHook_(
         hiveTableHandle_,
         scanSpec_,
-        readerOutputType_,
+        readerOutputTypeWithoutUpcasts_,
         &partitionKeys_,
         fileHandleFactory_,
         ioExecutor_,

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -41,7 +41,8 @@ class HiveDataSource : public DataSource {
       FileHandleFactory* fileHandleFactory,
       folly::Executor* ioExecutor,
       const ConnectorQueryCtx* connectorQueryCtx,
-      const std::shared_ptr<HiveConfig>& hiveConfig);
+      const std::shared_ptr<HiveConfig>& hiveConfig,
+      bool pushdownCasts = false);
 
   void addSplit(std::shared_ptr<ConnectorSplit> split) override;
 
@@ -100,7 +101,7 @@ class HiveDataSource : public DataSource {
 
  protected:
   virtual std::unique_ptr<SplitReader> createSplitReader();
-
+  const connector::ColumnHandleMap assignments_;
   FileHandleFactory* const fileHandleFactory_;
   folly::Executor* const ioExecutor_;
   const ConnectorQueryCtx* const connectorQueryCtx_;
@@ -110,13 +111,15 @@ class HiveDataSource : public DataSource {
   std::shared_ptr<HiveConnectorSplit> split_;
   HiveTableHandlePtr hiveTableHandle_;
   std::shared_ptr<common::ScanSpec> scanSpec_;
+  VectorPtr outputWithoutUpcasts_;
   VectorPtr output_;
   std::unique_ptr<SplitReader> splitReader_;
-
   // Output type from file reader.  This is different from outputType_ that it
   // contains column names before assignment, and columns that only used in
   // remaining filter.
   RowTypePtr readerOutputType_;
+  // The ColumnHandle name, e.g. order_id
+  RowTypePtr readerOutputTypeWithoutUpcasts_;
 
   // Column handles for the partition key columns keyed on partition key column
   // name.
@@ -151,9 +154,15 @@ class HiveDataSource : public DataSource {
   // object.
   void processColumnHandle(const HiveColumnHandlePtr& handle);
 
-  // The row type for the data source output, not including filter-only columns
+  // The row type for the data source output, including filter-only columns
+  // May be aliased, e.g. (order_id_21, order_id_21_upcast). Does not include
+  // filter only columns
   const RowTypePtr outputType_;
+  // Same as outputType_ but the column names are the ColumnHandle names
+  RowTypePtr outputTypeWithoutUpcasts_;
+
   core::ExpressionEvaluator* const expressionEvaluator_;
+  const bool pushdownCasts_;
 
   // Column handles for the Split info columns keyed on their column names.
   std::unordered_map<std::string, HiveColumnHandlePtr> infoColumns_;

--- a/velox/connectors/hive/HiveIndexReader.cpp
+++ b/velox/connectors/hive/HiveIndexReader.cpp
@@ -23,6 +23,7 @@
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/common/ReaderFactory.h"
+#include "velox/velox/serializers/KeyEncoder.h"
 
 namespace facebook::velox::connector::hive {
 namespace {

--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -52,7 +52,8 @@ std::unique_ptr<DataSource> IcebergConnector::createDataSource(
     const RowTypePtr& outputType,
     const ConnectorTableHandlePtr& tableHandle,
     const ColumnHandleMap& columnHandles,
-    ConnectorQueryCtx* connectorQueryCtx) {
+    ConnectorQueryCtx* connectorQueryCtx,
+    bool pushdownCasts) {
   return std::make_unique<IcebergDataSource>(
       outputType,
       tableHandle,

--- a/velox/connectors/hive/iceberg/IcebergConnector.h
+++ b/velox/connectors/hive/iceberg/IcebergConnector.h
@@ -43,7 +43,8 @@ class IcebergConnector final : public HiveConnector {
       const RowTypePtr& outputType,
       const ConnectorTableHandlePtr& tableHandle,
       const ColumnHandleMap& columnHandles,
-      ConnectorQueryCtx* connectorQueryCtx) override;
+      ConnectorQueryCtx* connectorQueryCtx,
+      bool pushdownCasts = false) override;
 
   /// Creates IcebergDataSink for writing to Iceberg tables.
   ///

--- a/velox/connectors/tests/ConnectorTest.cpp
+++ b/velox/connectors/tests/ConnectorTest.cpp
@@ -30,7 +30,8 @@ class TestConnector : public connector::Connector {
       const RowTypePtr& /* outputType */,
       const ConnectorTableHandlePtr& /* tableHandle */,
       const connector::ColumnHandleMap& /* columnHandles */,
-      connector::ConnectorQueryCtx* connectorQueryCtx) override {
+      connector::ConnectorQueryCtx* connectorQueryCtx,
+      bool pushdownCasts) override {
     VELOX_NYI();
   }
 

--- a/velox/connectors/tpcds/TpcdsConnector.h
+++ b/velox/connectors/tpcds/TpcdsConnector.h
@@ -145,7 +145,8 @@ class TpcdsConnector final : public velox::connector::Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<const velox::connector::ColumnHandle>>& columnHandles,
-      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx,
+      bool pushdownCasts = false) override final {
     return std::make_unique<TpcdsDataSource>(
         outputType,
         tableHandle,

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -219,7 +219,8 @@ class TpchConnector final : public Connector {
       const RowTypePtr& outputType,
       const ConnectorTableHandlePtr& tableHandle,
       const connector::ColumnHandleMap& columnHandles,
-      ConnectorQueryCtx* connectorQueryCtx) override final {
+      ConnectorQueryCtx* connectorQueryCtx,
+      bool pushdownCasts = false) override final {
     return std::make_unique<TpchDataSource>(
         outputType, tableHandle, columnHandles, connectorQueryCtx);
   }

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -49,6 +49,13 @@ class InputTypedExpr : public ITypedExpr {
     return std::make_shared<InputTypedExpr>(type());
   }
 
+  TypedExprPtr rewriteCastExprsWithUpcastName(
+      const std::
+          multimap<std::string, std::pair<core::TypedExprPtr, std::string>>&
+              castExprsToRewrite) const override {
+    return std::make_shared<InputTypedExpr>(type());
+  }
+
   void accept(
       const ITypedExprVisitor& visitor,
       ITypedExprVisitorContext& context) const override;
@@ -129,6 +136,17 @@ class ConstantTypedExpr : public ITypedExpr {
   TypedExprPtr rewriteInputNames(
       const std::unordered_map<std::string, TypedExprPtr>& /*mapping*/)
       const override {
+    if (hasValueVector()) {
+      return std::make_shared<ConstantTypedExpr>(valueVector_);
+    } else {
+      return std::make_shared<ConstantTypedExpr>(type(), value_);
+    }
+  }
+
+  TypedExprPtr rewriteCastExprsWithUpcastName(
+      const std::
+          multimap<std::string, std::pair<core::TypedExprPtr, std::string>>&
+              castExprsToRewrite) const override {
     if (hasValueVector()) {
       return std::make_shared<ConstantTypedExpr>(valueVector_);
     } else {
@@ -226,6 +244,16 @@ class CallTypedExpr : public ITypedExpr {
         type(), rewriteInputsRecursive(mapping), name_);
   }
 
+  TypedExprPtr rewriteCastExprsWithUpcastName(
+      const std::
+          multimap<std::string, std::pair<core::TypedExprPtr, std::string>>&
+              castExprsToRewrite) const override {
+    return std::make_shared<CallTypedExpr>(
+        type(),
+        rewriteCastExprsWithUpcastNameRecursive(castExprsToRewrite),
+        name_);
+  }
+
   std::string toString() const override;
 
   size_t localHash() const override {
@@ -294,6 +322,13 @@ class FieldAccessTypedExpr : public ITypedExpr {
   TypedExprPtr rewriteInputNames(
       const std::unordered_map<std::string, TypedExprPtr>& mapping)
       const override;
+
+  TypedExprPtr rewriteCastExprsWithUpcastName(
+      const std::
+          multimap<std::string, std::pair<core::TypedExprPtr, std::string>>&
+              castExprsToRewrite) const override {
+    return std::make_shared<FieldAccessTypedExpr>(type(), name_);
+  }
 
   std::string toString() const override;
 
@@ -376,6 +411,13 @@ class DereferenceTypedExpr : public ITypedExpr {
     return std::make_shared<DereferenceTypedExpr>(type(), newInputs[0], index_);
   }
 
+  TypedExprPtr rewriteCastExprsWithUpcastName(
+      const std::
+          multimap<std::string, std::pair<core::TypedExprPtr, std::string>>&
+              castExprsToRewrite) const override {
+    return std::make_shared<DereferenceTypedExpr>(type(), inputs()[0], index_);
+  }
+
   std::string toString() const override {
     return fmt::format("{}[{}]", inputs()[0]->toString(), name());
   }
@@ -432,6 +474,15 @@ class ConcatTypedExpr : public ITypedExpr {
       const override {
     return std::make_shared<ConcatTypedExpr>(
         type()->asRow().names(), rewriteInputsRecursive(mapping));
+  }
+
+  TypedExprPtr rewriteCastExprsWithUpcastName(
+      const std::
+          multimap<std::string, std::pair<core::TypedExprPtr, std::string>>&
+              castExprs) const override {
+    return std::make_shared<ConcatTypedExpr>(
+        type()->asRow().names(),
+        rewriteCastExprsWithUpcastNameRecursive(castExprs));
   }
 
   std::string toString() const override;
@@ -495,6 +546,14 @@ class LambdaTypedExpr : public ITypedExpr {
   TypedExprPtr rewriteInputNames(
       const std::unordered_map<std::string, TypedExprPtr>& mapping)
       const override;
+
+  TypedExprPtr rewriteCastExprsWithUpcastName(
+      const std::
+          multimap<std::string, std::pair<core::TypedExprPtr, std::string>>&
+              castExprs) const override {
+    return std::make_shared<LambdaTypedExpr>(
+        signature_, body_->rewriteCastExprsWithUpcastName(castExprs));
+  }
 
   std::string toString() const override {
     return fmt::format(
@@ -562,6 +621,25 @@ class CastTypedExpr : public ITypedExpr {
       const override {
     return std::make_shared<CastTypedExpr>(
         type(), rewriteInputsRecursive(mapping), isTryCast_);
+  }
+
+  TypedExprPtr rewriteCastExprsWithUpcastName(
+      const std::
+          multimap<std::string, std::pair<core::TypedExprPtr, std::string>>&
+              castExprsToRewrite) const override {
+    for (auto castExprToRewrite : castExprsToRewrite) {
+      if (*castExprToRewrite.second.first == *this) {
+        VELOX_CHECK(
+            castExprToRewrite.second.first->inputs()[0]->isFieldAccessKind());
+        auto fieldAccessTypedExpr =
+            std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+                castExprToRewrite.second.first->inputs()[0]);
+        return std::make_shared<FieldAccessTypedExpr>(
+            castExprToRewrite.second.first->type(),
+            fieldAccessTypedExpr->name() + "_upcast");
+      }
+    }
+    return std::make_shared<CastTypedExpr>(type(), inputs(), isTryCast_);
   }
 
   std::string toString() const override;

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -115,6 +115,11 @@ class ITypedExpr : public ISerializable {
   virtual TypedExprPtr rewriteInputNames(
       const std::unordered_map<std::string, TypedExprPtr>& mapping) const = 0;
 
+  virtual TypedExprPtr rewriteCastExprsWithUpcastName(
+      const std::multimap<
+          std::string,
+          std::pair<core::TypedExprPtr, std::string>>&) const = 0;
+
   /// Part of the visitor pattern. Calls visitor.vist(*this, context) with the
   /// "right" type of the first argument.
   virtual void accept(
@@ -155,6 +160,18 @@ class ITypedExpr : public ISerializable {
     newInputs.reserve(inputs().size());
     for (const auto& input : inputs()) {
       newInputs.emplace_back(input->rewriteInputNames(mapping));
+    }
+    return newInputs;
+  }
+
+  std::vector<TypedExprPtr> rewriteCastExprsWithUpcastNameRecursive(
+      const std::multimap<
+          std::string,
+          std::pair<core::TypedExprPtr, std::string>>& castExprs) const {
+    std::vector<TypedExprPtr> newInputs;
+    newInputs.reserve(inputs().size());
+    for (const auto& input : inputs()) {
+      newInputs.emplace_back(input->rewriteCastExprsWithUpcastName(castExprs));
     }
     return newInputs;
   }

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -97,6 +97,87 @@ std::unordered_map<V, K> invertMap(const std::unordered_map<K, V>& mapping) {
   }
   return inverted;
 }
+
+// Build a new output type using:
+//  - oldOutput: the original node output
+//  - oldSources: original child nodes
+//  - newSources: new child nodes
+//
+// Rules:
+//  * Keep columns that were in oldOutput (if still present).
+//  * Add columns that appear in newSources but not in oldSources ("new
+//  columns").
+//  * Order is determined by scanning newSources’ schemas left-to-right.
+//  * No vector::insert, only push_back into fresh vectors.
+RowTypePtr recomputeOutputTypeFromSources(
+    const RowTypePtr& oldOutput,
+    const std::vector<PlanNodePtr>& oldSources,
+    const std::vector<PlanNodePtr>& newSources) {
+  VELOX_CHECK_EQ(oldSources.size(), newSources.size());
+
+  // Set of column names that were in the old output.
+  folly::F14FastSet<std::string> oldOutputCols;
+  for (const auto& name : oldOutput->names()) {
+    oldOutputCols.insert(name);
+  }
+
+  // Identify "new" columns: in newSources but not in the corresponding old
+  // source.
+  folly::F14FastSet<std::string> newCols;
+
+  for (size_t i = 0; i < newSources.size(); ++i) {
+    auto oldType =
+        std::dynamic_pointer_cast<const RowType>(oldSources[i]->outputType());
+    auto newType =
+        std::dynamic_pointer_cast<const RowType>(newSources[i]->outputType());
+    VELOX_CHECK_NOT_NULL(oldType);
+    VELOX_CHECK_NOT_NULL(newType);
+
+    for (int c = 0; c < newType->size(); ++c) {
+      const auto& name = newType->nameOf(c);
+      if (!oldType->containsChild(name)) {
+        newCols.insert(name);
+      }
+    }
+  }
+
+  // Now build the final output in the order of newSources’ schemas:
+  // we only push_back, never insert.
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+
+  names.reserve(oldOutput->size() + newCols.size());
+  types.reserve(oldOutput->size() + newCols.size());
+
+  folly::F14FastSet<std::string> added;
+
+  for (size_t i = 0; i < newSources.size(); ++i) {
+    auto newType =
+        std::dynamic_pointer_cast<const RowType>(newSources[i]->outputType());
+    VELOX_CHECK_NOT_NULL(newType);
+
+    for (int c = 0; c < newType->size(); ++c) {
+      const auto& name = newType->nameOf(c);
+
+      if (added.contains(name)) {
+        continue;
+      }
+
+      const bool isOldOutput = oldOutputCols.contains(name);
+      const bool isNewCol = newCols.contains(name);
+
+      // Keep an existing output column, or append a new column.
+      if (isOldOutput || isNewCol) {
+        names.push_back(name);
+        types.push_back(newType->childAt(c));
+        added.insert(name);
+      }
+    }
+  }
+
+  return ROW(std::move(names), std::move(types));
+}
+
 } // namespace
 
 const SortOrder kAscNullsFirst(true, true);
@@ -504,6 +585,14 @@ PlanNodePtr AggregationNode::create(const folly::dynamic& obj, void* context) {
       deserializeSingleSource(obj, context));
 }
 
+PlanNodePtr AggregationNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 namespace {
 RowTypePtr getExpandOutputType(
     const std::vector<std::vector<TypedExprPtr>>& projections,
@@ -607,6 +696,14 @@ PlanNodePtr ExpandNode::create(const folly::dynamic& obj, void* context) {
       std::move(projections),
       std::move(names),
       std::move(source));
+}
+
+PlanNodePtr ExpandNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
 }
 
 namespace {
@@ -724,6 +821,14 @@ PlanNodePtr GroupIdNode::create(const folly::dynamic& obj, void* context) {
       deserializeFields(obj["aggregationInputs"], context),
       obj["groupIdName"].asString(),
       std::move(source));
+}
+
+PlanNodePtr GroupIdNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
 }
 
 const std::vector<PlanNodePtr>& ValuesNode::sources() const {
@@ -1139,6 +1244,14 @@ PlanNodePtr ProjectNode::create(const folly::dynamic& obj, void* context) {
       std::move(source));
 }
 
+PlanNodePtr ProjectNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 namespace {
 // makes a list of all names for use in the ProjectNode.
 std::vector<std::string> allNames(
@@ -1239,6 +1352,15 @@ PlanNodePtr ParallelProjectNode::create(
       std::move(source));
 }
 
+PlanNodePtr ParallelProjectNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1, "LazyDereferenceNode is unary");
+
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 // static
 PlanNodePtr LazyDereferenceNode::create(
     const folly::dynamic& obj,
@@ -1253,6 +1375,15 @@ PlanNodePtr LazyDereferenceNode::create(
       std::move(names),
       std::move(projections),
       std::move(source));
+}
+
+PlanNodePtr LazyDereferenceNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1, "LazyDereferenceNode is unary");
+
+  ProjectNode::Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
 }
 
 const std::vector<PlanNodePtr>& TableScanNode::sources() const {
@@ -1462,6 +1593,14 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
       std::move(source));
 }
 
+PlanNodePtr UnnestNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 AbstractJoinNode::AbstractJoinNode(
     const PlanNodeId& id,
     JoinType joinType,
@@ -1500,6 +1639,12 @@ void AbstractJoinNode::validate() const {
         key->name());
   }
   for (auto i = 0; i < leftKeys_.size(); ++i) {
+    auto leftType = leftKeys_[i]->type();
+    auto rightType = rightKeys_[i]->type();
+    if (isIntegral(leftType) && isIntegral(rightType)) {
+      continue;
+    }
+
     VELOX_CHECK_EQ(
         leftKeys_[i]->type()->kind(),
         rightKeys_[i]->type()->kind(),
@@ -1687,6 +1832,44 @@ PlanNodePtr HashJoinNode::create(const folly::dynamic& obj, void* context) {
       useHashTableCache);
 }
 
+namespace {
+std::vector<core::FieldAccessTypedExprPtr> getKeysFromSource(
+    const std::vector<core::FieldAccessTypedExprPtr>& keys,
+    const PlanNodePtr& source) {
+  std::vector<core::FieldAccessTypedExprPtr> result;
+  auto sourceType = source->outputType();
+  for (const auto& key : keys) {
+    auto keyName = key->name();
+    auto keyType = sourceType->findChild(keyName);
+    VELOX_CHECK_NOT_NULL(
+        keyType, "Join key not found in source output: {}", keyName);
+    result.push_back(std::make_shared<FieldAccessTypedExpr>(keyType, keyName));
+  }
+  return result;
+}
+} // namespace
+
+PlanNodePtr HashJoinNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 2);
+
+  std::vector<core::FieldAccessTypedExprPtr> leftKeys =
+      getKeysFromSource(leftKeys_, newSources[0]);
+  std::vector<core::FieldAccessTypedExprPtr> rightKeys =
+      getKeysFromSource(rightKeys_, newSources[1]);
+
+  // Recompute outputType using member helper (no key args needed here).
+  auto newOutputType = recomputeOutputTypeForNewSources(newSources);
+
+  Builder builder(*this);
+  builder.left(std::move(newSources[0]))
+      .right(std::move(newSources[1]))
+      .leftKeys(std::move(leftKeys))
+      .rightKeys(std::move(rightKeys))
+      .outputType(std::move(newOutputType));
+  return builder.build();
+}
+
 MergeJoinNode::MergeJoinNode(
     const PlanNodeId& id,
     JoinType joinType,
@@ -1763,6 +1946,27 @@ PlanNodePtr MergeJoinNode::create(const folly::dynamic& obj, void* context) {
       sources[0],
       sources[1],
       outputType);
+}
+
+PlanNodePtr MergeJoinNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 2);
+
+  std::vector<core::FieldAccessTypedExprPtr> leftKeys =
+      getKeysFromSource(leftKeys_, newSources[0]);
+  std::vector<core::FieldAccessTypedExprPtr> rightKeys =
+      getKeysFromSource(rightKeys_, newSources[1]);
+
+  // Recompute outputType using member helper (no key args needed here).
+  auto newOutputType = recomputeOutputTypeForNewSources(newSources);
+
+  Builder builder(*this);
+  builder.left(std::move(newSources[0]))
+      .right(std::move(newSources[1]))
+      .leftKeys(std::move(leftKeys))
+      .rightKeys(std::move(rightKeys))
+      .outputType(std::move(newOutputType));
+  return builder.build();
 }
 
 IndexLookupJoinNode::IndexLookupJoinNode(
@@ -1889,6 +2093,27 @@ PlanNodePtr IndexLookupJoinNode::create(
       std::move(outputType));
 }
 
+PlanNodePtr IndexLookupJoinNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 2);
+
+  std::vector<core::FieldAccessTypedExprPtr> leftKeys =
+      getKeysFromSource(leftKeys_, newSources[0]);
+  std::vector<core::FieldAccessTypedExprPtr> rightKeys =
+      getKeysFromSource(rightKeys_, newSources[1]);
+
+  // Recompute outputType using member helper (no key args needed here).
+  auto newOutputType = recomputeOutputTypeForNewSources(newSources);
+
+  Builder builder(*this);
+  builder.left(std::move(newSources[0]))
+      .right(std::move(newSources[1]))
+      .leftKeys(std::move(leftKeys))
+      .rightKeys(std::move(rightKeys))
+      .outputType(std::move(newOutputType));
+  return builder.build();
+}
+
 folly::dynamic IndexLookupJoinNode::serialize() const {
   auto obj = serializeBase();
   if (!joinConditions_.empty()) {
@@ -1924,6 +2149,110 @@ void IndexLookupJoinNode::addDetails(std::stringstream& stream) const {
          << " ], filter: ["
          << (filter_ == nullptr ? "null" : filter_->toString())
          << "], hasMarker: [" << (hasMarker_ ? "true" : "false") << "]";
+}
+
+RowTypePtr AbstractJoinNode::recomputeOutputTypeForNewSources(
+    const std::vector<PlanNodePtr>& newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 2);
+
+  const auto& oldOutput =
+      outputType_; // the join node's current (authoritative) output
+  const auto& newLeft = newSources[0]->outputType();
+  const auto& newRight = newSources[1]->outputType();
+
+  // Which sides are visible for this join type?
+  const bool allowLeft = !(isRightSemiFilterJoin() || isRightSemiProjectJoin());
+  const bool allowRight =
+      !(isLeftSemiFilterJoin() || isLeftSemiProjectJoin() || isAntiJoin());
+
+  // Collect *all* child fields from allowed sides (name -> type).
+  folly::F14FastMap<std::string, TypePtr> newFields;
+  auto collect = [&](const RowTypePtr& row, bool allowed) {
+    if (!allowed)
+      return;
+    for (int i = 0; i < row->size(); ++i) {
+      newFields[row->nameOf(i)] = row->childAt(i);
+    }
+  };
+  collect(newLeft, allowLeft);
+  collect(newRight, allowRight);
+
+  // Derive join key names from this node's existing key expressions.
+  // We use them only to *exclude* pure keys that were not previously visible.
+  folly::F14FastSet<std::string> joinKeyNames;
+  for (const auto& k : leftKeys_) {
+    if (auto fa =
+            std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(k)) {
+      joinKeyNames.insert(fa->name());
+    }
+  }
+  for (const auto& k : rightKeys_) {
+    if (auto fa =
+            std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(k)) {
+      joinKeyNames.insert(fa->name());
+    }
+  }
+
+  // If semi-project, temporarily strip trailing match column; we’ll re-append
+  // it last.
+  const bool semiProject = isLeftSemiProjectJoin() || isRightSemiProjectJoin();
+  std::optional<std::string> matchName;
+  int take = oldOutput->size();
+  if (semiProject) {
+    VELOX_CHECK_GT(take, 0);
+    const int matchIdx = take - 1;
+    VELOX_CHECK_EQ(oldOutput->childAt(matchIdx), BOOLEAN());
+    matchName = oldOutput->nameOf(matchIdx);
+    take = matchIdx; // seed without the match flag
+  }
+
+  // Seed with existing output (preserve order & names); update type if widened
+  // upstream.
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  names.reserve(oldOutput->size() + 8);
+  types.reserve(oldOutput->size() + 8);
+
+  folly::F14FastSet<std::string> seen;
+  for (int i = 0; i < take; ++i) {
+    const auto& n = oldOutput->nameOf(i);
+    auto t = oldOutput->childAt(i);
+    if (auto it = newFields.find(n); it != newFields.end()) {
+      t = it->second; // reflect upstream type change if any
+    }
+    names.push_back(n);
+    types.push_back(t);
+    seen.insert(n);
+  }
+
+  // Append *new* fields from allowed sides, but skip pure join keys
+  // that were not previously visible in oldOutput.
+  auto appendMissingFrom = [&](const RowTypePtr& row, bool allowed) {
+    if (!allowed)
+      return;
+    for (int i = 0; i < row->size(); ++i) {
+      const auto& n = row->nameOf(i);
+      if (!seen.contains(n) && !joinKeyNames.contains(n)) {
+        names.push_back(n);
+        types.push_back(row->childAt(i));
+        seen.insert(n);
+      }
+    }
+  };
+  appendMissingFrom(newLeft, allowLeft);
+  appendMissingFrom(newRight, allowRight);
+
+  // Re-append the semi-project match flag (BOOLEAN) as the very last column.
+  if (matchName.has_value()) {
+    VELOX_CHECK(
+        !seen.contains(*matchName),
+        "Semi-project match column '{}' collides with child columns",
+        *matchName);
+    names.push_back(*matchName);
+    types.push_back(BOOLEAN());
+  }
+
+  return ROW(std::move(names), std::move(types));
 }
 
 void IndexLookupJoinNode::accept(
@@ -2064,6 +2393,21 @@ PlanNodePtr NestedLoopJoinNode::create(
       outputType);
 }
 
+PlanNodePtr NestedLoopJoinNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 2);
+
+  auto updatedOutput =
+      recomputeOutputTypeFromSources(outputType_, sources_, newSources);
+
+  Builder builder(*this);
+  builder.left(std::move(newSources[0]))
+      .right(std::move(newSources[1]))
+      .outputType(std::move(updatedOutput));
+  ;
+  return builder.build();
+}
+
 AssignUniqueIdNode::AssignUniqueIdNode(
     const PlanNodeId& id,
     const std::string& idName,
@@ -2107,6 +2451,14 @@ PlanNodePtr AssignUniqueIdNode::create(
       obj["idName"].asString(),
       obj["taskUniqueId"].asInt(),
       std::move(source));
+}
+
+PlanNodePtr AssignUniqueIdNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
 }
 
 namespace {
@@ -2376,6 +2728,14 @@ PlanNodePtr WindowNode::create(const folly::dynamic& obj, void* context) {
       source);
 }
 
+PlanNodePtr WindowNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 RowTypePtr getMarkDistinctOutputType(
     const RowTypePtr& inputType,
     const std::string& markerName) {
@@ -2423,6 +2783,14 @@ PlanNodePtr MarkDistinctNode::create(const folly::dynamic& obj, void* context) {
 
   return std::make_shared<MarkDistinctNode>(
       deserializePlanNodeId(obj), markerName, distinctKeys, source);
+}
+
+PlanNodePtr MarkDistinctNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
 }
 
 EnforceDistinctNode::EnforceDistinctNode(
@@ -2600,6 +2968,14 @@ PlanNodePtr RowNumberNode::create(const folly::dynamic& obj, void* context) {
       source);
 }
 
+PlanNodePtr RowNumberNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 namespace {
 std::unordered_map<TopNRowNumberNode::RankFunction, std::string>
 rankFunctionNames() {
@@ -2741,6 +3117,14 @@ PlanNodePtr TopNRowNumberNode::create(
       source);
 }
 
+PlanNodePtr TopNRowNumberNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 void LocalMergeNode::addDetails(std::stringstream& stream) const {
   addSortingKeys(sortingKeys_, sortingOrders_, stream);
 }
@@ -2769,6 +3153,14 @@ PlanNodePtr LocalMergeNode::create(const folly::dynamic& obj, void* context) {
       std::move(sortingKeys),
       std::move(sortingOrders),
       std::move(sources));
+}
+
+PlanNodePtr LocalMergeNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.sources(std::move(newSources));
+  return builder.build();
 }
 
 void TableWriteNode::addDetails(std::stringstream& stream) const {
@@ -2888,6 +3280,14 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       deserializeSingleSource(obj, context));
 }
 
+PlanNodePtr TableWriteNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 void TableWriteMergeNode::addDetails(std::stringstream& /* stream */) const {}
 
 folly::dynamic TableWriteMergeNode::serialize() const {
@@ -2922,6 +3322,14 @@ PlanNodePtr TableWriteMergeNode::create(
       outputType,
       std::move(columnStatsSpec),
       deserializeSingleSource(obj, context));
+}
+
+PlanNodePtr TableWriteMergeNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
 }
 
 MergeExchangeNode::MergeExchangeNode(
@@ -2971,6 +3379,19 @@ PlanNodePtr MergeExchangeNode::create(
       serdeKind);
 }
 
+PlanNodePtr MergeExchangeNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  //  VELOX_CHECK_EQ(newSources.size(), 1);
+
+  // TODO: sortingKeys_ and outputType_ need to be constructed from newSources.
+  // All inputs must share the same schema; use the first one.
+  auto newOutputType = newSources[0]->outputType();
+
+  Builder builder(*this);
+  builder.outputType(std::move(newOutputType));
+  return builder.build();
+}
+
 void LocalPartitionNode::addDetails(std::stringstream& stream) const {
   stream << toName(type_);
   if (type_ != Type::kGather) {
@@ -3006,6 +3427,33 @@ PlanNodePtr LocalPartitionNode::create(
       ISerializable::deserialize<PartitionFunctionSpec>(
           obj["partitionFunctionSpec"], context),
       deserializeSources(obj, context));
+}
+
+PlanNodePtr LocalPartitionNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK(!newSources.empty());
+  VELOX_CHECK_EQ(newSources.size(), sources_.size());
+
+  Builder builder(*this);
+  builder.sources(newSources);
+
+  // Only repartition cares about a partition function / key channels.
+  if (type_ == Type::kRepartition && partitionFunctionSpec_ != nullptr) {
+    auto oldInputType =
+        std::dynamic_pointer_cast<const RowType>(sources_[0]->outputType());
+    auto newInputType =
+        std::dynamic_pointer_cast<const RowType>(newSources[0]->outputType());
+
+    // If either is not a RowType (shouldn't really happen), just bail out.
+    if (oldInputType && newInputType && *oldInputType != *newInputType) {
+      if (auto rewritten = partitionFunctionSpec_->rewriteInputType(
+              oldInputType, newInputType)) {
+        builder.partitionFunctionSpec(std::move(rewritten));
+      }
+    }
+  }
+
+  return builder.build();
 }
 
 namespace {
@@ -3141,6 +3589,14 @@ PlanNodePtr EnforceSingleRowNode::create(
       deserializePlanNodeId(obj), deserializeSingleSource(obj, context));
 }
 
+PlanNodePtr EnforceSingleRowNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 namespace {
 const auto& partitionKindNames() {
   static const folly::F14FastMap<PartitionedOutputNode::Kind, std::string_view>
@@ -3212,6 +3668,20 @@ PlanNodePtr PartitionedOutputNode::create(
       deserializeRowType(obj["outputType"]),
       VectorSerde::kindByName(obj["serdeKind"].asString()),
       deserializeSingleSource(obj, context));
+}
+
+PlanNodePtr PartitionedOutputNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  // In this case, the output type is the same as the source's. But we don't
+  // expect the type to be changed so commenting this line out
+  //  auto newOutputType = newSources[0]->outputType();
+
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  // The order may defer, so we will keep using the original output type.
+  //      .outputType(std::move(newOutputType));
+  return builder.build();
 }
 
 SpatialJoinNode::SpatialJoinNode(
@@ -3331,6 +3801,15 @@ PlanNodePtr SpatialJoinNode::create(const folly::dynamic& obj, void* context) {
       outputType);
 }
 
+PlanNodePtr SpatialJoinNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 2);
+
+  Builder builder(*this);
+  builder.left(std::move(newSources[0])).right(std::move(newSources[1]));
+  return builder.build();
+}
+
 TopNNode::TopNNode(
     const PlanNodeId& id,
     const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
@@ -3400,6 +3879,14 @@ PlanNodePtr TopNNode::create(const folly::dynamic& obj, void* context) {
       std::move(source));
 }
 
+PlanNodePtr TopNNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 void LimitNode::addDetails(std::stringstream& stream) const {
   if (isPartial_) {
     stream << "PARTIAL ";
@@ -3436,6 +3923,14 @@ PlanNodePtr LimitNode::create(const folly::dynamic& obj, void* context) {
       std::move(source));
 }
 
+PlanNodePtr LimitNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
+}
+
 void OrderByNode::addDetails(std::stringstream& stream) const {
   if (isPartial_) {
     stream << "PARTIAL ";
@@ -3469,6 +3964,14 @@ PlanNodePtr OrderByNode::create(const folly::dynamic& obj, void* context) {
       std::move(sortingOrders),
       obj["partial"].asBool(),
       std::move(source));
+}
+
+PlanNodePtr OrderByNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder(*this);
+  builder.source(newSources[0]);
+  return builder.build();
 }
 
 void MarkDistinctNode::addDetails(std::stringstream& stream) const {
@@ -3709,6 +4212,11 @@ folly::dynamic PlanNode::serialize() const {
   return obj;
 }
 
+PlanNodePtr PlanNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_UNSUPPORTED("copyWithNewSources is not implemented for {}", name());
+}
+
 const std::vector<PlanNodePtr>& TraceScanNode::sources() const {
   return kEmptySources;
 }
@@ -3784,6 +4292,14 @@ PlanNodePtr FilterNode::create(const folly::dynamic& obj, void* context) {
   auto filter = ISerializable::deserialize<ITypedExpr>(obj["filter"], context);
   return std::make_shared<FilterNode>(
       deserializePlanNodeId(obj), filter, std::move(source));
+}
+
+PlanNodePtr FilterNode::copyWithNewSources(
+    std::vector<PlanNodePtr> newSources) const {
+  VELOX_CHECK_EQ(newSources.size(), 1);
+  Builder builder;
+  builder.id(id()).filter(filter_).source(newSources[0]);
+  return builder.build();
 }
 
 folly::dynamic IndexLookupCondition::serialize() const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -152,6 +152,9 @@ struct PlanSummaryOptions {
   AggregateOptions aggregate = {};
 };
 
+class PlanNode;
+using PlanNodePtr = std::shared_ptr<const PlanNode>;
+
 class PlanNode : public ISerializable {
  public:
   explicit PlanNode(PlanNodeId id) : id_{std::move(id)} {}
@@ -170,6 +173,9 @@ class PlanNode : public ISerializable {
 
   virtual const std::vector<std::shared_ptr<const PlanNode>>& sources()
       const = 0;
+
+  virtual PlanNodePtr copyWithNewSources(
+      std::vector<std::shared_ptr<const PlanNode>> newSources) const;
 
   /// Accepts a visitor to visit this plan node.
   /// Implementations of this class should implement it as
@@ -320,8 +326,6 @@ class PlanNode : public ISerializable {
 
   const PlanNodeId id_;
 };
-
-using PlanNodePtr = std::shared_ptr<const PlanNode>;
 
 class ValuesNode : public PlanNode {
  public:
@@ -695,6 +699,9 @@ class FilterNode : public PlanNode {
     return sources_;
   }
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
   void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
       const override;
 
@@ -886,6 +893,9 @@ class ProjectNode : public AbstractProjectNode {
       const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 };
 
 using ProjectNodePtr = std::shared_ptr<const ProjectNode>;
@@ -911,6 +921,47 @@ class ParallelProjectNode : public core::AbstractProjectNode {
       std::vector<std::string> noLoadIdentities,
       core::PlanNodePtr input);
 
+  class Builder
+      : public AbstractProjectNode::Builder<ParallelProjectNode, Builder> {
+   public:
+    Builder() : AbstractProjectNode::Builder<ParallelProjectNode, Builder>() {}
+
+    explicit Builder(const ParallelProjectNode& other)
+        : AbstractProjectNode::Builder<ParallelProjectNode, Builder>(other) {}
+
+    Builder& exprNames(std::vector<std::string> exprNames) {
+      exprNames_ = std::move(exprNames);
+      return static_cast<Builder&>(*this);
+    }
+
+    Builder& exprGroups(
+        std::vector<std::vector<core::TypedExprPtr>> exprGroups) {
+      exprGroups_ = std::move(exprGroups);
+      return static_cast<Builder&>(*this);
+    }
+
+    Builder& noLoadIdentities(std::vector<std::string> noLoadIdentities) {
+      noLoadIdentities_ = std::move(noLoadIdentities);
+      return static_cast<Builder&>(*this);
+    }
+
+    std::shared_ptr<ProjectNode> build() const {
+      VELOX_USER_CHECK(id_.has_value(), "ProjectNode id is not set");
+      VELOX_USER_CHECK(names_.has_value(), "ProjectNode names is not set");
+      VELOX_USER_CHECK(
+          projections_.has_value(), "ProjectNode projections is not set");
+      VELOX_USER_CHECK(source_.has_value(), "ProjectNode source is not set");
+
+      return std::make_shared<ProjectNode>(
+          id_.value(), names_.value(), projections_.value(), source_.value());
+    }
+
+   private:
+    std::vector<std::string> exprNames_;
+    std::vector<std::vector<core::TypedExprPtr>> exprGroups_;
+    std::vector<std::string> noLoadIdentities_;
+  };
+
   std::string_view name() const override {
     return "ParallelProject";
   }
@@ -933,6 +984,9 @@ class ParallelProjectNode : public core::AbstractProjectNode {
       const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -963,6 +1017,9 @@ class LazyDereferenceNode : public core::ProjectNode {
   }
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 };
 
 using ParallelProjectNodePtr = std::shared_ptr<const ParallelProjectNode>;
@@ -1368,6 +1425,9 @@ class AggregationNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   static const std::vector<vector_size_t> kDefaultGlobalGroupingSets;
   static const std::optional<FieldAccessTypedExprPtr> kDefaultGroupId;
@@ -1674,6 +1734,9 @@ class TableWriteNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -1793,6 +1856,9 @@ class TableWriteMergeNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -1897,6 +1963,9 @@ class ExpandNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -2059,6 +2128,9 @@ class GroupIdNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -2259,6 +2331,9 @@ class MergeExchangeNode : public ExchangeNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -2366,6 +2441,9 @@ class LocalMergeNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -2404,6 +2482,18 @@ class PartitionFunctionSpec : public ISerializable {
   virtual ~PartitionFunctionSpec() = default;
 
   virtual std::string toString() const = 0;
+
+  /// NEW: called when the input RowType of the LocalPartition changes
+  /// (e.g. cast-pushdown added new columns or reordered columns).
+  ///
+  /// Implementations that depend on input column indices (hash keys,
+  /// bucket channels, etc.) can return a new adjusted spec.
+  /// Default: return nullptr meaning "no change needed".
+  virtual std::shared_ptr<PartitionFunctionSpec> rewriteInputType(
+      const RowTypePtr& /*oldInputType*/,
+      const RowTypePtr& /*newInputType*/) const {
+    return nullptr;
+  }
 };
 
 using PartitionFunctionSpecPtr = std::shared_ptr<const PartitionFunctionSpec>;
@@ -2587,6 +2677,9 @@ class LocalPartitionNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -2815,6 +2908,9 @@ class PartitionedOutputNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -3117,6 +3213,9 @@ class AbstractJoinNode : public PlanNode {
 
   folly::dynamic serializeBase() const;
 
+  RowTypePtr recomputeOutputTypeForNewSources(
+      const std::vector<PlanNodePtr>& newSources) const;
+
   const JoinType joinType_;
   const std::vector<FieldAccessTypedExprPtr> leftKeys_;
   const std::vector<FieldAccessTypedExprPtr> rightKeys_;
@@ -3258,9 +3357,27 @@ class HashJoinNode : public AbstractJoinNode {
     return useHashTableCache_;
   }
 
+  bool updateKeys(std::map<std::string, TypePtr> updatedOutputTypes) {
+    bool updated = false;
+    for (auto& key : leftKeys_) {
+      auto it = updatedOutputTypes.find(key->name());
+      if (it != updatedOutputTypes.end()) {
+        updated = true;
+        printf(
+            "Update left join key %s to type %s\n",
+            key->name().c_str(),
+            it->second->toString().c_str());
+      }
+    }
+    return updated;
+  }
+
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -3339,6 +3456,9 @@ class MergeJoinNode : public AbstractJoinNode {
   static bool isSupported(JoinType joinType);
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 };
 
 using MergeJoinNodePtr = std::shared_ptr<const MergeJoinNode>;
@@ -3616,6 +3736,9 @@ class IndexLookupJoinNode : public AbstractJoinNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
   /// Returns true if the lookup join supports this join type, otherwise false.
   static bool isSupported(JoinType joinType);
 
@@ -3768,6 +3891,9 @@ class NestedLoopJoinNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   static const JoinType kDefaultJoinType;
   static const TypedExprPtr kDefaultJoinCondition;
@@ -3913,6 +4039,9 @@ class OrderByNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -4129,6 +4258,9 @@ class SpatialJoinNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   constexpr static JoinType kDefaultJoinType = JoinType::kInner;
 
@@ -4262,6 +4394,9 @@ class TopNNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -4392,6 +4527,9 @@ class LimitNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -4570,6 +4708,9 @@ class UnnestNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -4646,6 +4787,9 @@ class EnforceSingleRowNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -4755,6 +4899,9 @@ class AssignUniqueIdNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -4992,6 +5139,9 @@ class WindowNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -5134,6 +5284,9 @@ class RowNumberNode : public PlanNode {
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -5245,6 +5398,9 @@ class MarkDistinctNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -5519,6 +5675,9 @@ class TopNRowNumberNode : public PlanNode {
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  PlanNodePtr copyWithNewSources(
+      std::vector<PlanNodePtr> newSources) const override;
 
  private:
   void addDetails(std::stringstream& stream) const override;

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -843,6 +843,9 @@ class QueryConfig {
   static constexpr const char* kJoinBuildVectorHasherMaxNumDistinct =
       "join_build_vector_hasher_max_num_distinct";
 
+  static constexpr const char* kPushdownIntegerUpcastsToSource =
+      "pushdown_integer_upcasts_to_source";
+
   enum class RowSizeTrackingMode {
     DISABLED = 0,
     EXCLUDE_DELTA_SPLITS = 1,
@@ -1502,6 +1505,10 @@ class QueryConfig {
 
   uint32_t joinBuildVectorHasherMaxNumDistinct() const {
     return get<uint32_t>(kJoinBuildVectorHasherMaxNumDistinct, 1'000'000);
+  }
+
+  bool pushdownIntegerUpcastsToSource() const {
+    return get<bool>(kPushdownIntegerUpcastsToSource, false);
   }
 
   template <typename T>

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -80,7 +80,23 @@ Exchange::Exchange(
           serdeKind_)},
       processSplits_{operatorCtx_->driverCtx()->driverId == 0},
       driverId_{driverCtx->driverId},
-      exchangeClient_{std::move(exchangeClient)} {}
+      pushDownCasts_{driverCtx->queryConfig().pushdownIntegerUpcastsToSource()},
+      exchangeClient_{std::move(exchangeClient)} {
+  std::vector<std::string> outputNames;
+  std::vector<TypePtr> outputTypes;
+
+  for (int i = 0; i < outputType_->size(); ++i) {
+    const auto& columnName = outputType_->nameOf(i);
+    const auto& columnType = outputType_->childAt(i);
+
+    if (pushDownCasts_ && columnName.ends_with("_upcast")) {
+      continue;
+    }
+    outputNames.push_back(columnName);
+    outputTypes.push_back(columnType);
+  }
+  outputTypeWithoutUpcasts_ = ROW(outputNames, outputTypes);
+}
 
 void Exchange::addRemoteTaskIds(std::vector<std::string>& remoteTaskIds) {
   std::shuffle(std::begin(remoteTaskIds), std::end(remoteTaskIds), rng_);
@@ -134,7 +150,8 @@ BlockingReason Exchange::isBlocked(ContinueFuture* future) {
     return BlockingReason::kNotBlocked;
   }
 
-  // Start fetching data right away. Do not wait for all splits to be available.
+  // Start fetching data right away. Do not wait for all splits to be
+  // available.
   if (!splitFuture_.valid()) {
     getSplits(&splitFuture_);
   }
@@ -175,9 +192,20 @@ bool Exchange::isFinished() {
 RowVectorPtr Exchange::getOutput() {
   auto* serde = getSerde();
   if (serde->supportsAppendInDeserialize()) {
-    return getOutputFromColumnarPages(serde);
+    resultWithoutUpcasts_ = getOutputFromColumnarPages(serde);
+  } else {
+    resultWithoutUpcasts_ = getOutputFromRowPages(serde);
   }
-  return getOutputFromRowPages(serde);
+
+  if (resultWithoutUpcasts_ && resultWithoutUpcasts_->size() > 0 &&
+      pushDownCasts_ &&
+      outputTypeWithoutUpcasts_->size() < outputType_->size()) {
+    widenResults();
+  } else {
+    result_ = resultWithoutUpcasts_;
+  }
+
+  return result_;
 }
 
 RowVectorPtr Exchange::getOutputFromColumnarPages(VectorSerde* serde) {
@@ -195,12 +223,13 @@ RowVectorPtr Exchange::getOutputFromColumnarPages(VectorSerde* serde) {
       : kInitialOutputRows;
 
   // Process pages one-by-one from currentPages_ pointed by columnarPageIdx_.
-  // Within each page, deserialize vectors incrementally until we hit the target
-  // batch size.
+  // Within each page, deserialize vectors incrementally until we hit the
+  // target batch size.
   uint64_t rawInputBytes = 0;
   vector_size_t resultOffset{0};
 
-  // Should be either starting fresh or continuing from a previous partial page
+  // Should be either starting fresh or continuing from a previous partial
+  // page
   VELOX_CHECK(
       inputStream_ == nullptr || columnarPageIdx_ < currentPages_.size());
 
@@ -223,14 +252,15 @@ RowVectorPtr Exchange::getOutputFromColumnarPages(VectorSerde* serde) {
       serde->deserialize(
           inputStream_.get(),
           pool(),
-          outputType_,
-          &result_,
+          outputTypeWithoutUpcasts_,
+          &resultWithoutUpcasts_,
           resultOffset,
           serdeOptions_.get());
 
-      resultOffset = result_->size();
+      resultOffset = resultWithoutUpcasts_->size();
     }
 
+    // If page is fully consumed
     if (inputStream_->atEnd()) {
       // Page is fully consumed, free memory immediately, and move to the next.
       inputStream_ = nullptr;
@@ -244,11 +274,11 @@ RowVectorPtr Exchange::getOutputFromColumnarPages(VectorSerde* serde) {
     }
   }
 
-  const auto numOutputRows = result_->size();
+  const auto numOutputRows = resultWithoutUpcasts_->size();
   VELOX_CHECK_GT(numOutputRows, 0);
 
   estimatedRowSize_ = std::max(
-      result_->estimateFlatSize() / numOutputRows,
+      resultWithoutUpcasts_->estimateFlatSize() / numOutputRows,
       estimatedRowSize_.value_or(1L));
 
   // If processed all pages, clear the vector and reset state.
@@ -259,7 +289,7 @@ RowVectorPtr Exchange::getOutputFromColumnarPages(VectorSerde* serde) {
   }
 
   recordInputStats(rawInputBytes);
-  return result_;
+  return resultWithoutUpcasts_;
 }
 
 RowVectorPtr Exchange::getOutputFromRowPages(VectorSerde* serde) {
@@ -290,16 +320,22 @@ RowVectorPtr Exchange::getOutputFromRowPages(VectorSerde* serde) {
       inputStream_.get(),
       rowIterator_,
       numRows,
-      outputType_,
-      &result_,
+      outputTypeWithoutUpcasts_,
+      &resultWithoutUpcasts_,
       pool(),
       serdeOptions_.get());
 
-  const auto numOutputRows = result_->size();
+//  VLOG(2)
+//      << "Exchange::getOutputFromRowPages with "
+//      << resultWithoutUpcasts_->size() << " rows, type "
+//      << resultWithoutUpcasts_->type()->kind() << " value:"
+//      << resultWithoutUpcasts_->childAt(0)->asFlatVector<int64_t>()->valueAt(0);
+
+  const auto numOutputRows = resultWithoutUpcasts_->size();
   VELOX_CHECK_GT(numOutputRows, 0);
 
   estimatedRowSize_ = std::max(
-      result_->estimateFlatSize() / numOutputRows,
+      resultWithoutUpcasts_->estimateFlatSize() / numOutputRows,
       estimatedRowSize_.value_or(1L));
 
   if (inputStream_->atEnd() && rowIterator_ == nullptr) {
@@ -312,20 +348,21 @@ RowVectorPtr Exchange::getOutputFromRowPages(VectorSerde* serde) {
   }
 
   recordInputStats(rawInputBytes);
-  return result_;
+  return resultWithoutUpcasts_;
 }
 
 void Exchange::recordInputStats(uint64_t rawInputBytes) {
   auto lockedStats = stats_.wlock();
   lockedStats->rawInputBytes += rawInputBytes;
   lockedStats->rawInputPositions += result_->size();
-  lockedStats->addInputVector(result_->estimateFlatSize(), result_->size());
+  lockedStats->addInputVector(resultWithoutUpcasts_->estimateFlatSize(), result_->size());
 }
 
 void Exchange::close() {
   SourceOperator::close();
   currentPages_.clear();
   result_ = nullptr;
+  resultWithoutUpcasts_ = nullptr;
 
   // Clean up stateful deserialization state
   inputStream_ = nullptr;
@@ -374,6 +411,53 @@ void Exchange::recordExchangeClientStats() {
 
 VectorSerde* Exchange::getSerde() {
   return getNamedVectorSerde(serdeKind_);
+}
+
+void Exchange::widenResults() {
+  auto rowVector = resultWithoutUpcasts_->asUnchecked<RowVector>();
+
+  // find the upcast columns and add them to result_
+  std::vector<VectorPtr> outputColumns;
+  outputColumns.reserve(outputType_->size());
+
+  for (int i = 0; i < outputType_->size(); ++i) {
+    const auto& columnName = outputType_->nameOf(i);
+    if (columnName.ends_with("_upcast")) {
+      auto originalOutputName =
+          columnName.substr(0, columnName.size() - strlen("_upcast"));
+
+      auto index =
+          outputTypeWithoutUpcasts_->getChildIdxIfExists(originalOutputName);
+      VELOX_CHECK(index.has_value());
+      auto originalColumn = rowVector->childAt(*index);
+
+      std::shared_ptr<BaseVector> casted = nullptr;
+      if (!result_ || result_.use_count() > 1 ||
+          result_->childAt(i)->size() < rowVector->size()) {
+        casted = BaseVector::create(
+            outputType_->childAt(i), originalColumn->size(), pool());
+      } else {
+        // Reuse the original column vector if possible to reduce memory
+        // usage.
+        casted = result_->childAt(i);
+      }
+      casted->copy(originalColumn.get(), 0, 0, originalColumn->size());
+      outputColumns.push_back(casted);
+
+    } else {
+      auto index = outputTypeWithoutUpcasts_->getChildIdxIfExists(columnName);
+      VELOX_CHECK(index.has_value());
+      auto originalColumn = rowVector->childAt(*index);
+      outputColumns.push_back(originalColumn);
+    }
+  }
+
+  result_ = std::make_shared<RowVector>(
+      pool(),
+      outputType_,
+      resultWithoutUpcasts_->nulls(),
+      resultWithoutUpcasts_->size(),
+      std::move(outputColumns));
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/serialization/Serializable.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
+#include "velox/expression/PrestoCastHooks.h"
 #include "velox/serializers/CompactRowSerializer.h"
 
 namespace facebook::velox::exec {
@@ -441,7 +442,47 @@ void Exchange::widenResults() {
         // usage.
         casted = result_->childAt(i);
       }
-      casted->copy(originalColumn.get(), 0, 0, originalColumn->size());
+      if (isWideningIntegerType(originalColumn->type(), casted->type())) {
+        casted->copy(originalColumn.get(), 0, 0, originalColumn->size());
+      } else if (originalColumn->type()->isDate() && casted->type()->isTimestamp()) {
+        auto targetChildFlatVector = casted->asFlatVector<Timestamp>();
+        const velox::DecodedVector decodedOriginalVector(*originalColumn);
+        static const int64_t kMillisPerDay{86'400'000};
+        const tz::TimeZone* timeZone = nullptr;
+
+        if (operatorCtx_->driverCtx()->queryConfig().adjustTimestampToTimezone()) {
+          const auto sessionTzName = operatorCtx_->driverCtx()->queryConfig().sessionTimezone();
+          if (!sessionTzName.empty()) {
+            timeZone = tz::locateZone(sessionTzName);
+          }
+        }
+
+        for (vector_size_t j = 0; j < originalColumn->size(); ++j) {
+          const auto decodedIndex = decodedOriginalVector.index(j);
+          VLOG(2) << "Copying value at index " << j;
+          VLOG(2) << "DateToTimestamp: Value at index " << j << " is " << decodedOriginalVector.valueAt<int32_t>(decodedIndex);
+          auto timestamp = Timestamp::fromMillis(
+              decodedOriginalVector.valueAt<int32_t>(decodedIndex) * kMillisPerDay);
+          if (timeZone) {
+            VLOG(2) << "Timezone is " << timeZone->name();
+            timestamp.toGMT(*timeZone);
+          }
+          targetChildFlatVector->set(j, timestamp);
+        }
+      } else if (originalColumn->type()->isVarchar() && casted->type()->isTimestamp()) {
+        const exec::PrestoCastHooks hooks(operatorCtx_->driverCtx()->queryConfig().isLegacyCast(),
+                                          operatorCtx_->driverCtx()->queryConfig().adjustTimestampToTimezone(),
+                                          operatorCtx_->driverCtx()->queryConfig().sessionTimezone());
+        auto targetChildFlatVector = casted->asFlatVector<Timestamp>();
+        const velox::DecodedVector decodedOriginalVector(*originalColumn);
+
+        for (vector_size_t j = 0; j < originalColumn->size(); ++j) {
+          const auto decodedIndex = decodedOriginalVector.index(j);
+          VLOG(2) << "Copying value at index " << j;
+          VLOG(2) << "StringToTimestamp: Value at index " << j << " is " << decodedOriginalVector.valueAt<StringView>(decodedIndex);
+          targetChildFlatVector->set(j, hooks.castStringToTimestamp(decodedOriginalVector.valueAt<StringView>(decodedIndex)).value());
+        }
+      }
       outputColumns.push_back(casted);
 
     } else {

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -66,8 +66,9 @@ class Exchange : public SourceOperator {
 
  protected:
   virtual VectorSerde* getSerde();
+  void widenResults();
 
-  // When 'estimatedRowSize_' is unset, meaning we haven't materialized
+      // When 'estimatedRowSize_' is unset, meaning we haven't materialized
   // and returned any output from this exchange operator, we return this
   // conservative number of output rows, to make sure memory does not grow too
   // much.
@@ -94,6 +95,8 @@ class Exchange : public SourceOperator {
 
   RowVectorPtr getOutputFromRowPages(VectorSerde* serde);
 
+  RowTypePtr outputTypeWithoutUpcasts_;
+
   const uint64_t preferredOutputBatchBytes_;
 
   const VectorSerde::Kind serdeKind_;
@@ -108,6 +111,8 @@ class Exchange : public SourceOperator {
 
   bool noMoreSplits_ = false;
 
+  bool pushDownCasts_ = false;
+
   std::shared_ptr<ExchangeClient> exchangeClient_;
 
   // A future received from Task::getSplitOrFuture(). It will be complete when
@@ -116,6 +121,7 @@ class Exchange : public SourceOperator {
 
   // Reusable result vector.
   RowVectorPtr result_;
+  RowVectorPtr resultWithoutUpcasts_;
 
   std::vector<std::unique_ptr<SerializedPageBase>> currentPages_;
   bool atEnd_{false};

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -159,7 +159,6 @@ class GroupingSet {
   }
 
   std::optional<int64_t> estimateOutputRowSize() const;
-
  private:
   bool isDistinct() const {
     return aggregates_.empty();

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -349,6 +349,14 @@ RowVectorPtr HashAggregation::getOutput() {
   // - running in partial streaming mode and have some output ready.
   if (!noMoreInput_ && !partialFull_ && !newDistincts_ &&
       !groupingSet_->hasOutput()) {
+//    VLOG(2) << "HashAggregation::getOutput no output ready yet. groupingSet_:"
+//              << groupingSet_.get() << " noMoreInput_:" << noMoreInput_
+//              << " partialFull_:" << partialFull_
+//              << " newDistincts_:" << newDistincts_
+//              << " hasOutput():" << groupingSet_->hasOutput()
+//              << " groupingSet_->noMoreInput_:" << groupingSet_->noMoreInput_
+//              << " groupingSet_->remainingInput_:"
+//              << groupingSet_->remainingInput_;
     input_ = nullptr;
     return nullptr;
   }
@@ -377,6 +385,10 @@ RowVectorPtr HashAggregation::getOutput() {
     return nullptr;
   }
   numOutputRows_ += output_->size();
+
+//  VLOG(2) << "HashAggregation::getOutput produced " << output_->size()
+//            << " rows"
+//            << output_->childAt(0)->asFlatVector<int64_t>()->valueAt(0);
   return output_;
 }
 
@@ -440,6 +452,7 @@ RowVectorPtr HashAggregation::getDistinctOutput() {
 }
 
 void HashAggregation::noMoreInput() {
+  VLOG(google::INFO) << "HashAggregation::noMoreInput called";
   updateEstimatedOutputRowSize();
   groupingSet_->noMoreInput();
   Operator::noMoreInput();

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -114,7 +114,6 @@ HashBuild::HashBuild(
   }
 
   tableType_ = hashJoinTableType(joinNode_);
-
   stateCleared_ = false;
 }
 
@@ -415,6 +414,11 @@ void HashBuild::addInput(RowVectorPtr input) {
       (cacheEntry_->builderTaskId == taskId() && !cacheEntry_->buildComplete));
 
   ensureInputFits(input);
+
+//  // Log input data type and size for debugging.
+//  VLOG(2) << "HashBuild addInput: "
+//          << " input data type: " << input->type()->toString()
+//          << " input size: " << input->size();
 
   TestValue::adjust("facebook::velox::exec::HashBuild::addInput", this);
 

--- a/velox/exec/HashPartitionFunction.cpp
+++ b/velox/exec/HashPartitionFunction.cpp
@@ -180,4 +180,52 @@ core::PartitionFunctionSpecPtr HashPartitionFunctionSpec::deserialize(
   return std::make_shared<HashPartitionFunctionSpec>(
       ISerializable::deserialize<RowType>(obj["inputType"]), keys, constValues);
 }
+
+std::shared_ptr<core::PartitionFunctionSpec> HashPartitionFunctionSpec::rewriteInputType(
+    const RowTypePtr& oldInputType,
+    const RowTypePtr& newInputType) const {
+  // If the layout is identical, no change.
+  if (*oldInputType == *newInputType && inputType_->equivalent(*newInputType)) {
+    return nullptr;
+  }
+
+  std::vector<column_index_t> newKeyChannels;
+  newKeyChannels.reserve(keyChannels_.size());
+  bool changed = false;
+
+  for (auto channel : keyChannels_) {
+    VELOX_CHECK_LT(
+        channel,
+        oldInputType->size(),
+        "Partition key channel index {} is out of bounds for old input type {}",
+        channel,
+        oldInputType->toString());
+
+    const auto& name = oldInputType->nameOf(channel);
+    auto newIndexOpt = newInputType->getChildIdxIfExists(name);
+    VELOX_USER_CHECK(
+        newIndexOpt.has_value(),
+        "Failed to find partition key column '{}' in LocalPartition new input type {}",
+        name,
+        newInputType->toString());
+
+    auto newIndex = static_cast<column_index_t>(*newIndexOpt);
+    newKeyChannels.push_back(newIndex);
+    if (newIndex != channel) {
+      changed = true;
+    }
+  }
+
+  // If indexes and type didn't really change, just keep the old spec.
+  if (!changed && inputType_->equivalent(*newInputType)) {
+    return nullptr;
+  }
+
+  // Build a new spec with updated inputType_ and keyChannels_.
+  return std::make_shared<HashPartitionFunctionSpec>(
+      newInputType,
+      std::move(newKeyChannels),
+      constValues_ /* unchanged */);
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/HashPartitionFunction.h
+++ b/velox/exec/HashPartitionFunction.h
@@ -95,6 +95,10 @@ class HashPartitionFunctionSpec : public core::PartitionFunctionSpec {
       const folly::dynamic& obj,
       void* context);
 
+ std::shared_ptr<core::PartitionFunctionSpec> rewriteInputType(
+     const RowTypePtr& oldInputType,
+     const RowTypePtr& newInputType) const override;
+
  private:
   const RowTypePtr inputType_;
   const std::vector<column_index_t> keyChannels_;

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -136,6 +136,33 @@ HashProbe::HashProbe(
       filterResult_(1),
       outputTableRowsCapacity_(outputBatchSize_) {
   VELOX_CHECK_NOT_NULL(joinBridge_);
+
+//  // Log outputType_ and probeType_ for debugging.
+//  VELOX_CHECK_NOT_NULL(outputType_);
+//  VELOX_CHECK_NOT_NULL(probeType_);
+//  // log PlanNodeId for debugging.
+//
+//  // log join keys for debugging.
+//  std::vector<std::string> leftKeyNames;
+//  for (const auto& key : joinNode_->leftKeys()) {
+//    leftKeyNames.push_back(key->name());
+//  }
+//  std::vector<std::string> rightKeyNames;
+//  for (const auto& key : joinNode_->rightKeys()) {
+//    rightKeyNames.push_back(key->name());
+//  }
+//
+//  VLOG(2) << "HashProbe planNodeId_: " << joinNode_->id()
+//          << " outputType_: " << outputType_->toString()
+//          << " probeType_: " << probeType_->toString()
+//          << " left keys: " << folly::join(", ", leftKeyNames)
+//          << " right keys: " << folly::join(", ", rightKeyNames)
+//          << " left source id " << joinNode_->sources()[0]->id()
+//          << " left output type: "
+//          << joinNode_->sources()[0]->outputType()->toString()
+//          << " right source id " << joinNode_->sources()[1]->id()
+//          << " right output type: "
+//          << joinNode_->sources()[1]->outputType()->toString();
 }
 
 void HashProbe::initialize() {
@@ -334,7 +361,7 @@ std::optional<uint64_t> HashProbe::estimatedRowSize(
 
 std::optional<RowColumn::Stats> HashProbe::columnStats(
     int32_t columnIndex) const {
-  std::vector<RowColumn::Stats> columnStats;
+   std::vector<RowColumn::Stats> columnStats;
   const auto rowContainers = table_->allRows();
   for (const auto* rowContainer : rowContainers) {
     VELOX_CHECK_NOT_NULL(rowContainer);
@@ -357,6 +384,7 @@ void HashProbe::initializeResultIter() {
   for (const auto& projection : tableOutputProjections_) {
     listColumns.push_back(projection.inputChannel);
   }
+
   std::vector<vector_size_t> varSizeListColumns;
   uint64_t fixedSizeListColumnsSizeSum{0};
   varSizeListColumns.reserve(tableOutputProjections_.size());

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -148,7 +148,7 @@ class HashProbe : public Operator {
   // arbitration.
   RowVectorPtr getOutputInternal(bool toSpillOutput);
 
-  // Check if output_ can be re-used and if not make a new one.
+  // Check if outputWithoutUpcasts_ can be re-used and if not make a new one.
   void prepareOutput(vector_size_t size);
 
   // Populate output columns.
@@ -157,7 +157,7 @@ class HashProbe : public Operator {
   // Populate 'match' output column for the left semi join project,
   void fillLeftSemiProjectMatchColumn(vector_size_t size);
 
-  // Clears the columns of 'output_' that are projected from
+  // Clears the columns of 'outputWithoutUpcasts_' that are projected from
   // 'input_'. This should be done when preparing to produce a next
   // batch of output to drop any lingering references to row
   // number mappings or input vectors. In this way input vectors do
@@ -277,7 +277,7 @@ class HashProbe : public Operator {
   // spill them on to disk in case the output is too large to fit in memory in
   // some edge case, like one input row has many matches with the build side.
   // The function returns true if it has read the spilled output and saves in
-  // 'output_'.
+  // 'outputWithoutUpcasts_'.
   bool maybeReadSpillOutput();
 
   // Invoked after finishes processing the probe inputs and there is spill data
@@ -500,7 +500,7 @@ class HashProbe : public Operator {
   // checked if there is a carryover.  Use a temporary buffer in this case.
   BufferPtr tempOutputRowMapping_;
 
-  // maps from column index in 'table_' to channel in 'output_'.
+  // maps from column index in 'table_' to channel in 'outputWithoutUpcasts_'.
   std::vector<IdentityProjection> tableOutputProjections_;
 
   // Rows of table found by join probe, later filtered by 'filter_'.

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -217,7 +217,7 @@ class IndexLookupJoin : public Operator {
   // for output rows without lookup matches.
   void prepareOutputRowMappings(size_t outputBatchSize);
 
-  // Prepare 'output_' for the next output batch with size of 'numOutputRows'.
+  // Prepare 'outputWithoutUpcasts_' for the next output batch with size of 'numOutputRows'.
   void prepareOutput(vector_size_t numOutputRows);
 
   // Invoked to ensure the match column is created to store the output match

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -263,6 +263,37 @@ bool isWideningIntegerCast(
   return false;
 }
 
+bool isWideningDateCast(const TypePtr& outputType, const TypePtr& inputType) {
+  if (outputType->isTimestamp() && inputType->isDate()) {
+    return true;
+  }
+  return false;
+}
+
+
+bool isVarcharToTimestampCast(const TypePtr& outputType, const TypePtr& inputType) {
+  if (outputType->isTimestamp() && inputType->isVarchar()) {
+    return true;
+  }
+  return false;
+}
+
+bool isWideningCastOperation(const TypePtr& outputType, const TypePtr& inputType) {
+  return isWideningIntegerCast(outputType, inputType) || isWideningDateCast(outputType, inputType) || isVarcharToTimestampCast(outputType, inputType);
+}
+
+bool isWideningCastOperation(const core::ITypedExpr& expr) {
+  if (!expr.isCastKind()) {
+    return false;
+  }
+  auto inputExpr = expr.inputs()[0];
+  if (!inputExpr->isFieldAccessKind()) {
+    return false;
+  }
+  return isWideningCastOperation(expr.type(), inputExpr->type());
+}
+
+
 void plan(
     const PlanNodePtr& planNode,
     std::vector<PlanNodePtr>* currentPlanNodes,
@@ -330,7 +361,7 @@ PlanNodePtr rewriteProjectNode(
 
     // Case 1: replace by its input expression
     if (exprReplaceIdx.count(i)) {
-      VELOX_CHECK(isWideningIntegerCast(proj));
+      VELOX_CHECK(isWideningCastOperation(*proj));
       VELOX_CHECK_EQ(proj->inputs().size(), 1);
 
       auto field = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
@@ -530,7 +561,7 @@ NodeAnalysis preAnalyzeNode(const PlanNodePtr& node, ExprMap& exprsToPush) {
   for (int i = 0; i < names.size(); i++) {
     const auto& projection = exprs[i];
 
-    if (!isWideningIntegerCast(projection)) {
+    if (!isWideningCastOperation(*projection)) {
       continue;
     }
 

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "velox/exec/LocalPlanner.h"
+
+#include <set>
+
 #include "velox/core/PlanFragment.h"
 #include "velox/exec/ArrowStream.h"
 #include "velox/exec/AssignUniqueId.h"
@@ -58,6 +61,7 @@
 
 namespace facebook::velox::exec {
 
+
 namespace {
 
 // If the upstream is partial limit, downstream is final limit and we want to
@@ -77,10 +81,10 @@ bool eagerFlush(const core::PlanNode& node) {
 
 namespace detail {
 
+using PlanNodePtr = std::shared_ptr<const core::PlanNode>;
+
 /// Returns true if source nodes must run in a separate pipeline.
-bool mustStartNewPipeline(
-    const std::shared_ptr<const core::PlanNode>& planNode,
-    int sourceId) {
+bool mustStartNewPipeline(const PlanNodePtr& planNode, int sourceId) {
   if (auto localMerge =
           std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode)) {
     // LocalMerge's source runs on its own pipeline.
@@ -126,8 +130,7 @@ OperatorSupplier makeOperatorSupplier(ConsumerSupplier consumerSupplier) {
   return nullptr;
 }
 
-OperatorSupplier makeOperatorSupplier(
-    const std::shared_ptr<const core::PlanNode>& planNode) {
+OperatorSupplier makeOperatorSupplier(const PlanNodePtr& planNode) {
   if (auto localMerge =
           std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode)) {
     return [localMerge](int32_t operatorId, DriverCtx* ctx) {
@@ -248,10 +251,22 @@ OperatorSupplier makeOperatorSupplier(
   return Operator::operatorSupplierFromPlanNode(planNode);
 }
 
+bool isWideningIntegerCast(
+    const TypePtr& outputType,
+    const TypePtr& inputType) {
+  if (!isIntegral(outputType) || !isIntegral(inputType)) {
+    return false;
+  }
+  if (outputType->cppSizeInBytes() > inputType->cppSizeInBytes()) {
+    return true;
+  }
+  return false;
+}
+
 void plan(
-    const std::shared_ptr<const core::PlanNode>& planNode,
-    std::vector<std::shared_ptr<const core::PlanNode>>* currentPlanNodes,
-    const std::shared_ptr<const core::PlanNode>& consumerNode,
+    const PlanNodePtr& planNode,
+    std::vector<PlanNodePtr>* currentPlanNodes,
+    const PlanNodePtr& consumerNode,
     OperatorSupplier operatorSupplier,
     std::vector<std::unique_ptr<DriverFactory>>* driverFactories) {
   if (!currentPlanNodes) {
@@ -281,9 +296,303 @@ void plan(
   currentPlanNodes->push_back(planNode);
 }
 
+// Add upcast column (name + "_upcast") into names/types vectors.
+void addUpcastColumn(
+    const std::string& name,
+    const core::TypedExprPtr& expr,
+    std::vector<std::string>& names,
+    std::vector<TypePtr>& types) {
+  auto castExpr = std::dynamic_pointer_cast<const core::CastTypedExpr>(expr);
+  VELOX_CHECK(castExpr, "Expected CastTypedExpr for {}", name);
+
+  names.push_back(name + "_upcast");
+  types.push_back(castExpr->type());
+}
+
+PlanNodePtr rewriteProjectNode(
+    core::ProjectNodePtr projectNode,
+    ExprMap& castExprs,
+    const std::set<int>& exprReplaceIdx,
+    const std::vector<PlanNodePtr>& newSources) {
+  const auto& planNodeId = projectNode->id();
+  const auto& names = projectNode->names();
+  const auto& exprs = projectNode->projections();
+
+  std::vector<core::TypedExprPtr> newProjections;
+  newProjections.reserve(exprs.size() + castExprs.size());
+
+  std::vector<std::string> newNames;
+  newNames.reserve(names.size() + castExprs.size());
+
+  for (int i = 0; i < exprs.size(); i++) {
+    const auto& proj = exprs[i];
+    const auto& name = names[i];
+
+    // Case 1: replace by its input expression
+    if (exprReplaceIdx.count(i)) {
+      VELOX_CHECK(isWideningIntegerCast(proj));
+      VELOX_CHECK_EQ(proj->inputs().size(), 1);
+
+      auto field = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+          proj->inputs()[0]);
+      VELOX_CHECK(field);
+
+      // Note that field->name() is not necessarily equal to 'name' here. E.g.
+      // name = "expr_298", field->name() = "provider_id"
+      const auto upcastName = field->name() + "_upcast";
+
+      // Validate that the upcast column exists in the new source
+      const auto found = newSources[0]->outputType()->findChild(upcastName);
+      VELOX_CHECK(
+          found && found->equivalent(*proj->type()),
+          "Upcast type mismatch for '{}_upcast'",
+          field->name());
+
+      newProjections.push_back(
+          std::make_shared<core::FieldAccessTypedExpr>(
+              proj->type(), upcastName));
+      newNames.push_back(name);
+
+      // The replacement is done and downstream plan nodes don't need to change
+      // anymore. Remove this cast from the castExprs map
+      auto it = castExprs.find(field->name());
+      while (it != castExprs.end()) {
+        if (it->second.second == planNodeId) {
+          castExprs.erase(it);
+          break;
+        }
+        ++it;
+      }
+
+      continue;
+    }
+
+    // Case 2: keep original projection, e.g. provider_id
+    newProjections.push_back(proj);
+    newNames.push_back(name);
+
+    // Case 3: add upcast column if this is not case 1 but needs upcasting, e.g.
+    // provider_id_upcast
+    auto it = castExprs.find(name);
+    if (it != castExprs.end() && exprReplaceIdx.count(i) == 0) {
+      const std::string upName = name + "_upcast";
+      const auto& castExpr = it->second.first;
+      auto expectedType = castExpr->type();
+
+      const auto found = newSources[0]->outputType()->findChild(upName);
+      VELOX_CHECK(
+          found && found->equivalent(*expectedType),
+          "Upcast type mismatch for '{}'",
+          upName);
+
+      newProjections.push_back(
+          std::make_shared<core::FieldAccessTypedExpr>(expectedType, upName));
+      newNames.push_back(upName);
+    }
+  }
+
+  return std::make_shared<core::ProjectNode>(
+      projectNode->id(), newNames, newProjections, newSources[0]);
+}
+
+PlanNodePtr rewriteTableScanNode(
+    core::TableScanNodePtr scan,
+    const ExprMap& castExprs) {
+  if (castExprs.empty()) {
+    return scan;
+  }
+
+  const auto& type = scan->outputType();
+
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+
+  names.reserve(type->size() + castExprs.size());
+  types.reserve(type->size() + castExprs.size());
+
+  for (int i = 0; i < type->size(); i++) {
+    const auto& name = type->nameOf(i);
+    names.push_back(std::move(name));
+    types.push_back(std::move(type->childAt(i)));
+
+    if (auto it = castExprs.find(name); it != castExprs.end()) {
+      // It could have multiple widening casts on the same field name, but we
+      // only need to add it once.
+      addUpcastColumn(name, it->second.first, names, types);
+    }
+  }
+
+  auto newType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  core::TableScanNode::Builder builder(*scan);
+  return builder.outputType(newType).build();
+}
+
+PlanNodePtr rewriteExchangeNode(
+    core::ExchangeNodePtr exchangeNode,
+    const ExprMap& castExprs) {
+  if (castExprs.empty()) {
+    return exchangeNode;
+  }
+
+  const auto& type = exchangeNode->outputType();
+
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+
+  names.reserve(type->size() + castExprs.size());
+  types.reserve(type->size() + castExprs.size());
+
+  for (int i = 0; i < type->size(); i++) {
+    const auto& name = type->nameOf(i);
+    names.push_back(std::move(name));
+    types.push_back(std::move(type->childAt(i)));
+
+    if (auto it = castExprs.find(name); it != castExprs.end()) {
+      addUpcastColumn(name, it->second.first, names, types);
+      //      VLOG(2) << "Insert new column: " << names.back() << " with type "
+      //              << type->childAt(i) << " to TableScanNode.";
+    }
+  }
+
+  auto newType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  core::ExchangeNode::Builder builder(*exchangeNode);
+  return builder.outputType(newType).build();
+}
+
+// returns true if the cast can be pushed to the scan/exchange through this plan
+// subtree.
+bool canPushUpcastThrough(
+    const core::PlanNodePtr& node,
+    const std::string& column) {
+  using namespace facebook::velox::core;
+
+  // blocking nodes
+  if (std::dynamic_pointer_cast<const AggregationNode>(node) ||
+      std::dynamic_pointer_cast<const ExpandNode>(node) ||
+      std::dynamic_pointer_cast<const GroupIdNode>(node) ||
+      std::dynamic_pointer_cast<const WindowNode>(node)) {
+    return false;
+  }
+
+  // Join case — we must determine which side carries the column.
+  if (auto join = std::dynamic_pointer_cast<const AbstractJoinNode>(node)) {
+    auto left = join->sources()[0];
+    auto right = join->sources()[1];
+
+    bool leftHas = left->outputType()->containsChild(column);
+    bool rightHas = right->outputType()->containsChild(column);
+
+    // illegal if both or neither sides contain it
+    if ((leftHas && rightHas) || (!leftHas && !rightHas)) {
+      return false;
+    }
+
+    // Only recurse into the correct side
+    return canPushUpcastThrough(leftHas ? left : right, column);
+  }
+
+  // Base case support source
+  if (std::dynamic_pointer_cast<const TableScanNode>(node) ||
+      std::dynamic_pointer_cast<const ExchangeNode>(node)) {
+    return true;
+  }
+
+  // Generic recursive case (Filter, Project, Limit, TopN, OrderBy…)
+  for (auto& src : node->sources()) {
+    if (src->outputType()->containsChild(column) &&
+        !canPushUpcastThrough(src, column)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+struct NodeAnalysis {
+  bool needRewrite{false};
+  std::set<int> projectionsToReplace; // indices of projections to replace
+};
+
+NodeAnalysis preAnalyzeNode(const PlanNodePtr& node, ExprMap& exprsToPush) {
+  NodeAnalysis analysis;
+
+  auto project = std::dynamic_pointer_cast<const core::ProjectNode>(node);
+  if (!project) {
+    return analysis;
+  }
+
+  VELOX_CHECK_EQ(project->sources().size(), 1);
+
+  const auto& names = project->names();
+  const auto& exprs = project->projections();
+
+  for (int i = 0; i < names.size(); i++) {
+    const auto& projection = exprs[i];
+
+    if (!isWideningIntegerCast(projection)) {
+      continue;
+    }
+
+    VELOX_CHECK_EQ(projection->inputs().size(), 1);
+
+    auto input = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+        projection->inputs()[0]);
+    VELOX_CHECK(input);
+
+    if (!canPushUpcastThrough(node->sources()[0], input->name())) {
+      // block this cast from being pushed down
+      continue;
+    }
+
+    // We use the field name (input->name()) as the key to push down the
+    // cast expression. E.g. provider_id -> (Cast(provider_id as bigint), 22)
+    exprsToPush.emplace(input->name(), std::make_pair(projection, node->id()));
+    analysis.projectionsToReplace.insert(i);
+    analysis.needRewrite = true;
+
+    //    VLOG(2) << "Pushdown cast " << names[i] << " → child: " <<
+    //    input->name();
+  }
+
+  return analysis;
+}
+
+PlanNodePtr rewriteNode(
+    PlanNodePtr node,
+     ExprMap& exprsToPush,
+    const NodeAnalysis& analysis,
+    const std::vector<PlanNodePtr>& newSources) {
+  // TableScan
+  if (auto scan = std::dynamic_pointer_cast<const core::TableScanNode>(node)) {
+    return rewriteTableScanNode(scan, exprsToPush);
+  }
+
+  // Exchange
+  if (auto exch = std::dynamic_pointer_cast<const core::ExchangeNode>(node)) {
+    return rewriteExchangeNode(exch, exprsToPush);
+  }
+
+  // Project
+  if (auto proj = std::dynamic_pointer_cast<const core::ProjectNode>(node)) {
+    return rewriteProjectNode(
+        proj,
+        exprsToPush,
+        analysis.projectionsToReplace,
+        newSources);
+  }
+
+  // Generic
+  if (!newSources.empty()) {
+    auto rewritten = node->copyWithNewSources(std::move(newSources));
+    return rewritten;
+  }
+
+  return node;
+}
+
 // Sometimes consumer limits the number of drivers its producer can run.
-uint32_t maxDriversForConsumer(
-    const std::shared_ptr<const core::PlanNode>& node) {
+uint32_t maxDriversForConsumer(const PlanNodePtr& node) {
   if (std::dynamic_pointer_cast<const core::MergeJoinNode>(node)) {
     // MergeJoinNode must run single-threaded.
     return 1;
@@ -391,6 +700,109 @@ uint32_t maxDrivers(
 }
 } // namespace detail
 
+PlanNodePtr LocalPlanner::planWithCastPushdown(
+    PlanNodePtr node,
+    bool newPipeline,
+    const PlanNodePtr& consumerNode,
+    OperatorSupplier incomingSupplier,
+    std::vector<std::unique_ptr<DriverFactory>>* driverFactories,
+    ExprMap& exprsToPush) {
+  // 1. Pipeline creation
+
+  if (newPipeline) {
+    // New pipeline root -> compute supplier *NOW* using rewritten node
+    auto newDriverFactory = std::make_unique<DriverFactory>();
+
+    // Only call makeOperatorSupplier when creating a new DriverFactory
+    newDriverFactory->operatorSupplier = incomingSupplier;
+    newDriverFactory->consumerNode = consumerNode;
+    driverFactories->push_back(std::move(newDriverFactory));
+  }
+
+  auto driverFactory = driverFactories->back().get();
+  auto& currentPlanNodes = driverFactory->planNodes;
+
+  // 2. Analyze the current node to see if there is any upcast that can be
+  // pushed down. Populate analysis info and exprsToPush
+
+  auto analysis = detail::preAnalyzeNode(node, exprsToPush);
+
+  // 3. Plan children
+
+  auto& sources = node->sources();
+  const int numSources = isIndexLookupJoin(node.get()) ? 1 : sources.size();
+  std::vector<PlanNodePtr> newSources;
+
+  // For each child we record whether it started its own pipeline and,
+  // if so, which DriverFactory index corresponds to that child pipeline.
+  std::vector<int> childPipelineIndex(numSources, -1);
+  bool childrenChanged = false;
+
+  if (sources.empty()) {
+    driverFactory->inputDriver = true;
+  } else {
+    for (int i = 0; i < numSources; i++) {
+      ExprMap exprsForChild;
+      const auto& childType = sources[i]->outputType();
+
+      for (auto& [name, expr] : exprsToPush) {
+        if (childType->containsChild(name)) {
+          exprsForChild.emplace(name, expr);
+        }
+      }
+
+      // If the child starts a new pipeline, remember the index *before*
+      // recursing. The child's root pipeline will be created at this index.
+      bool childNewPipeline = detail::mustStartNewPipeline(node, i);
+      if (childNewPipeline) {
+        // The root pipeline for this child is at index 'before'.
+        childPipelineIndex[i] = driverFactories->size();
+      }
+      auto child = planWithCastPushdown(
+          sources[i],
+          childNewPipeline,
+          node,
+          /*incomingSupplier*/ nullptr, // supplier will be set after rewrite
+          driverFactories,
+          exprsForChild);
+
+      newSources.push_back(child);
+      childrenChanged |= (child != sources[i]);
+    }
+  }
+
+  // 4. Rewrite current node if needed
+
+  if (analysis.needRewrite || childrenChanged || !exprsToPush.empty()) {
+    node = rewriteNode(node, exprsToPush, analysis, newSources);
+  }
+
+  // 5. Update the operator supplier for the child pipelines, if this node(e.g.
+  // LocalPartition, LocalMerge, HashJoin build) creates new pipeline.
+
+  for (int i = 0; i < numSources; i++) {
+    const int childDriverFactoryIndex = childPipelineIndex[i];
+    if (childDriverFactoryIndex < 0) {
+      continue; // this child didn't start a new pipeline
+    }
+    VELOX_CHECK_LT(childDriverFactoryIndex, driverFactories->size());
+    auto* childDriverFactory =
+        (*driverFactories)[childDriverFactoryIndex].get();
+
+    // Only override if it wasn't set at creation time (should be nullptr
+    // for child pipelines in this scheme).
+    VELOX_CHECK(
+        !childDriverFactory->operatorSupplier,
+        "Child pipeline operatorSupplier unexpectedly already set.");
+    childDriverFactory->operatorSupplier = detail::makeOperatorSupplier(node);
+  }
+
+  // 6. Add this node (rewritten) to current pipeline
+  currentPlanNodes.push_back(node);
+
+  return node;
+}
+
 // static
 void LocalPlanner::plan(
     const core::PlanFragment& planFragment,
@@ -403,12 +815,25 @@ void LocalPlanner::plan(
       adapter.inspect(planFragment);
     }
   }
-  detail::plan(
-      planFragment.planNode,
-      nullptr,
-      nullptr,
-      detail::makeOperatorSupplier(std::move(consumerSupplier)),
-      driverFactories);
+
+  if (queryConfig.pushdownIntegerUpcastsToSource()) {
+    ExprMap exprsToBePushedDown;
+    planWithCastPushdown(
+        planFragment.planNode,
+        true,
+        nullptr,
+        //        nullptr,
+        detail::makeOperatorSupplier(std::move(consumerSupplier)),
+        driverFactories,
+        exprsToBePushedDown);
+  } else {
+    detail::plan(
+        planFragment.planNode,
+        nullptr,
+        nullptr,
+        detail::makeOperatorSupplier(std::move(consumerSupplier)),
+        driverFactories);
+  }
 
   (*driverFactories)[0]->outputDriver = true;
 

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -17,6 +17,7 @@
 
 #include <set>
 
+#include "velox/core/Expressions.h"
 #include "velox/core/PlanFragment.h"
 #include "velox/exec/ArrowStream.h"
 #include "velox/exec/AssignUniqueId.h"
@@ -270,16 +271,21 @@ bool isWideningDateCast(const TypePtr& outputType, const TypePtr& inputType) {
   return false;
 }
 
-
-bool isVarcharToTimestampCast(const TypePtr& outputType, const TypePtr& inputType) {
+bool isVarcharToTimestampCast(
+    const TypePtr& outputType,
+    const TypePtr& inputType) {
   if (outputType->isTimestamp() && inputType->isVarchar()) {
     return true;
   }
   return false;
 }
 
-bool isWideningCastOperation(const TypePtr& outputType, const TypePtr& inputType) {
-  return isWideningIntegerCast(outputType, inputType) || isWideningDateCast(outputType, inputType) || isVarcharToTimestampCast(outputType, inputType);
+bool isWideningCastOperation(
+    const TypePtr& outputType,
+    const TypePtr& inputType) {
+  return isWideningIntegerCast(outputType, inputType) ||
+      isWideningDateCast(outputType, inputType) ||
+      isVarcharToTimestampCast(outputType, inputType);
 }
 
 bool isWideningCastOperation(const core::ITypedExpr& expr) {
@@ -292,7 +298,6 @@ bool isWideningCastOperation(const core::ITypedExpr& expr) {
   }
   return isWideningCastOperation(expr.type(), inputExpr->type());
 }
-
 
 void plan(
     const PlanNodePtr& planNode,
@@ -426,6 +431,26 @@ PlanNodePtr rewriteProjectNode(
       projectNode->id(), newNames, newProjections, newSources[0]);
 }
 
+PlanNodePtr rewriteFilterNode(
+    core::FilterNodePtr filterNode,
+    ExprMap& castExprs,
+    const std::vector<PlanNodePtr>& newSources) {
+  auto newFilter =
+      filterNode->filter()->rewriteCastExprsWithUpcastName(castExprs);
+  auto it = castExprs.begin();
+  while (it != castExprs.end()) {
+    if (it->second.second == filterNode->id()) {
+      castExprs.erase(it);
+      break;
+    }
+    ++it;
+  }
+
+  VLOG(2) << "Created new filter: " << newFilter->toString();
+  return std::make_shared<core::FilterNode>(
+      filterNode->id(), newFilter, newSources[0]);
+}
+
 PlanNodePtr rewriteTableScanNode(
     core::TableScanNodePtr scan,
     const ExprMap& castExprs) {
@@ -545,45 +570,104 @@ struct NodeAnalysis {
   std::set<int> projectionsToReplace; // indices of projections to replace
 };
 
+class CastExprVisitor : public core::DefaultTypedExprVisitor {
+ public:
+  class CastExprVisitorContext : public core::ITypedExprVisitorContext {
+   public:
+    CastExprVisitorContext(
+        ExprMap& castExprsToPush,
+        NodeAnalysis& analysis,
+        const std::string& nodeId)
+        : castExprsToPush_(castExprsToPush),
+          nodeId_(nodeId),
+          analysis_(analysis) {}
+
+    void addCastExprsToPush(
+        const std::string& name,
+        core::TypedExprPtr castExpr) {
+      castExprsToPush_.emplace(name, std::make_pair(castExpr, nodeId_));
+    }
+
+    NodeAnalysis& analysis() {
+      return analysis_;
+    }
+
+    const std::string& planNodeId() {
+      return nodeId_;
+    }
+
+   private:
+    ExprMap& castExprsToPush_;
+    const std::string& nodeId_;
+    NodeAnalysis& analysis_;
+  };
+
+  void visit(
+      const core::CastTypedExpr& expr,
+      core::ITypedExprVisitorContext& ctx) const override {
+    auto& myCtx = static_cast<CastExprVisitorContext&>(ctx);
+    if (isWideningCastOperation(expr)) {
+      VELOX_CHECK_EQ(expr.inputs().size(), 1);
+      auto input = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+          expr.inputs()[0]);
+      VELOX_CHECK(input);
+      auto castExpr = std::make_shared<core::CastTypedExpr>(
+          expr.type(), expr.inputs(), expr.isTryCast());
+      myCtx.addCastExprsToPush(input->name(), castExpr);
+      VLOG(2) << "Pushdown cast " << castExpr->toString()
+              << " → child: " << input->name();
+      visitInputs(expr, ctx);
+    }
+  }
+};
+
 NodeAnalysis preAnalyzeNode(const PlanNodePtr& node, ExprMap& exprsToPush) {
   NodeAnalysis analysis;
 
-  auto project = std::dynamic_pointer_cast<const core::ProjectNode>(node);
-  if (!project) {
-    return analysis;
-  }
+  if (auto project = std::dynamic_pointer_cast<const core::ProjectNode>(node)) {
+    VELOX_CHECK_EQ(project->sources().size(), 1);
 
-  VELOX_CHECK_EQ(project->sources().size(), 1);
+    const auto& names = project->names();
+    const auto& exprs = project->projections();
 
-  const auto& names = project->names();
-  const auto& exprs = project->projections();
+    for (int i = 0; i < names.size(); i++) {
+      const auto& projection = exprs[i];
 
-  for (int i = 0; i < names.size(); i++) {
-    const auto& projection = exprs[i];
+      if (!isWideningCastOperation(*projection)) {
+        continue;
+      }
 
-    if (!isWideningCastOperation(*projection)) {
-      continue;
+      VELOX_CHECK_EQ(projection->inputs().size(), 1);
+
+      auto input = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+          projection->inputs()[0]);
+      VELOX_CHECK(input);
+
+      if (!canPushUpcastThrough(node->sources()[0], input->name())) {
+        // block this cast from being pushed down
+        continue;
+      }
+
+      // We use the field name (input->name()) as the key to push down the
+      // cast expression. E.g. provider_id -> (Cast(provider_id as bigint), 22)
+      exprsToPush.emplace(input->name(), std::make_pair(projection, node->id()));
+      analysis.projectionsToReplace.insert(i);
+      analysis.needRewrite = true;
+
+      //    VLOG(2) << "Pushdown cast " << names[i] << " → child: " <<
+      //    input->name();
     }
-
-    VELOX_CHECK_EQ(projection->inputs().size(), 1);
-
-    auto input = std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
-        projection->inputs()[0]);
-    VELOX_CHECK(input);
-
-    if (!canPushUpcastThrough(node->sources()[0], input->name())) {
-      // block this cast from being pushed down
-      continue;
+  } else if (
+      auto filterNode =
+          std::dynamic_pointer_cast<const core::FilterNode>(node)) {
+    auto filter = filterNode->filter();
+    CastExprVisitor::CastExprVisitorContext ctx(
+        exprsToPush, analysis, node->id());
+    CastExprVisitor visitor;
+    filter->accept(visitor, ctx);
+    if (exprsToPush.size() > 0) {
+      analysis.needRewrite = true;
     }
-
-    // We use the field name (input->name()) as the key to push down the
-    // cast expression. E.g. provider_id -> (Cast(provider_id as bigint), 22)
-    exprsToPush.emplace(input->name(), std::make_pair(projection, node->id()));
-    analysis.projectionsToReplace.insert(i);
-    analysis.needRewrite = true;
-
-    //    VLOG(2) << "Pushdown cast " << names[i] << " → child: " <<
-    //    input->name();
   }
 
   return analysis;
@@ -611,6 +695,12 @@ PlanNodePtr rewriteNode(
         exprsToPush,
         analysis.projectionsToReplace,
         newSources);
+  }
+
+  // Filter
+  if (auto filter = std::dynamic_pointer_cast<const core::FilterNode>(node)) {
+    return rewriteFilterNode(
+        filter, const_cast<ExprMap&>(exprsToPush), newSources);
   }
 
   // Generic

--- a/velox/exec/LocalPlanner.h
+++ b/velox/exec/LocalPlanner.h
@@ -23,6 +23,14 @@ struct PlanFragment;
 
 namespace facebook::velox::exec {
 
+using PlanNodePtr = std::shared_ptr<const core::PlanNode>;
+// E.g. provider_id -> (Cast(provider_id as bigint), 22). There could be
+// multiple entries for the same field name, eg. provider_id ->
+// (Cast(provider_id as bigint), 1943) because there could be multiple widening
+// integer casts on the same field on different PlanNodes in the plan.
+using ExprMap =
+    std::multimap<std::string, std::pair<core::TypedExprPtr, core::PlanNodeId>>;
+
 class LocalPlanner {
  public:
   static void plan(
@@ -31,6 +39,15 @@ class LocalPlanner {
       std::vector<std::unique_ptr<DriverFactory>>* driverFactories,
       const core::QueryConfig& queryConfig,
       uint32_t maxDrivers);
+
+  static
+  PlanNodePtr planWithCastPushdown(
+      PlanNodePtr node,
+      bool newPipeline,
+      const PlanNodePtr& consumerNode,
+      OperatorSupplier incomingSupplier,
+      std::vector<std::unique_ptr<DriverFactory>>* driverFactories,
+      ExprMap& exprsToPush);
 
   // Determine which pipelines should run Grouped Execution.
   static void determineGroupedExecutionPipelines(

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -128,7 +128,7 @@ class Merge : public SourceOperator {
   Stats mergeStats_;
 
   RowVectorPtr output_;
-  /// Number of rows accumulated in 'output_' so far.
+  /// Number of rows accumulated in 'outputWithoutUpcasts_' so far.
   vector_size_t outputSize_{0};
   bool finished_{false};
 
@@ -181,7 +181,7 @@ class SourceMerger {
 
   // Reusable output vector.
   RowVectorPtr output_;
-  // The number of rows in 'output_' vector.
+  // The number of rows in 'outputWithoutUpcasts_' vector.
   uint64_t outputRows_{0};
 };
 

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -469,7 +469,7 @@ bool MergeJoin::tryAddOutputRow(
 bool MergeJoin::prepareOutput(
     const RowVectorPtr& left,
     const RowVectorPtr& right) {
-  // If there is already an allocated output_, check if we can use it.
+  // If there is already an allocated outputWithoutUpcasts_, check if we can use it.
   if (output_ != nullptr) {
     // If there is a new left, we can't continue using it as the old one is the
     // base for the current left dictionary.
@@ -957,7 +957,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
     while (compareResult < 0) {
       if (isLeftJoin(joinType_) || isAntiJoin(joinType_) ||
           isFullJoin(joinType_)) {
-        // If output_ is currently wrapping a different buffer, return it
+        // If outputWithoutUpcasts_ is currently wrapping a different buffer, return it
         // first.
         if (prepareOutput(input_, nullptr)) {
           output_->resize(outputSize_);
@@ -982,7 +982,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
     // Catch up rightInput_ with input_.
     while (compareResult > 0) {
       if (isRightJoin(joinType_) || isFullJoin(joinType_)) {
-        // If output_ is currently wrapping a different buffer, return it
+        // If outputWithoutUpcasts_ is currently wrapping a different buffer, return it
         // first.
         if (prepareOutput(nullptr, rightInput_)) {
           output_->resize(outputSize_);
@@ -1080,7 +1080,7 @@ RowVectorPtr MergeJoin::handleSingleSideOutput() {
 
   if (isLeftJoin(joinType_) || isAntiJoin(joinType_)) {
     if (input_ && rightHasNoInput()) {
-      // If output_ is currently wrapping a different buffer, return it
+      // If outputWithoutUpcasts_ is currently wrapping a different buffer, return it
       // first.
       if (prepareOutput(input_, nullptr)) {
         output_->resize(outputSize_);
@@ -1110,7 +1110,7 @@ RowVectorPtr MergeJoin::handleSingleSideOutput() {
     }
   } else if (isRightJoin(joinType_)) {
     if (rightInput_ && leftHasNoInput()) {
-      // If output_ is currently wrapping a different buffer, return it
+      // If outputWithoutUpcasts_ is currently wrapping a different buffer, return it
       // first.
       if (prepareOutput(nullptr, rightInput_)) {
         output_->resize(outputSize_);
@@ -1142,7 +1142,7 @@ RowVectorPtr MergeJoin::handleSingleSideOutput() {
     }
   } else if (isFullJoin(joinType_)) {
     if (input_ && rightHasNoInput()) {
-      // If output_ is currently wrapping a different buffer, return it
+      // If outputWithoutUpcasts_ is currently wrapping a different buffer, return it
       // first.
       if (prepareOutput(input_, nullptr)) {
         output_->resize(outputSize_);
@@ -1168,7 +1168,7 @@ RowVectorPtr MergeJoin::handleSingleSideOutput() {
     }
 
     if (rightInput_ && leftHasNoInput()) {
-      // If output_ is currently wrapping a different buffer, return it
+      // If outputWithoutUpcasts_ is currently wrapping a different buffer, return it
       // first.
       if (prepareOutput(nullptr, rightInput_)) {
         output_->resize(outputSize_);

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -211,19 +211,19 @@ class MergeJoin : public Operator {
       const std::vector<column_index_t>& keys,
       Match& match);
 
-  // Ensures `output_` is ready to receive records via `addOutput()` or
+  // Ensures `outputWithoutUpcasts_` is ready to receive records via `addOutput()` or
   // `addOutputRowForLeftJoin()`. Initialize vectors using `outputBatchSize_`.
-  // Returns true is the output_ needs to be returned/produced first, and false
+  // Returns true is the outputWithoutUpcasts_ needs to be returned/produced first, and false
   // in case it is ready to take records.
   bool prepareOutput(const RowVectorPtr& left, const RowVectorPtr& right);
 
   // Appends a cartesian product of the current set of matching rows, leftMatch_
   // x rightMatch_ for left join and rightMatch_ x leftMatch_ for right join, to
-  // output_. Returns true if output_ is full. Sets leftMatchCursor_ and
-  // rightMatchCursor_ if output_ filled up before all the rows were added.
+  // outputWithoutUpcasts_. Returns true if outputWithoutUpcasts_ is full. Sets leftMatchCursor_ and
+  // rightMatchCursor_ if outputWithoutUpcasts_ filled up before all the rows were added.
   // Fills up output starting from leftMatchCursor_ and rightMatchCursor_
   // positions if these are set. Clears leftMatch_ and rightMatch_ if all rows
-  // were added. Updates leftMatchCursor_ and rightMatchCursor_ if output_
+  // were added. Updates leftMatchCursor_ and rightMatchCursor_ if outputWithoutUpcasts_
   // filled up before all rows were added.
   bool addToOutput();
 
@@ -601,7 +601,7 @@ class MergeJoin : public Operator {
   // Join filter input type.
   RowTypePtr filterInputType_;
 
-  // Maps 'filterInputType_' channels to the corresponding channels in output_,
+  // Maps 'filterInputType_' channels to the corresponding channels in outputWithoutUpcasts_,
   // if any.
   folly::F14FastMap<column_index_t, column_index_t> filterInputToOutputChannel_;
 
@@ -639,7 +639,7 @@ class MergeJoin : public Operator {
 
   RowVectorPtr output_;
 
-  // Number of rows accumulated in the output_.
+  // Number of rows accumulated in the outputWithoutUpcasts_.
   vector_size_t outputSize_;
 
   // A future that will be completed when right side input becomes available.

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -267,7 +267,7 @@ RowVectorPtr NestedLoopJoinProbe::getOutput() {
 }
 
 RowVectorPtr NestedLoopJoinProbe::generateOutput() {
-  // If addToOutput() returns false, output_ is filled. Need to produce it.
+  // If addToOutput() returns false, outputWithoutUpcasts_ is filled. Need to produce it.
   if (!addToOutput()) {
     VELOX_CHECK_GT(output_->size(), 0);
     return std::move(output_);
@@ -277,8 +277,8 @@ RowVectorPtr NestedLoopJoinProbe::generateOutput() {
   if (advanceProbe()) {
     finishProbeInput();
     if (numOutputRows_ == 0) {
-      // output_ can only be re-used across probe rows within the same input_.
-      // Here we have to abandon the emtpy non-null output_ before we advance to
+      // outputWithoutUpcasts_ can only be re-used across probe rows within the same input_.
+      // Here we have to abandon the emtpy non-null outputWithoutUpcasts_ before we advance to
       // the next probe input.
       output_ = nullptr;
     }
@@ -302,7 +302,7 @@ bool NestedLoopJoinProbe::readyToProduceOutput() {
     return true;
   }
 
-  // If the input_ has no remaining rows or the output_ is fully filled,
+  // If the input_ has no remaining rows or the outputWithoutUpcasts_ is fully filled,
   // it's right time for output.
   return !input_ || numOutputRows_ >= outputBatchSize_;
 }

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -113,19 +113,19 @@ class NestedLoopJoinProbe : public Operator {
   // smaller in some cases - outputs follow the probe side buffer boundaries.
   RowVectorPtr generateOutput();
 
-  // For non cross-join mode, the `output_` can be reused across multible probe
-  // rows. If the input_ has remaining rows and the output_ is not fully filled,
+  // For non cross-join mode, the `outputWithoutUpcasts_` can be reused across multible probe
+  // rows. If the input_ has remaining rows and the outputWithoutUpcasts_ is not fully filled,
   // it returns false here.
   bool readyToProduceOutput();
 
-  // Fill in joined output to `output_` by matching the current probeRow_ and
+  // Fill in joined output to `outputWithoutUpcasts_` by matching the current probeRow_ and
   // successive build vectors (using getNextCrossProductBatch()). Stops when
   // either all build vectors were matched for the current probeRow (returns
   // true), or if the output is full (returns false). If it returns false, a
-  // valid vector with more than zero records will be available at `output_`; if
-  // it returns true, either nullptr or zero records may be placed at `output_`.
+  // valid vector with more than zero records will be available at `outputWithoutUpcasts_`; if
+  // it returns true, either nullptr or zero records may be placed at `outputWithoutUpcasts_`.
   // Also if it returns true, it's the caller's responsiblity to decide when to
-  // set `output_` size.
+  // set `outputWithoutUpcasts_` size.
   //
   // Also updates `buildMatched_` if the build records that received a match, so
   // that they can be used to implement right and full outer join semantic once
@@ -137,7 +137,7 @@ class NestedLoopJoinProbe : public Operator {
   // (and hence a new probe input is required). False otherwise.
   bool advanceProbe();
 
-  // Ensures a new batch of records is available at `output_` and ready to
+  // Ensures a new batch of records is available at `outputWithoutUpcasts_` and ready to
   // receive rows. Batches have space for `outputBatchSize_`.
   void prepareOutput();
 
@@ -190,7 +190,7 @@ class NestedLoopJoinProbe : public Operator {
       const std::vector<IdentityProjection>& probeProjections,
       const std::vector<IdentityProjection>& buildProjections);
 
-  // Add a single record to `output_` based on buildRow from buildVector, and
+  // Add a single record to `outputWithoutUpcasts_` based on buildRow from buildVector, and
   // the current probeRow and probe vector (input_). Probe side projections are
   // zero-copy (dictionary indices), and build side projections are marked to be
   // copied using `buildCopyRanges_`; they will be copied later on by
@@ -198,7 +198,7 @@ class NestedLoopJoinProbe : public Operator {
   void addOutputRow(vector_size_t buildRow);
 
   // Checks if it is required to add a probe mismatch row, and does it if
-  // needed. The caller needs to ensure there is available space in `output_`
+  // needed. The caller needs to ensure there is available space in `outputWithoutUpcasts_`
   // for the new record, which has nulled out build projections.
   void checkProbeMismatchRow();
 
@@ -207,7 +207,7 @@ class NestedLoopJoinProbe : public Operator {
   void addProbeMismatchRow();
 
   // Copies the ranges from buildVector specified by `buildCopyRanges_` to
-  // `output_`, one projected column at a time. Clears buildCopyRanges_.
+  // `outputWithoutUpcasts_`, one projected column at a time. Clears buildCopyRanges_.
   void copyBuildValues(const RowVectorPtr& buildVector);
 
   // Called when we are done processing the current probe batch, to signal we

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -70,7 +70,8 @@ OperatorCtx::createConnectorQueryCtx(
       driverCtx_->queryConfig().sessionTimezone(),
       driverCtx_->queryConfig().adjustTimestampToTimezone(),
       task->getCancellationToken(),
-      task->queryCtx()->fsTokenProvider());
+      task->queryCtx()->fsTokenProvider(),
+      driverCtx_->queryConfig().isLegacyCast());
   connectorQueryCtx->setSelectiveNimbleReaderEnabled(
       driverCtx_->queryConfig().selectiveNimbleReaderEnabled());
   connectorQueryCtx->setRowSizeTrackingMode(

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "velox/exec/PartitionedOutput.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/OutputBufferManager.h"
@@ -128,6 +127,15 @@ BlockingReason Destination::flush(
   bytesInCurrent_ = 0;
   rowsInCurrent_ = 0;
   setTargetSizePct();
+
+  auto serializedpage = std::make_unique<SerializedPage>(
+      stream.getIOBuf(bufferReleaseFn), nullptr, flushedRows);
+  //  LOG(INFO) << "Sending SerializedPage For Task " << taskId_ << "
+  //  destination " << destination_
+  //            << " serializedPage size " << serializedpage->size()
+  //            << " serializedPage numRows "
+  //            << serializedpage->numRows().value_or(-1) << " flushed "
+  //            << flushedRows << " rows, " << flushedBytes << " bytes";
 
   bool blocked = bufferManager.enqueue(
       taskId_,
@@ -298,6 +306,10 @@ void PartitionedOutput::estimateRowSizes() {
 }
 
 void PartitionedOutput::addInput(RowVectorPtr input) {
+//  VLOG(google::INFO) << "PartitionedOutput::addInput with " << input->size()
+//          << " rows, type " << input->type()->kind()  << " value:"
+//          << input->childAt(0)->asFlatVector<int64_t>()->valueAt(0);
+
   initializeInput(std::move(input));
   initializeDestinations();
   initializeSizeBuffers();
@@ -440,7 +452,7 @@ RowVectorPtr PartitionedOutput::getOutput() {
     }
     return nullptr;
   }
-  // All of 'output_' is written into the destinations. We are finishing, hence
+  // All of 'outputWithoutUpcasts_' is written into the destinations. We are finishing, hence
   // move all the destinations to the output queue. This will not grow memory
   // and hence does not need blocking.
   if (noMoreInput_) {

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -228,12 +228,12 @@ class PartitionedOutput : public Operator {
   // Contains pointers to 'rowSize_' elements. 'sizePointers_[i]' contains a
   // pointer to 'rowSize_[i]'.
   std::vector<vector_size_t*> sizePointers_;
-  // The estimated row size for each row. Index maps back to 'output_' index
+  // The estimated row size for each row. Index maps back to 'outputWithoutUpcasts_' index
   std::vector<vector_size_t> rowSize_;
   std::vector<std::unique_ptr<detail::Destination>> destinations_;
   bool replicatedAny_{false};
   RowVectorPtr output_;
-  // This is only set with current 'output_' in case of compact row serde
+  // This is only set with current 'outputWithoutUpcasts_' in case of compact row serde
   // format. It is used to accelerate serialized row size calculation and the
   // actual serialization processing.
   //

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -156,7 +156,7 @@ class SortBuffer {
   // Used to merge the sorted runs from in-memory rows and spilled rows on disk.
   std::unique_ptr<TreeOfLosers<SpillMergeStream>> spillMerger_;
 
-  // Records the source rows to copy to 'output_' in order.
+  // Records the source rows to copy to 'outputWithoutUpcasts_' in order.
   std::vector<const RowVector*> spillSources_;
 
   std::vector<vector_size_t> spillSourceRows_;

--- a/velox/exec/SpatialJoinProbe.cpp
+++ b/velox/exec/SpatialJoinProbe.cpp
@@ -378,7 +378,7 @@ RowVectorPtr SpatialJoinProbe::generateOutput() {
   outputBuilder_.initializeOutput(input_, pool());
 
   while (!isOutputDone()) {
-    // Fill output_ with the results from one row.  This may produce too
+    // Fill outputWithoutUpcasts_ with the results from one row.  This may produce too
     // much output and only partially complete.  If so, the next time we
     // call this we'll get the next chunk.
     //

--- a/velox/exec/SpatialJoinProbe.h
+++ b/velox/exec/SpatialJoinProbe.h
@@ -47,7 +47,7 @@ class SpatialJoinOutputBuilder {
   void addOutputRow(vector_size_t probeRow, vector_size_t buildRow);
 
   /// Checks if it is required to add a probe mismatch row, and does it if
-  /// needed. The caller needs to ensure there is available space in `output_`
+  /// needed. The caller needs to ensure there is available space in `outputWithoutUpcasts_`
   /// for the new record, which has nulled out build projections.
   void addProbeMismatchRow(vector_size_t probeRow);
 

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -68,7 +68,7 @@ class StreamingAggregation : public Operator {
   // Write grouping keys from the specified input row into specified group.
   void storeKeys(char* group, vector_size_t index);
 
-  // Populate output_ vector using specified number of groups from the beginning
+  // Populate outputWithoutUpcasts_ vector using specified number of groups from the beginning
   // of the groups_ vector.
   RowVectorPtr createOutput(size_t numGroups);
 

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -30,9 +30,10 @@ std::unique_ptr<connector::DataSource> createDataSource(
     const RowTypePtr& outputType,
     const connector::ConnectorTableHandlePtr& tableHandle,
     const connector::ColumnHandleMap& columnHandles,
-    connector::ConnectorQueryCtx* connectorQueryCtx) {
+    connector::ConnectorQueryCtx* connectorQueryCtx,
+    bool pushdownCasts) {
   auto dataSource = connector.createDataSource(
-      outputType, tableHandle, columnHandles, connectorQueryCtx);
+      outputType, tableHandle, columnHandles, connectorQueryCtx, pushdownCasts);
   auto* staticFilters = dataSource->getFilters();
   if (!staticFilters) {
     VELOX_CHECK(!connector.canAddDynamicFilter());
@@ -50,7 +51,11 @@ std::unique_ptr<connector::DataSource> createDataSource(
   auto lk = pushdownFilters.wlock();
   if (!lk->staticFiltersInitialized) {
     for (column_index_t i = 0, size = outputType->size(); i < size; ++i) {
-      auto handle = columnHandles.find(outputType->nameOf(i));
+      std::string columnName = outputType->nameOf(i);
+      if (columnName.ends_with("_upcast")) {
+        columnName = columnName.substr(0, columnName.size() - 7);
+      }
+      auto handle = columnHandles.find(columnName);
       VELOX_CHECK(handle != columnHandles.end());
       auto field = common::Subfield::create(handle->second->name());
       if (auto it = staticFilters->find(*field); it != staticFilters->end()) {
@@ -337,7 +342,8 @@ bool TableScan::getSplit() {
         outputType_,
         tableHandle_,
         columnHandles_,
-        connectorQueryCtx_.get());
+        connectorQueryCtx_.get(),
+        driverCtx_->queryConfig().pushdownIntegerUpcastsToSource());
   }
 
   debugString_ = fmt::format(
@@ -427,6 +433,8 @@ void TableScan::preload(
            split->connectorId, planNodeId(), connectorPool_),
        task = operatorCtx_->task(),
        pushdownFilters = driverCtx_->driver->pushdownFilters(),
+       pushdownCasts =
+           driverCtx_->queryConfig().pushdownIntegerUpcastsToSource(),
        split]() -> std::unique_ptr<connector::DataSource> {
         if (task->isCancelled()) {
           return nullptr;
@@ -445,7 +453,8 @@ void TableScan::preload(
             type,
             table,
             columns,
-            ctx.get());
+            ctx.get(),
+            pushdownCasts);
         if (task->isCancelled()) {
           return nullptr;
         }

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -147,7 +147,8 @@ class TestConnector : public connector::Connector {
       const std::unordered_map<
           std::string,
           connector::ColumnHandlePtr>& /* columnHandles */,
-      connector::ConnectorQueryCtx* connectorQueryCtx) override {
+      connector::ConnectorQueryCtx* connectorQueryCtx,
+      bool pushdownCasts = false) override {
     return std::make_unique<TestDataSource>(connectorQueryCtx->memoryPool());
   }
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -37,6 +37,26 @@ target_link_libraries(
 )
 
 add_executable(
+        local_planner_test
+        LocalPlannerTest.cpp
+)
+
+add_test(
+        NAME local_planner_test
+        COMMAND local_planner_test
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(
+        local_planner_test
+        velox_exec
+        velox_exec_test_lib
+        velox_presto_types
+        GTest::gtest
+        GTest::gtest_main
+)
+
+add_executable(
   velox_exec_test
   AddressableNonNullValueListTest.cpp
   AggregationTest.cpp

--- a/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -126,7 +126,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
       for (auto& child : output->children()) {
         child->resize(maxOutputRows);
       }
-      // Records the source rows to copy to 'output_' in order.
+      // Records the source rows to copy to 'outputWithoutUpcasts_' in order.
       std::vector<const RowVector*> spillSources(maxOutputRows);
       std::vector<vector_size_t> spillSourceRows(maxOutputRows);
       int32_t outputRow = 0;

--- a/velox/exec/tests/LocalPlannerTest.cpp
+++ b/velox/exec/tests/LocalPlannerTest.cpp
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/LocalPlanner.h"
+#include "velox/type/Type.h"
+#include "velox/velox/connectors/hive/TableHandle.h"
+#include "velox/velox/exec/HashPartitionFunction.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::core;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::connector::hive;
+
+namespace facebook::velox::exec::test {
+
+// 这些 alias 在 LocalPlanner.cpp 里是内部的，这里在 test TU
+// 里再声明一遍没问题。
+using PlanNodePtr = std::shared_ptr<const core::PlanNode>;
+using ExprMap =
+    std::multimap<std::string, std::pair<core::TypedExprPtr, core::PlanNodeId>>;
+
+// Forward-declare internal helper so tests can call it.
+PlanNodePtr planWithCastPushdown(
+    PlanNodePtr node,
+    bool newPipeline,
+    const PlanNodePtr& consumerNode,
+    OperatorSupplier incomingSupplier,
+    std::vector<std::unique_ptr<DriverFactory>>* driverFactories,
+    ExprMap& exprsToPush);
+
+} // namespace facebook::velox::exec::test
+
+namespace {
+
+using facebook::velox::core::PlanNodePtr;
+using facebook::velox::exec::ExprMap;
+
+// =============== Test 1: Leaf stage, FilterProject(upcast) - TableScan
+// ===============
+//
+// Plan shape before:
+//   Project(a_cast := cast(a as BIGINT))
+//     TableScan(a: INTEGER)
+//
+// 期待：cast 下推到 TableScan，Project 只做 field access。
+// - TableScan 输出 schema: [a: INTEGER, a_upcast: BIGINT]
+// - Project projection: FieldAccess(a_upcast) : BIGINT
+// - 只有一个 pipeline: [TableScan, Project]
+TEST(PlanWithCastPushdownTest, PushesUpcastIntoLeafTableScan) {
+  // Leaf TableScan: column "a" as INTEGER.
+  auto scanType = ROW({"a"}, {INTEGER()});
+
+  connector::ColumnHandleMap assignments;
+  assignments["a"] = std::make_shared<HiveColumnHandle>(
+      "a", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
+
+  core::TableScanNode::Builder scanBuilder;
+  scanBuilder.id("scan")
+      .outputType(scanType)
+      .tableHandle(nullptr) // dummy handle is fine for planner-only test
+      .assignments(assignments);
+  auto scan = scanBuilder.build();
+
+  // Project casting 'a' -> BIGINT.
+  auto input = std::make_shared<FieldAccessTypedExpr>(INTEGER(), "a");
+  auto castExpr = std::make_shared<core::CastTypedExpr>(
+      BIGINT(), std::vector<TypedExprPtr>{input}, false);
+
+  std::vector<std::string> projNames = {"expr1"};
+  std::vector<TypedExprPtr> projExprs = {castExpr};
+  auto project = std::make_shared<ProjectNode>(
+      "project", std::move(projNames), std::move(projExprs), scan);
+
+  // Run cast pushdown.
+  std::vector<std::unique_ptr<DriverFactory>> driverFactories;
+  ExprMap exprsToPush;
+  core::PlanNodePtr consumer; // nullptr
+
+  LocalPlanner planner;
+  auto planned = planner.planWithCastPushdown(
+      project,
+      /*newPipeline*/ true,
+      consumer,
+      /*incomingSupplier*/ OperatorSupplier{},
+      &driverFactories,
+      exprsToPush);
+
+  // Verify basic pipeline structure.
+  ASSERT_TRUE(std::dynamic_pointer_cast<const ProjectNode>(planned));
+  ASSERT_EQ(driverFactories.size(), 1);
+  ASSERT_EQ(driverFactories[0]->planNodes.size(), 2);
+
+  auto scanAfter = std::dynamic_pointer_cast<const TableScanNode>(
+      driverFactories[0]->planNodes.front());
+  auto projectAfter = std::dynamic_pointer_cast<const ProjectNode>(
+      driverFactories[0]->planNodes.back());
+
+  ASSERT_TRUE(scanAfter);
+  ASSERT_TRUE(projectAfter);
+
+  // 1) Upcast column exists in TableScan output schema.
+  auto scanTypeAfter = scanAfter->outputType();
+  ASSERT_EQ(scanTypeAfter->size(), 2);
+  EXPECT_EQ(scanTypeAfter->nameOf(0), "a");
+  EXPECT_EQ(scanTypeAfter->nameOf(1), "a_upcast");
+  EXPECT_TRUE(scanTypeAfter->childAt(0)->equivalent(*INTEGER()));
+  EXPECT_TRUE(scanTypeAfter->childAt(1)->equivalent(*BIGINT()));
+
+  // 2) Project expression has been rewritten to a plain field access.
+  const auto& newProjections = projectAfter->projections();
+  ASSERT_EQ(newProjections.size(), 1);
+
+  auto fieldAfter =
+      std::dynamic_pointer_cast<const FieldAccessTypedExpr>(newProjections[0]);
+  ASSERT_TRUE(fieldAfter);
+  EXPECT_EQ(fieldAfter->name(), "a_upcast");
+  EXPECT_TRUE(fieldAfter->type()->equivalent(*BIGINT()));
+
+  // 3) exprsToPush must be empty after full rewrite.
+  EXPECT_TRUE(exprsToPush.empty());
+
+  // 4) Sanity check with some sample values: INTEGER -> BIGINT upcast preserves
+  //    value.（不是直接 testing planner，而是 sanity check widening 行为）
+  std::vector<int32_t> ints = {
+      0,
+      1,
+      10,
+      -5,
+      std::numeric_limits<int32_t>::max(),
+      std::numeric_limits<int32_t>::min()};
+
+  std::vector<int64_t> bigs;
+  bigs.reserve(ints.size());
+  for (auto v : ints) {
+    bigs.push_back(static_cast<int64_t>(v));
+  }
+
+  for (size_t i = 0; i < ints.size(); ++i) {
+    EXPECT_EQ(static_cast<int64_t>(ints[i]), bigs[i]);
+  }
+}
+
+// ========== Test 2: Intermediate stage, FilterProject(upcast) - Join -
+// Exchange ==========
+//
+// Plan shape before:
+//   Project(a_cast := cast(a as BIGINT))
+//     HashJoin[a = b] (INNER)
+//       Exchange (left, a: INTEGER)
+//       LocalExchange (right, b: INTEGER)
+//          TableScan(b: INTEGER)
+//
+// 期待：
+// - cast 从 Project 下推到 left-side Exchange：
+//     left Exchange 输出: [a: INTEGER, a_upcast: BIGINT]
+// - HashJoin 的 outputType 通过 recomputeOutputTypeForNewSources() 带上新列：
+//     [a: INTEGER, b: INTEGER, a_upcast: BIGINT]
+// - Project 把 cast 换成 FieldAccess(a_upcast)
+// - Join and LocalPartition broke drivers into 3 pipelines：
+//     pipeline 0: left Exchange -> HashJoin -> Project
+//     pipeline 1: LocalPartition
+//     pipeline 2: TableScan
+TEST(PlanWithCastPushdownTest, PushesUpcastThroughExchangeIntoJoin) {
+  // ====== Build right side: TableScan(b: INTEGER) ======
+  auto rightScanType = ROW({"b"}, {INTEGER()});
+
+  connector::ColumnHandleMap bAssignments;
+  bAssignments["b"] = std::make_shared<HiveColumnHandle>(
+      "b", HiveColumnHandle::ColumnType::kRegular, INTEGER(), INTEGER());
+
+  core::TableScanNode::Builder rightScanBuilder;
+  rightScanBuilder.id("rightScan")
+      .outputType(rightScanType)
+      .tableHandle(nullptr)
+      .assignments(bAssignments);
+
+  auto rightScan = rightScanBuilder.build();
+
+  // ====== Build a LocalPartitionNode (repartition on column 'b') ======
+  auto partitionSpec = std::make_shared<HashPartitionFunctionSpec>(
+      rightScanType, // input row type
+      std::vector<column_index_t>{0} // key column: 'b'
+  );
+
+  LocalPartitionNode::Builder rightPartBuilder;
+  rightPartBuilder.id("rightLocalPartition")
+      .type(LocalPartitionNode::Type::kRepartition)
+      .scaleWriter(false)
+      .partitionFunctionSpec(partitionSpec)
+      .sources({rightScan});
+
+  auto rightLocalPartition = rightPartBuilder.build();
+
+  // ====== Build left side: Exchange(a: INTEGER) ======
+  auto leftType = ROW({"a"}, {INTEGER()});
+  core::ExchangeNode::Builder exchangeBuilder;
+  exchangeBuilder.id("leftExchange")
+      .outputType(leftType)
+      .serdeKind(
+          VectorSerde::Kind::kPresto); // no sources in local planner tests
+  auto leftExchange = exchangeBuilder.build();
+
+  // ====== HashJoin: a = b ======
+  HashJoinNode::Builder joinBuilder;
+
+  joinBuilder.id("join")
+      .joinType(core::JoinType::kInner)
+      .leftKeys({std::make_shared<FieldAccessTypedExpr>(INTEGER(), "a")})
+      .rightKeys({std::make_shared<FieldAccessTypedExpr>(INTEGER(), "b")})
+      .left(leftExchange)
+      .right(rightLocalPartition)
+      .outputType(ROW({"a", "b"}, {INTEGER(), INTEGER()}))
+      .nullAware(false);
+
+  auto join = joinBuilder.build();
+
+  // ====== Project: cast(a AS BIGINT) ======
+  auto aInput = std::make_shared<FieldAccessTypedExpr>(INTEGER(), "a");
+  auto castExpr = std::make_shared<core::CastTypedExpr>(
+      BIGINT(), std::vector<TypedExprPtr>{aInput}, false);
+
+  std::vector<std::string> projNames = {"expr1"};
+  std::vector<TypedExprPtr> projExprs = {castExpr};
+  auto project = std::make_shared<ProjectNode>(
+      "project", std::move(projNames), std::move(projExprs), join);
+
+  // ====== Pushdown ======
+  LocalPlanner planner;
+  std::vector<std::unique_ptr<DriverFactory>> driverFactories;
+  ExprMap exprsToPush;
+  core::PlanNodePtr consumer; // nullptr
+
+  auto planned = planner.planWithCastPushdown(
+      project,
+      /*newPipeline*/ true,
+      consumer,
+      /*incomingSupplier*/ OperatorSupplier{},
+      &driverFactories,
+      exprsToPush);
+
+  // ========== Verify pipeline structure ==========
+  ASSERT_EQ(driverFactories.size(), 3)
+      << "Join should produce three pipelines: probe and build sides.";
+
+  // Pipeline 0 = leftExchange -> join -> project
+  // Pipeline 1 = rightScan -> localExchange
+  const auto& probePipe = driverFactories[0]->planNodes;
+  const auto& localPartitionPipe = driverFactories[1]->planNodes;
+  const auto& scanPipe = driverFactories[2]->planNodes;
+
+  // Probe pipeline ends with Project.
+  ASSERT_TRUE(std::dynamic_pointer_cast<const ProjectNode>(probePipe.back()));
+
+  // First operator in probe is Exchange.
+  auto exchAfter =
+      std::dynamic_pointer_cast<const ExchangeNode>(probePipe.front());
+  ASSERT_TRUE(exchAfter);
+
+  // ========== Check Exchange output type ==========
+  auto exchTypeAfter = exchAfter->outputType();
+  ASSERT_EQ(exchTypeAfter->size(), 2);
+  EXPECT_EQ(exchTypeAfter->nameOf(0), "a");
+  EXPECT_EQ(exchTypeAfter->nameOf(1), "a_upcast");
+  EXPECT_TRUE(exchTypeAfter->childAt(0)->equivalent(*INTEGER()));
+  EXPECT_TRUE(exchTypeAfter->childAt(1)->equivalent(*BIGINT()));
+
+  // ========== Check Join output grows the new column ==========
+  auto joinAfter = std::dynamic_pointer_cast<const HashJoinNode>(probePipe[1]);
+  ASSERT_TRUE(joinAfter);
+
+  auto joinTypeAfter = joinAfter->outputType();
+  ASSERT_EQ(joinTypeAfter->size(), 3); // [a, b, a_upcast]
+  EXPECT_EQ(joinTypeAfter->nameOf(0), "a");
+  EXPECT_EQ(joinTypeAfter->nameOf(1), "b");
+  EXPECT_EQ(joinTypeAfter->nameOf(2), "a_upcast");
+  EXPECT_TRUE(joinTypeAfter->childAt(2)->equivalent(*BIGINT()));
+
+  // ========== Check Project rewritten into FieldAccess ==========
+  auto projectAfter =
+      std::dynamic_pointer_cast<const ProjectNode>(probePipe.back());
+  ASSERT_TRUE(projectAfter);
+
+  const auto& newProjExprs = projectAfter->projections();
+  ASSERT_EQ(newProjExprs.size(), 1);
+
+  auto fieldAfter =
+      std::dynamic_pointer_cast<const FieldAccessTypedExpr>(newProjExprs[0]);
+  ASSERT_TRUE(fieldAfter);
+  EXPECT_EQ(fieldAfter->name(), "a_upcast");
+  EXPECT_TRUE(fieldAfter->type()->equivalent(*BIGINT()));
+
+  // ========== Build side pipelines: should contain right scan + localPartition
+  // ==========
+  ASSERT_EQ(localPartitionPipe.size(), 1);
+  ASSERT_TRUE(
+      std::dynamic_pointer_cast<const LocalPartitionNode>(
+          localPartitionPipe.front()));
+
+  ASSERT_EQ(scanPipe.size(), 1);
+  ASSERT_TRUE(std::dynamic_pointer_cast<const TableScanNode>(scanPipe.front()));
+
+  // ========== exprsToPush must be empty after full rewrite ==========
+  EXPECT_TRUE(exprsToPush.empty());
+}
+
+// =============== Test 3: Aggregation blocks cast pushdown ===============
+//
+// Plan shape:
+//
+//   Project(expr1 := cast(a AS BIGINT))
+//     Aggregation (global)
+//       TableScan(a: INTEGER)
+//
+// Expectation:
+// - Cast should NOT be pushed into TableScan because AggregationNode does not
+//   support passing through expressions yet.
+// - TableScan schema remains unchanged: [a]
+// - Aggregation output remains unchanged: [a]
+// - Project still contains the CastTypedExpr instead of being rewritten.
+// - Only one pipeline: [TableScan, Aggregation, Project]
+TEST(PlanWithCastPushdownTest, AggregationBlocksUpcastPushdown) {
+  // ====== Leaf TableScan: column "a" is INTEGER ======
+  auto scanType = ROW({"a"}, {INTEGER()});
+
+  connector::ColumnHandleMap assignments;
+  assignments["a"] = std::make_shared<HiveColumnHandle>(
+      "a",
+      HiveColumnHandle::ColumnType::kRegular,
+      INTEGER(),
+      INTEGER()); // no upcast allowed here
+
+  core::TableScanNode::Builder scanBuilder;
+  scanBuilder.id("scan").outputType(scanType).tableHandle(nullptr).assignments(
+      assignments);
+  auto scan = scanBuilder.build();
+
+  // ====== Aggregation: global, just grouping on 'a' ======
+  AggregationNode::Builder aggBuilder;
+  aggBuilder.id("agg")
+      .source(scan)
+      .preGroupedKeys({}) // none
+      .groupingKeys({std::make_shared<FieldAccessTypedExpr>(INTEGER(), "a")})
+      .aggregateNames({}) // no aggregates
+      .aggregates({})
+      .ignoreNullKeys(false)
+      .step(AggregationNode::Step::kPartial);
+
+  auto agg = aggBuilder.build();
+
+  // ====== Project casting a -> BIGINT ======
+  auto aInput = std::make_shared<FieldAccessTypedExpr>(INTEGER(), "a");
+  auto castExpr = std::make_shared<core::CastTypedExpr>(
+      BIGINT(), std::vector<TypedExprPtr>{aInput}, false);
+
+  auto project = std::make_shared<ProjectNode>(
+      "project",
+      std::vector<std::string>{"expr1"},
+      std::vector<TypedExprPtr>{castExpr},
+      agg);
+
+  // ====== Run planner with cast pushdown ======
+  LocalPlanner planner;
+  std::vector<std::unique_ptr<DriverFactory>> driverFactories;
+  ExprMap exprsToPush;
+
+  core::PlanNodePtr consumer;
+  auto planned = planner.planWithCastPushdown(
+      project,
+      /*newPipeline*/ true,
+      consumer,
+      OperatorSupplier{},
+      &driverFactories,
+      exprsToPush);
+
+  // ====== Pipeline count: still one pipeline ======
+  ASSERT_EQ(driverFactories.size(), 1);
+  ASSERT_EQ(driverFactories[0]->planNodes.size(), 3);
+
+  auto scanAfter = std::dynamic_pointer_cast<const TableScanNode>(
+      driverFactories[0]->planNodes[0]);
+  auto aggAfter = std::dynamic_pointer_cast<const AggregationNode>(
+      driverFactories[0]->planNodes[1]);
+  auto projectAfter = std::dynamic_pointer_cast<const ProjectNode>(
+      driverFactories[0]->planNodes[2]);
+
+  ASSERT_TRUE(scanAfter);
+  ASSERT_TRUE(aggAfter);
+  ASSERT_TRUE(projectAfter);
+
+  // ====== 1) TableScan schema unchanged ======
+  auto scanTypeAfter = scanAfter->outputType();
+  ASSERT_EQ(scanTypeAfter->size(), 1);
+  EXPECT_EQ(scanTypeAfter->nameOf(0), "a");
+  EXPECT_TRUE(scanTypeAfter->childAt(0)->equivalent(*INTEGER()));
+
+  // ====== 2) Aggregation output unchanged ======
+  auto aggTypeAfter = aggAfter->outputType();
+  ASSERT_EQ(aggTypeAfter->size(), 1);
+  EXPECT_EQ(aggTypeAfter->nameOf(0), "a");
+  EXPECT_TRUE(aggTypeAfter->childAt(0)->equivalent(*INTEGER()));
+
+  // ====== 3) Project still contains CastTypedExpr ======
+  const auto& projExprs = projectAfter->projections();
+  ASSERT_EQ(projExprs.size(), 1);
+  auto castAfter =
+      std::dynamic_pointer_cast<const core::CastTypedExpr>(projExprs[0]);
+  ASSERT_TRUE(castAfter); // still a cast, not replaced by FieldAccess
+  EXPECT_TRUE(castAfter->type()->equivalent(*BIGINT()));
+
+  // ====== 4) exprsToPush must be empty → cast cannot be pushed ======
+  EXPECT_TRUE(exprsToPush.empty());
+  EXPECT_TRUE(exprsToPush.count("a") == 0);
+}
+
+} // namespace

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -368,7 +368,8 @@ class TestIndexConnector : public connector::Connector {
       const RowTypePtr&,
       const connector::ConnectorTableHandlePtr&,
       const connector::ColumnHandleMap&,
-      connector::ConnectorQueryCtx*) override {
+      connector::ConnectorQueryCtx*,
+      bool pushdownCasts = false) override {
     VELOX_UNSUPPORTED("{} not implemented", __FUNCTION__);
   }
 

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnector.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnector.cpp
@@ -37,7 +37,8 @@ std::unique_ptr<DataSource> CudfHiveConnector::createDataSource(
     const RowTypePtr& outputType,
     const ConnectorTableHandlePtr& tableHandle,
     const ColumnHandleMap& columnHandles,
-    ConnectorQueryCtx* connectorQueryCtx) {
+    ConnectorQueryCtx* connectorQueryCtx,
+    bool pushdownCasts) {
   // If it's parquet then return CudfHiveDataSource
   // If it's not parquet then return HiveDataSource
   // TODO (dm): Make this ^^^ happen

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnector.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnector.h
@@ -41,7 +41,8 @@ class CudfHiveConnector final
       const RowTypePtr& outputType,
       const ConnectorTableHandlePtr& tableHandle,
       const ColumnHandleMap& columnHandles,
-      ConnectorQueryCtx* connectorQueryCtx) override final;
+      ConnectorQueryCtx* connectorQueryCtx,
+      bool pushdownCasts = false) override final;
 
   bool canAddDynamicFilter() const override {
     return false;

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -26,17 +26,20 @@
 
 namespace facebook::velox::exec {
 
-PrestoCastHooks::PrestoCastHooks(const core::QueryConfig& config)
-    : CastHooks(), legacyCast_(config.isLegacyCast()) {
+PrestoCastHooks::PrestoCastHooks(bool isLegacyCast, bool adjustTimestampToTimezone, const std::string& sessionTimezone)
+    : CastHooks(), legacyCast_(isLegacyCast) {
   if (!legacyCast_) {
     options_.zeroPaddingYear = true;
     options_.dateTimeSeparator = ' ';
-    const auto sessionTzName = config.sessionTimezone();
-    if (config.adjustTimestampToTimezone() && !sessionTzName.empty()) {
+    const auto sessionTzName = sessionTimezone;
+    if (adjustTimestampToTimezone && !sessionTzName.empty()) {
       options_.timeZone = tz::locateZone(sessionTzName);
     }
   }
 }
+
+PrestoCastHooks::PrestoCastHooks(const core::QueryConfig& config)
+    : PrestoCastHooks(config.isLegacyCast(), config.adjustTimestampToTimezone(), config.sessionTimezone()) {}
 
 Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
     const StringView& view) const {

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -25,6 +25,7 @@ namespace facebook::velox::exec {
 class PrestoCastHooks : public CastHooks {
  public:
   explicit PrestoCastHooks(const core::QueryConfig& config);
+  PrestoCastHooks(bool isLegacyCast, bool adjustTimestampToTimezone, const std::string& sessionTimezone);
 
   // Uses the default implementation of 'castFromDateString'.
   Expected<Timestamp> castStringToTimestamp(

--- a/velox/expression/tests/ExpressionRunnerTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerTest.cpp
@@ -27,7 +27,9 @@
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 #include "velox/expression/tests/ExpressionVerifier.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#ifdef VELOX_ENABLE_SPARK_FUNCTIONS
 #include "velox/functions/sparksql/registration/Register.h"
+#endif
 #include "velox/vector/VectorSaver.h"
 
 using namespace facebook::velox;
@@ -140,15 +142,27 @@ static bool validateMode(const char* flagName, const std::string& value) {
 
 static bool validateRegistry(const char* flagName, const std::string& value) {
   static const std::unordered_set<std::string> kRegistries = {
-      "presto", "spark"};
+      "presto"
+#ifdef VELOX_ENABLE_SPARK_FUNCTIONS
+      , "spark"
+#endif
+  };
+
   if (kRegistries.count(value) != 1) {
     std::cerr << "Invalid value for --" << flagName << ": " << value << ". ";
     std::cerr << "Valid values are: " << folly::join(", ", kRegistries) << "."
               << std::endl;
     return false;
   }
+
   if (value == "spark") {
+#ifdef VELOX_ENABLE_SPARK_FUNCTIONS
     functions::sparksql::registerFunctions("");
+#else
+    VELOX_FAIL("Spark function registry requested, "
+                 "but VELOX_ENABLE_SPARK_FUNCTIONS=OFF.");
+    return false;
+#endif
   } else if (value == "presto") {
     functions::prestosql::registerAllScalarFunctions();
   }

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -160,6 +160,15 @@ void PrestoVectorSerde::deserialize(
         header.compressedSize);
   }
 
+//  LOG(INFO) << "Deserializing page: "
+//            << " codecMarker=" << header.pageCodecMarker
+//            << " numRows=" << header.numRows
+//            << " uncompressedSize=" << header.uncompressedSize
+//            << " compressedSize=" << header.compressedSize
+//            << " checksum=" << header.checksum
+//            << " actualChecksum=" << actualCheckSum
+//            << " remainingSize=" << source->remainingSize();
+
   VELOX_CHECK_EQ(
       header.checksum, actualCheckSum, "Received corrupted serialized page.");
 

--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -936,7 +936,6 @@ void readArrayVector(
   ArrayVector* arrayVector = result->as<ArrayVector>();
 
   const auto resultElementsOffset = arrayVector->elements()->size();
-
   std::vector<TypePtr> childTypes = {type->childAt(0)};
   std::vector<VectorPtr> children{arrayVector->elements()};
   readColumns(
@@ -1090,7 +1089,6 @@ void readRowVector(
 
   source->read<int32_t>(); // numChildren
   auto& children = row->children();
-
   const auto& childTypes = type->asRow().children();
   readColumns(
       source,
@@ -1315,6 +1313,8 @@ void readColumns(
     auto& columnResult = results[i];
 
     const auto encoding = readLengthPrefixedString(source);
+    //    LOG(INFO) << "Column " << i << " encoding: " << encoding;
+
     if (encoding == kRLE) {
       readConstantVector(
           source,

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -1649,10 +1649,14 @@ bool isIntegral(const TypePtr& type) {
 }
 
 bool isWideningIntegerType(const TypePtr& inputType, const TypePtr& outputType) {
-  if (!isIntegral(outputType) || !isIntegral(inputType)) {
-    return false;
+  VLOG(2) << "OutputType: " << outputType->toString() << ", InputType: " << inputType->toString();
+  if (isIntegral(outputType) && isIntegral(inputType)) {
+    if (outputType->cppSizeInBytes() < inputType->cppSizeInBytes()) {
+      return true;
+    }
   }
-  if (outputType->cppSizeInBytes() < inputType->cppSizeInBytes()) {
+
+  if (inputType->isTimestamp() && outputType->isDate()) {
     return true;
   }
   return false;

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -512,8 +512,16 @@ bool RowType::containsChild(std::string_view name) const {
 }
 
 uint32_t RowType::getChildIdx(std::string_view name) const {
+//  LOG(INFO) << "\ngetChildIdx: \n" << std::string(name).c_str();
+
   auto index = getChildIdxIfExists(name);
   if (!index.has_value()) {
+//    const auto& nameToIndex = this->nameToIndex();
+//    LOG(INFO) << name << " not found. nameToIndex: \n";
+//    for (auto entry : nameToIndex) {
+//      LOG(INFO) << entry.data << " -> " << entry.index;
+//    }
+
     VELOX_USER_FAIL(makeFieldNotFoundErrorMessage(name, names_));
   }
   return index.value();
@@ -521,7 +529,11 @@ uint32_t RowType::getChildIdx(std::string_view name) const {
 
 std::optional<uint32_t> RowType::getChildIdxIfExists(
     std::string_view name) const {
-  const auto& nameToIndex = this->nameToIndex();
+    const auto& nameToIndex = this->nameToIndex();
+//  for (auto entry : nameToIndex) {
+//    LOG(INFO) << entry.data << " -> " << entry.index;
+//  }
+
   auto it = nameToIndex.find(NameIndex{name, 0});
   if (it != nameToIndex.end()) {
     return it->index;
@@ -1629,5 +1641,20 @@ std::string stringifyTruncatedElementList(
   }
   out << "}";
   return out.str();
+}
+
+bool isIntegral(const TypePtr& type) {
+  return type->isBigint() || type->isInteger() || type->isSmallint() ||
+      type->isTinyint();
+}
+
+bool isWideningIntegerType(const TypePtr& inputType, const TypePtr& outputType) {
+  if (!isIntegral(outputType) || !isIntegral(inputType)) {
+    return false;
+  }
+  if (outputType->cppSizeInBytes() < inputType->cppSizeInBytes()) {
+    return true;
+  }
+  return false;
 }
 } // namespace facebook::velox

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2558,7 +2558,6 @@ std::string stringifyTruncatedElementList(
 bool isIntegral(const TypePtr& type);
 
 bool isWideningIntegerType(const TypePtr& inputType, const TypePtr& outputType);
-
 } // namespace facebook::velox
 
 namespace folly {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2554,6 +2554,11 @@ std::string stringifyTruncatedElementList(
     const std::function<void(std::stringstream&, size_t)>& stringifyElement,
     size_t limit = 5);
 
+
+bool isIntegral(const TypePtr& type);
+
+bool isWideningIntegerType(const TypePtr& inputType, const TypePtr& outputType);
+
 } // namespace facebook::velox
 
 namespace folly {

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -293,6 +293,110 @@ void FlatVector<T>::copyValuesAndNulls(
   }
 }
 
+namespace {
+
+// Narrow → wide only for integral types (bool excluded).
+template <typename Dst, typename Src>
+inline void copyWideningIntegralRange(
+    Dst* __restrict dst,
+    const Src* __restrict src,
+    vector_size_t targetIndex,
+    vector_size_t sourceIndex,
+    vector_size_t count) {
+  for (vector_size_t i = 0; i < count; ++i) {
+    dst[targetIndex + i] = static_cast<Dst>(src[sourceIndex + i]);
+  }
+}
+
+template <typename T, typename Src>
+inline void copyFromFlatWideningIntegral(
+    const BaseVector* source,
+    FlatVector<T>* self,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    const uint64_t* sourceRawNulls,
+    uint64_t* rawNulls) {
+  static_assert(std::is_integral_v<Src> && !std::is_same_v<Src, bool>);
+  auto* srcFlat = source->asUnchecked<FlatVector<Src>>();
+  if (srcFlat->values() == nullptr) {
+    BaseVector::setNulls(self->BaseVector::mutableRawNulls(), ranges, true);
+    return;
+  }
+
+  const Src* srcValues = srcFlat->rawValues();
+  auto* dst = self->mutableRawValues();
+  applyToEachRange(ranges, [&](auto targetIndex, auto sourceIndex, auto count) {
+    copyWideningIntegralRange<T, Src>(
+        dst, srcValues, targetIndex, sourceIndex, count);
+  });
+
+  if (rawNulls) {
+    if (sourceRawNulls) {
+      BaseVector::copyNulls(rawNulls, sourceRawNulls, ranges);
+    } else {
+      BaseVector::setNulls(rawNulls, ranges, false);
+    }
+  }
+}
+
+template <typename T, typename Src>
+inline void copyFromConstantWideningIntegral(
+    const BaseVector* source,
+    FlatVector<T>* self,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    uint64_t* rawNulls) {
+  static_assert(std::is_integral_v<Src> && !std::is_same_v<Src, bool>);
+  auto* constant = source->asUnchecked<ConstantVector<Src>>();
+  const T widened = static_cast<T>(constant->valueAt(0));
+
+  if constexpr (std::is_same_v<T, bool>) {
+    auto rawValues = reinterpret_cast<uint64_t*>(self->rawValues());
+    applyToEachRange(
+        ranges, [&](auto targetIndex, auto /*sourceIndex*/, auto count) {
+          bits::fillBits(rawValues, targetIndex, targetIndex + count, widened);
+        });
+  } else {
+    applyToEachRow(ranges, [&](auto targetIndex, auto /*sourceIndex*/) {
+      self->mutableRawValues()[targetIndex] = widened;
+    });
+  }
+
+  if (rawNulls) {
+    BaseVector::setNulls(rawNulls, ranges, false);
+  }
+}
+
+template <typename T, typename Src>
+inline void copyFromSimpleWideningIntegral(
+    const BaseVector* source,
+    FlatVector<T>* self,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    uint64_t* rawNulls) {
+  static_assert(std::is_integral_v<Src> && !std::is_same_v<Src, bool>);
+  auto* srcVec = source->asUnchecked<SimpleVector<Src>>();
+
+  uint64_t* rawBoolValues = nullptr;
+  if constexpr (std::is_same_v<T, bool>) {
+    rawBoolValues = reinterpret_cast<uint64_t*>(self->rawValues());
+  }
+
+  applyToEachRow(ranges, [&](auto targetIndex, auto sourceIndex) {
+    if (!source->isNullAt(sourceIndex)) {
+      const auto v = static_cast<T>(srcVec->valueAt(sourceIndex));
+      if constexpr (std::is_same_v<T, bool>) {
+        bits::setBit(rawBoolValues, targetIndex, v);
+      } else {
+        self->mutableRawValues()[targetIndex] = v;
+      }
+      if (rawNulls)
+        bits::clearNull(rawNulls, targetIndex);
+    } else {
+      bits::setNull(rawNulls, targetIndex);
+    }
+  });
+}
+
+} // namespace
+
 template <typename T>
 void FlatVector<T>::copyRanges(
     const BaseVector* source,
@@ -303,7 +407,9 @@ void FlatVector<T>::copyRanges(
   }
 
   source = source->loadedVector();
-  VELOX_CHECK_EQ(BaseVector::typeKind(), source->typeKind());
+  VELOX_CHECK(
+      BaseVector::typeKind() == source->typeKind() ||
+      isWideningIntegerType(this->type(), source->type()));
 
   if constexpr (std::is_same_v<T, StringView>) {
     auto leaf =
@@ -337,44 +443,83 @@ void FlatVector<T>::copyRanges(
   }
 
   if (source->isFlatEncoding()) {
-    auto* flatSource = source->asUnchecked<FlatVector<T>>();
-    if (flatSource->values() == nullptr) {
-      // All source values are null.
-      BaseVector::setNulls(BaseVector::mutableRawNulls(), ranges, true);
-      return;
-    }
+    // If exact type match, keep the fast path:
+    if (BaseVector::typeKind() == source->typeKind()) {
+      auto* flatSource = source->asUnchecked<FlatVector<T>>();
+      if (flatSource->values() == nullptr) {
+        // All source values are null.
+        BaseVector::setNulls(BaseVector::mutableRawNulls(), ranges, true);
+        return;
+      }
 
-    if constexpr (std::is_same_v<T, bool>) {
-      auto rawValues = reinterpret_cast<uint64_t*>(rawValues_);
-      auto* sourceValues = flatSource->template rawValues<uint64_t>();
-      applyToEachRange(
-          ranges, [&](auto targetIndex, auto sourceIndex, auto count) {
-            bits::copyBits(
-                sourceValues, sourceIndex, rawValues, targetIndex, count);
-          });
-    } else {
-      const T* sourceValues = flatSource->rawValues();
-      applyToEachRange(
-          ranges, [&](auto targetIndex, auto sourceIndex, auto count) {
-            if constexpr (Buffer::is_pod_like_v<T>) {
-              memcpy(
-                  &rawValues_[targetIndex],
-                  &sourceValues[sourceIndex],
-                  count * sizeof(T));
-            } else {
-              std::copy(
-                  sourceValues + sourceIndex,
-                  sourceValues + sourceIndex + count,
-                  rawValues_ + targetIndex);
-            }
-          });
-    }
-
-    if (rawNulls) {
-      if (sourceRawNulls) {
-        BaseVector::copyNulls(rawNulls, sourceRawNulls, ranges);
+      if constexpr (std::is_same_v<T, bool>) {
+        auto rawValues = reinterpret_cast<uint64_t*>(rawValues_);
+        auto* sourceValues = flatSource->template rawValues<uint64_t>();
+        applyToEachRange(
+            ranges, [&](auto targetIndex, auto sourceIndex, auto count) {
+              bits::copyBits(
+                  sourceValues, sourceIndex, rawValues, targetIndex, count);
+            });
       } else {
-        BaseVector::setNulls(rawNulls, ranges, false);
+        const T* sourceValues = flatSource->rawValues();
+        if (isWideningIntegerType(this->type(), source->type())) {
+          applyToEachRange(
+              ranges, [&](auto targetIndex, auto sourceIndex, auto count) {
+                for (auto i = 0; i < count; ++i) {
+                  rawValues_[targetIndex + i] =
+                      static_cast<T>(sourceValues[sourceIndex + i]);
+                }
+              });
+        } else {
+          applyToEachRange(
+              ranges, [&](auto targetIndex, auto sourceIndex, auto count) {
+                if constexpr (Buffer::is_pod_like_v<T>) {
+                  memcpy(
+                      &rawValues_[targetIndex],
+                      &sourceValues[sourceIndex],
+                      count * sizeof(T));
+                } else {
+                  std::copy(
+                      sourceValues + sourceIndex,
+                      sourceValues + sourceIndex + count,
+                      rawValues_ + targetIndex);
+                }
+              });
+        }
+      }
+
+      if (rawNulls) {
+        if (sourceRawNulls) {
+          BaseVector::copyNulls(rawNulls, sourceRawNulls, ranges);
+        } else {
+          BaseVector::setNulls(rawNulls, ranges, false);
+        }
+      }
+    } else if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+      if (isWideningIntegerType(this->type(), source->type())) {
+        switch (source->typeKind()) {
+          case TypeKind::TINYINT:
+            copyFromFlatWideningIntegral<T, int8_t>(
+                source, this, ranges, sourceRawNulls, rawNulls);
+            break;
+          case TypeKind::SMALLINT:
+            copyFromFlatWideningIntegral<T, int16_t>(
+                source, this, ranges, sourceRawNulls, rawNulls);
+            break;
+          case TypeKind::INTEGER:
+            copyFromFlatWideningIntegral<T, int32_t>(
+                source, this, ranges, sourceRawNulls, rawNulls);
+            break;
+          case TypeKind::BIGINT:
+            copyFromFlatWideningIntegral<T, int64_t>(
+                source, this, ranges, sourceRawNulls, rawNulls);
+            break;
+          default:
+            VELOX_UNSUPPORTED(
+                "FlatVector widening: unsupported {} -> {}",
+                source->typeKind(),
+                BaseVector::typeKind());
+        }
       }
     }
   } else if (source->isConstantEncoding()) {
@@ -382,44 +527,103 @@ void FlatVector<T>::copyRanges(
       BaseVector::setNulls(rawNulls, ranges, true);
       return;
     }
-    auto constant = source->asUnchecked<ConstantVector<T>>();
-    T value = constant->valueAt(0);
-    if constexpr (std::is_same_v<T, bool>) {
-      auto rawValues = reinterpret_cast<uint64_t*>(rawValues_);
-      applyToEachRange(
-          ranges, [&](auto targetIndex, auto /*sourceIndex*/, auto count) {
-            bits::fillBits(rawValues, targetIndex, targetIndex + count, value);
-          });
-    } else {
-      applyToEachRow(ranges, [&](auto targetIndex, auto /*sourceIndex*/) {
-        rawValues_[targetIndex] = value;
-      });
-    }
 
-    if (rawNulls) {
-      BaseVector::setNulls(rawNulls, ranges, false);
+    if (BaseVector::typeKind() == source->typeKind()) {
+      auto constant = source->asUnchecked<ConstantVector<T>>();
+      T value = constant->valueAt(0);
+      if constexpr (std::is_same_v<T, bool>) {
+        auto rawValues = reinterpret_cast<uint64_t*>(rawValues_);
+        applyToEachRange(
+            ranges, [&](auto targetIndex, auto /*sourceIndex*/, auto count) {
+              bits::fillBits(
+                  rawValues, targetIndex, targetIndex + count, value);
+            });
+      } else {
+        applyToEachRow(ranges, [&](auto targetIndex, auto /*sourceIndex*/) {
+          rawValues_[targetIndex] = value;
+        });
+      }
+
+      if (rawNulls) {
+        BaseVector::setNulls(rawNulls, ranges, false);
+      }
+    } else if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+      if (isWideningIntegerType(this->type(), source->type())) {
+        switch (source->typeKind()) {
+          case TypeKind::TINYINT:
+            copyFromConstantWideningIntegral<T, int8_t>(
+                source, this, ranges, rawNulls);
+            break;
+          case TypeKind::SMALLINT:
+            copyFromConstantWideningIntegral<T, int16_t>(
+                source, this, ranges, rawNulls);
+            break;
+          case TypeKind::INTEGER:
+            copyFromConstantWideningIntegral<T, int32_t>(
+                source, this, ranges, rawNulls);
+            break;
+          case TypeKind::BIGINT:
+            copyFromConstantWideningIntegral<T, int64_t>(
+                source, this, ranges, rawNulls);
+            break;
+          default:
+            VELOX_UNSUPPORTED(
+                "Constant widening: unsupported {} -> {}",
+                source->typeKind(),
+                BaseVector::typeKind());
+        }
+      }
     }
   } else {
-    auto* sourceVector = source->asUnchecked<SimpleVector<T>>();
-    uint64_t* rawBoolValues = nullptr;
-    if constexpr (std::is_same_v<T, bool>) {
-      rawBoolValues = reinterpret_cast<uint64_t*>(rawValues_);
-    }
-    applyToEachRow(ranges, [&](auto targetIndex, auto sourceIndex) {
-      if (!source->isNullAt(sourceIndex)) {
-        auto sourceValue = sourceVector->valueAt(sourceIndex);
-        if constexpr (std::is_same_v<T, bool>) {
-          bits::setBit(rawBoolValues, targetIndex, sourceValue);
-        } else {
-          rawValues_[targetIndex] = sourceValue;
-        }
-        if (rawNulls) {
-          bits::clearNull(rawNulls, targetIndex);
-        }
-      } else {
-        bits::setNull(rawNulls, targetIndex);
+    // wrapped/simple (e.g., dictionary)
+    if (BaseVector::typeKind() == source->typeKind()) {
+      auto* sourceVector = source->asUnchecked<SimpleVector<T>>();
+      uint64_t* rawBoolValues = nullptr;
+      if constexpr (std::is_same_v<T, bool>) {
+        rawBoolValues = reinterpret_cast<uint64_t*>(rawValues_);
       }
-    });
+      applyToEachRow(ranges, [&](auto targetIndex, auto sourceIndex) {
+        if (!source->isNullAt(sourceIndex)) {
+          auto sourceValue = sourceVector->valueAt(sourceIndex);
+          if constexpr (std::is_same_v<T, bool>) {
+            bits::setBit(rawBoolValues, targetIndex, sourceValue);
+          } else {
+            rawValues_[targetIndex] = sourceValue;
+          }
+          if (rawNulls) {
+            bits::clearNull(rawNulls, targetIndex);
+          }
+        } else {
+          bits::setNull(rawNulls, targetIndex);
+        }
+      });
+    } else if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+      if (isWideningIntegerType(this->type(), source->type())) {
+        switch (source->typeKind()) {
+          case TypeKind::TINYINT:
+            copyFromSimpleWideningIntegral<T, int8_t>(
+                source, this, ranges, rawNulls);
+            break;
+          case TypeKind::SMALLINT:
+            copyFromSimpleWideningIntegral<T, int16_t>(
+                source, this, ranges, rawNulls);
+            break;
+          case TypeKind::INTEGER:
+            copyFromSimpleWideningIntegral<T, int32_t>(
+                source, this, ranges, rawNulls);
+            break;
+          case TypeKind::BIGINT:
+            copyFromSimpleWideningIntegral<T, int64_t>(
+                source, this, ranges, rawNulls);
+            break;
+          default:
+            VELOX_UNSUPPORTED(
+                "Simple widening: unsupported {} -> {}",
+                source->typeKind(),
+                BaseVector::typeKind());
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
PUshdown integer upcasts to source operators

Only when there are join nodes or result output nodes in the fragment that an integer upcast is needed. In this case, pushdown the upcasts to source operators like TableScanNode or ExchangeNode.