### PR TITLE
feat: Add now() and current_timestamp function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -188,6 +188,19 @@ Date and Time Functions
 
         SELECT current_timezone;   -- Asia/Kolkata
 
+.. function:: current_timestamp() -> timestamp with time zone
+.. function:: now() -> timestamp with time zone
+
+    Returns the current timestamp with session time zone applied.
+    The timestamp is captured once at the start of query execution and remains
+    constant throughout the query. This matches the standard SQL behavior for
+    ``CURRENT_TIMESTAMP`` and ``NOW()``.
+
+    Example::
+
+        SELECT current_timestamp;  -- 2025-07-17 14:53:12.123 Asia/Kolkata
+        SELECT now();              -- 2025-07-17 14:53:12.123 Asia/Kolkata
+
 Truncation Function
 -------------------
 

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -126,6 +126,9 @@ std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
 // testing. Use function signature to exclude only a specific signature.
 std::unordered_set<std::string> skipFunctions = {
     "noisy_empty_approx_set_sfm", // Non-deterministic because of privacy.
+    "current_timestamp", // Non-deterministic: returns the current timestamp at
+                         // query execution time, so results differ across runs
+    "now", // alias for current_timestamp
     "merge_sfm", // Fuzzer can generate sketches of different sizes.
     "element_at",
     "width_bucket",

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1782,6 +1782,30 @@ struct CurrentDateFunction {
 };
 
 template <typename T>
+struct CurrentTimestampFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  int64_t result_{0};
+  const tz::TimeZone* timeZone_ = nullptr;
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /* type */,
+      const core::QueryConfig& config) {
+    Timestamp ts = Timestamp::now();
+    timeZone_ = getTimeZoneFromConfig(config);
+    if (timeZone_ != nullptr) {
+      result_ = pack(ts, timeZone_->id());
+      return;
+    }
+    result_ = pack(ts, Timestamp::defaultTimezone().id());
+  }
+
+  FOLLY_ALWAYS_INLINE void call(out_type<TimestampWithTimezone>& result) {
+    result = result_;
+  }
+};
+
+template <typename T>
 struct CurrentTimezoneFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
   std::string tzName_;

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -90,6 +90,10 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "to_unixtime"});
 
   registerFromUnixtime(prefix + "from_unixtime");
+  registerFunction<CurrentTimestampFunction, TimestampWithTimezone>(
+      {prefix + "current_timestamp"});
+  registerFunction<CurrentTimestampFunction, TimestampWithTimezone>(
+      {prefix + "now"});
   registerFunction<CurrentTimezoneFunction, Varchar>(
       {prefix + "current_timezone"});
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -6833,3 +6833,37 @@ TEST_F(DateTimeFunctionsTest, currentTimezone) {
     EXPECT_EQ(tz.value(), "America/New_York");
   }
 }
+
+TEST_F(DateTimeFunctionsTest, currentTimestamp) {
+    setQueryTimeZone("Asia/Kolkata");
+
+  auto empotyRowVector = makeRowVector(ROW({}), 1);
+  auto befre = Timestamp::now().toMillis();
+
+  auto packedNow = evaluateOnce<int64_t>("now()", emptyRowVector);
+  auto packedCurrentTimestamp =
+      evaluateOnce<int64_t>("current_timestamp()", emptyRowVector);
+
+  auto after = Timestamp::now().toMillis();
+
+  ASSERT_TRUE(packedNow.has_value()) << "now() returned nullopt";
+  auto unpackedNow = TimestampWithTimezone::unpack(packedNow);
+  ASSERT_TRUE(unpackedNow.has_value()) << "Failed to unpack now() result";
+
+  ASSERT_TRUE(packedCurrentTimestamp.has_value())
+      << "current_timestamp() returned nullopt";
+  auto unpackedCurrent = TimestampWithTimezone::unpack(packedCurrentTimestamp);
+  ASSERT_TRUE(unpackedCurrent.has_value())
+      << "Failed to unpack current_timestamp() result";
+
+  EXPECT_LE(before, unpackedNow->milliSeconds_);
+  EXPECT_LE(unpackedNow->milliSeconds_, after);
+  EXPECT_LE(before, unpackedCurrent->milliSeconds_);
+  EXPECT_LE(unpackedCurrent->milliSeconds_, after);
+
+  EXPECT_EQ(unpackedNow->timezone_->name(), "Asia/Kolkata");
+  EXPECT_EQ(unpackedCurrent->timezone_->name(), "Asia/Kolkata");
+  EXPECT_EQ(unpackedNow->timezone_->name(), unpackedCurrent->timezone_->name());
+
+  EXPECT_NEAR(unpackedNow->milliSeconds_, unpackedCurrent->milliSeconds_, 200);
+}


### PR DESCRIPTION
In the past, we were not implementing functions like now() that returned constants in Velox. This was because Presto Java would infer the constant value at the co-ordinator and fold it, so the worker was never passed this function in execution.

However, with recent changes for side-car and worker based constant folding implementation, we need native implementations for functions like now(), so adding to Velox as well.