### PR TITLE
Fix field id test in velox_parquet_writer_test

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -259,7 +259,6 @@ std::shared_ptr<::arrow::Field> updateFieldNameAndIdRecursive(
     }
     newField = newField->WithType(::arrow::struct_(newFields));
   } else if (type.isArray()) {
-    newField = field->WithName(name);
     auto listType =
         std::dynamic_pointer_cast<::arrow::BaseListType>(newField->type());
     auto elementType = type.asArray().elementType();
@@ -270,7 +269,6 @@ std::shared_ptr<::arrow::Field> updateFieldNameAndIdRecursive(
     newField = newField->WithType(::arrow::list(updatedElementField));
   } else if (type.isMap()) {
     auto mapType = type.asMap();
-    newField = field->WithName(name);
     auto arrowMapType =
         std::dynamic_pointer_cast<::arrow::MapType>(newField->type());
     const auto* keySetting = fieldId ? &fieldId->children.at(0) : nullptr;


### PR DESCRIPTION
Fix the test failure

```
[2025-12-31T07:36:30.840Z] [ RUN      ] ParquetWriterTest.withFieldIds
[2025-12-31T07:36:30.840Z] /opt/velox/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp:920: Failure
[2025-12-31T07:36:30.840Z] Expected equality of these values:
[2025-12-31T07:36:30.840Z]   root->field(2)->field_id()
[2025-12-31T07:36:30.840Z]     Which is: -1
[2025-12-31T07:36:30.840Z]   30
[2025-12-31T07:36:30.840Z] /opt/velox/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp:921: Failure
[2025-12-31T07:36:30.840Z] Expected equality of these values:
[2025-12-31T07:36:30.840Z]   root->field(3)->field_id()
[2025-12-31T07:36:30.840Z]     Which is: -1
[2025-12-31T07:36:30.840Z]   40
[2025-12-31T07:36:30.840Z] [  FAILED  ] ParquetWriterTest.withFieldIds (2 ms)
[2025-12-31T07:36:30.840Z] [----------] 11 tests from ParquetWriterTest (238 ms total)
[2025-12-31T07:36:30.840Z] 
[2025-12-31T07:36:30.840Z] [----------] 2 tests from ParquetWriterFieldIdTest/ParquetWriterFieldIdTest
[2025-12-31T07:36:30.840Z] [ RUN      ] ParquetWriterFieldIdTest/ParquetWriterFieldIdTest.fieldIds/0
[2025-12-31T07:36:30.840Z] [       OK ] ParquetWriterFieldIdTest/ParquetWriterFieldIdTest.fieldIds/0 (1 ms)
[2025-12-31T07:36:30.840Z] [ RUN      ] ParquetWriterFieldIdTest/ParquetWriterFieldIdTest.fieldIds/1
[2025-12-31T07:36:30.840Z] /opt/velox/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp:96: Failure
[2025-12-31T07:36:30.840Z] Expected equality of these values:
[2025-12-31T07:36:30.840Z]   root->field(2)->field_id()
[2025-12-31T07:36:30.840Z]     Which is: -1
[2025-12-31T07:36:30.840Z]   exp(30)
[2025-12-31T07:36:30.840Z]     Which is: 30
[2025-12-31T07:36:30.840Z] /opt/velox/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp:97: Failure
[2025-12-31T07:36:30.840Z] Expected equality of these values:
[2025-12-31T07:36:30.840Z]   root->field(3)->field_id()
[2025-12-31T07:36:30.840Z]     Which is: -1
[2025-12-31T07:36:30.840Z]   exp(40)
[2025-12-31T07:36:30.840Z]     Which is: 40
[2025-12-31T07:36:30.840Z] [  FAILED  ] ParquetWriterFieldIdTest/ParquetWriterFieldIdTest.fieldIds/1, where GetParam() = true (1 ms)
```