### PR TITLE
Add PartitionedVector benchmark

### DIFF
--- a/velox/vector/benchmarks/CMakeLists.txt
+++ b/velox/vector/benchmarks/CMakeLists.txt
@@ -45,3 +45,13 @@ target_link_libraries(
   gflags::gflags
   glog::glog
 )
+
+add_executable(velox_vector_partitioned_vector_benchmark PartitionedVectorBenchmark.cpp)
+target_link_libraries(
+  velox_vector_partitioned_vector_benchmark
+  velox_dwio_common_test_utils
+  velox_vector
+  velox_vector_test_lib
+  Folly::folly
+  Folly::follybenchmark
+)

--- a/velox/vector/benchmarks/PartitionedVectorBenchmark.cpp
+++ b/velox/vector/benchmarks/PartitionedVectorBenchmark.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <absl/random/uniform_int_distribution.h>
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include <algorithm>
+
+#include "dwio/common/tests/utils/BatchMaker.h"
+#include "vector/PartitionedVector.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::test {
+
+namespace {
+
+thread_local auto gen = std::mt19937(42);
+
+auto noNulls = [](vector_size_t) { return false; };
+
+auto allNulls = [](vector_size_t) { return true; };
+
+auto halfNulls = [](vector_size_t row) { return row % 2 == 0; };
+
+template <TypeKind T>
+RowTypePtr scalarTypeGenerator(int32_t numColumns) {
+  return ROW(std::vector<TypePtr>(numColumns, createScalarType<T>()));
+}
+
+RowTypePtr dateTypeGenerator(int32_t numColumns) {
+  return ROW(std::vector<TypePtr>(numColumns, DATE()));
+}
+
+RowTypePtr shortDecimalTypeGenerator(int32_t numColumns) {
+  return ROW(std::vector<TypePtr>(numColumns, DECIMAL(10, 2)));
+}
+
+RowTypePtr longDecimalTypeGenerator(int32_t numColumns) {
+  return ROW(std::vector<TypePtr>(numColumns, DECIMAL(20, 3)));
+}
+
+RowTypePtr mixedFlatTypeGenerator(int32_t numColumns) {
+  const std::vector<TypePtr> typeSelection = {
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      HUGEINT(),
+      REAL(),
+      DOUBLE(),
+      TIMESTAMP(),
+      DATE(),
+      DECIMAL(10, 2),
+      DECIMAL(20, 3),
+  };
+
+  std::vector<TypePtr> types;
+  types.reserve(numColumns);
+
+  for (int i = 0; i < numColumns; ++i) {
+    types.push_back(typeSelection[i % typeSelection.size()]);
+  }
+
+  std::ranges::shuffle(types, gen);
+
+  return ROW(std::move(types));
+}
+
+auto randomPartitionFunction = [](const RowVectorPtr& vector,
+                                  uint32_t numPartitions,
+                                  std::vector<uint32_t>& partitions) {
+  partitions.resize(vector->size());
+  for (int i = 0; i < vector->size(); ++i) {
+    partitions[i] = gen() % numPartitions;
+  }
+};
+
+std::shared_ptr<memory::MemoryPool> pool;
+std::vector<uint32_t> partitions;
+
+RowVectorPtr createTestVector(
+    const std::function<RowTypePtr(int32_t)>& rowTypeGenerator,
+    vector_size_t numRows,
+    int32_t numColumns,
+    const std::function<bool(vector_size_t)>& isNullAt) {
+  auto rowType = rowTypeGenerator(numColumns);
+  const auto batch = BatchMaker::createBatch(rowType, numRows, *pool, isNullAt);
+  return std::static_pointer_cast<RowVector>(batch);
+}
+
+} // namespace
+
+void runBM(
+    uint32_t iterations,
+    const std::function<RowTypePtr(int32_t)>& rowTypeGenerator,
+    int32_t numColumns,
+    uint32_t numPartitions,
+    const std::function<bool(vector_size_t)>& isNullAt = noNulls,
+    vector_size_t numRows = 10000) {
+  folly::BenchmarkSuspender suspender;
+  PartitionBuildContext ctx;
+  auto vector =
+      createTestVector(rowTypeGenerator, numRows, numColumns, isNullAt);
+  randomPartitionFunction(vector, numPartitions, partitions);
+  for (uint32_t i = 0; i < iterations; ++i) {
+    // PartitionedVector::create mutates its input, so each iteration needs a
+    // fresh copy to keep inputs consistent.
+    const auto vectorCopy = std::static_pointer_cast<RowVector>(
+        BaseVector::copy(*vector, pool.get()));
+    suspender.dismiss();
+    PartitionedVector::create(
+        vectorCopy, partitions, numPartitions, ctx, pool.get());
+    suspender.rehire();
+  }
+}
+
+#define BENCHMARK_CONFIG(name, generator, numCols, nulls, numParts) \
+  BENCHMARK_NAMED_PARAM(                                            \
+      runBM,                                                        \
+      name##_##numCols##Cols_##nulls##_P##numParts,                 \
+      generator,                                                    \
+      numCols,                                                      \
+      numParts,                                                     \
+      nulls);
+
+#define BENCHMARK_PARTITIONS(name, generator, numCols, nulls) \
+  BENCHMARK_CONFIG(name, generator, numCols, nulls, 4)        \
+  BENCHMARK_CONFIG(name, generator, numCols, nulls, 16)       \
+  BENCHMARK_CONFIG(name, generator, numCols, nulls, 64)       \
+  BENCHMARK_CONFIG(name, generator, numCols, nulls, 256)      \
+  BENCHMARK_CONFIG(name, generator, numCols, nulls, 1024)
+
+#define BENCHMARK_SIZES(name, generator, nulls)     \
+  BENCHMARK_PARTITIONS(name, generator, 1, nulls)   \
+  BENCHMARK_PARTITIONS(name, generator, 10, nulls)  \
+  BENCHMARK_PARTITIONS(name, generator, 100, nulls) \
+  BENCHMARK_PARTITIONS(name, generator, 1000, nulls)
+
+#define BENCHMARK_TYPE(name, generator)      \
+  BENCHMARK_SIZES(name, generator, noNulls)  \
+  BENCHMARK_SIZES(name, generator, allNulls) \
+  BENCHMARK_SIZES(name, generator, halfNulls)
+
+BENCHMARK_TYPE(BOOLEAN, scalarTypeGenerator<TypeKind::BOOLEAN>);
+BENCHMARK_TYPE(SMALLINT, scalarTypeGenerator<TypeKind::SMALLINT>);
+BENCHMARK_TYPE(INTEGER, scalarTypeGenerator<TypeKind::INTEGER>);
+BENCHMARK_TYPE(BIGINT, scalarTypeGenerator<TypeKind::BIGINT>);
+BENCHMARK_TYPE(HUGEINT, scalarTypeGenerator<TypeKind::HUGEINT>);
+BENCHMARK_TYPE(REAL, scalarTypeGenerator<TypeKind::REAL>);
+BENCHMARK_TYPE(DOUBLE, scalarTypeGenerator<TypeKind::DOUBLE>);
+BENCHMARK_TYPE(TIMESTAMP, scalarTypeGenerator<TypeKind::TIMESTAMP>);
+BENCHMARK_TYPE(VARCHAR, scalarTypeGenerator<TypeKind::VARCHAR>);
+BENCHMARK_TYPE(VARBINARY, scalarTypeGenerator<TypeKind::VARBINARY>);
+BENCHMARK_TYPE(DATE, dateTypeGenerator);
+BENCHMARK_TYPE(ShortDecimal, shortDecimalTypeGenerator);
+BENCHMARK_TYPE(LongDecimal, longDecimalTypeGenerator);
+BENCHMARK_TYPE(Mixed, mixedFlatTypeGenerator);
+
+} // namespace facebook::velox::test
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  pool = memory::memoryManager()->addLeafPool();
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Add benchmark for the creation of PartitionedVectors (Only flat vectors now).

The following benchmark data was collected on an Apple machine with:
Chip: Apple M3 Max
Total Number of Cores: 16 (12 Performance and 4 Efficiency)
Memory: 64 GB
OS: macOS 26.3  (25D125)

<details>
<summary>Benchmark Results</summary>

```
./velox_vector_partitioned_vector_benchmark
WARNING: Benchmark running in DEBUG mode
============================================================================
[...]hmarks/PartitionedVectorBenchmark.cpp     relative  time/iter   iters/s
============================================================================
runBM(BOOLEAN_1Cols_noNulls_P4)                            82.88us    12.07K
runBM(BOOLEAN_1Cols_noNulls_P16)                           81.61us    12.25K
runBM(BOOLEAN_1Cols_noNulls_P64)                           77.24us    12.95K
runBM(BOOLEAN_1Cols_noNulls_P256)                          87.80us    11.39K
runBM(BOOLEAN_1Cols_noNulls_P1024)                         88.99us    11.24K
runBM(BOOLEAN_10Cols_noNulls_P4)                          439.72us     2.27K
runBM(BOOLEAN_10Cols_noNulls_P16)                         542.47us     1.84K
runBM(BOOLEAN_10Cols_noNulls_P64)                         568.09us     1.76K
runBM(BOOLEAN_10Cols_noNulls_P256)                        603.13us     1.66K
runBM(BOOLEAN_10Cols_noNulls_P1024)                       645.72us     1.55K
runBM(BOOLEAN_100Cols_noNulls_P4)                           4.22ms    236.90
runBM(BOOLEAN_100Cols_noNulls_P16)                          5.57ms    179.57
runBM(BOOLEAN_100Cols_noNulls_P64)                          5.57ms    179.59
runBM(BOOLEAN_100Cols_noNulls_P256)                         6.08ms    164.36
runBM(BOOLEAN_100Cols_noNulls_P1024)                        6.05ms    165.32
runBM(BOOLEAN_1000Cols_noNulls_P4)                         42.41ms     23.58
runBM(BOOLEAN_1000Cols_noNulls_P16)                        56.23ms     17.79
runBM(BOOLEAN_1000Cols_noNulls_P64)                        59.45ms     16.82
runBM(BOOLEAN_1000Cols_noNulls_P256)                       60.80ms     16.45
runBM(BOOLEAN_1000Cols_noNulls_P1024)                      61.48ms     16.26
runBM(BOOLEAN_1Cols_allNulls_P4)                           77.90us    12.84K
runBM(BOOLEAN_1Cols_allNulls_P16)                          70.59us    14.17K
runBM(BOOLEAN_1Cols_allNulls_P64)                          76.22us    13.12K
runBM(BOOLEAN_1Cols_allNulls_P256)                         87.67us    11.41K
runBM(BOOLEAN_1Cols_allNulls_P1024)                        88.97us    11.24K
runBM(BOOLEAN_10Cols_allNulls_P4)                         407.68us     2.45K
runBM(BOOLEAN_10Cols_allNulls_P16)                        495.97us     2.02K
runBM(BOOLEAN_10Cols_allNulls_P64)                        539.18us     1.85K
runBM(BOOLEAN_10Cols_allNulls_P256)                       596.93us     1.68K
runBM(BOOLEAN_10Cols_allNulls_P1024)                      602.34us     1.66K
runBM(BOOLEAN_100Cols_allNulls_P4)                          3.29ms    304.24
runBM(BOOLEAN_100Cols_allNulls_P16)                         4.05ms    246.69
runBM(BOOLEAN_100Cols_allNulls_P64)                         4.54ms    220.46
runBM(BOOLEAN_100Cols_allNulls_P256)                        4.62ms    216.44
runBM(BOOLEAN_100Cols_allNulls_P1024)                       4.49ms    222.65
runBM(BOOLEAN_1000Cols_allNulls_P4)                        32.08ms     31.18
runBM(BOOLEAN_1000Cols_allNulls_P16)                       39.77ms     25.15
runBM(BOOLEAN_1000Cols_allNulls_P64)                       44.18ms     22.63
runBM(BOOLEAN_1000Cols_allNulls_P256)                      44.05ms     22.70
runBM(BOOLEAN_1000Cols_allNulls_P1024)                     44.51ms     22.47
runBM(BOOLEAN_1Cols_halfNulls_P4)                          78.97us    12.66K
runBM(BOOLEAN_1Cols_halfNulls_P16)                         81.13us    12.33K
runBM(BOOLEAN_1Cols_halfNulls_P64)                         84.88us    11.78K
runBM(BOOLEAN_1Cols_halfNulls_P256)                        93.92us    10.65K
runBM(BOOLEAN_1Cols_halfNulls_P1024)                       88.99us    11.24K
runBM(BOOLEAN_10Cols_halfNulls_P4)                        464.80us     2.15K
runBM(BOOLEAN_10Cols_halfNulls_P16)                       567.09us     1.76K
runBM(BOOLEAN_10Cols_halfNulls_P64)                       591.26us     1.69K
runBM(BOOLEAN_10Cols_halfNulls_P256)                      605.05us     1.65K
runBM(BOOLEAN_10Cols_halfNulls_P1024)                     603.84us     1.66K
runBM(BOOLEAN_100Cols_halfNulls_P4)                         4.50ms    222.42
runBM(BOOLEAN_100Cols_halfNulls_P16)                        5.72ms    174.85
runBM(BOOLEAN_100Cols_halfNulls_P64)                        5.83ms    171.48
runBM(BOOLEAN_100Cols_halfNulls_P256)                       6.07ms    164.88
runBM(BOOLEAN_100Cols_halfNulls_P1024)                      6.10ms    164.07
runBM(BOOLEAN_1000Cols_halfNulls_P4)                       46.03ms     21.73
runBM(BOOLEAN_1000Cols_halfNulls_P16)                      56.94ms     17.56
runBM(BOOLEAN_1000Cols_halfNulls_P64)                      59.25ms     16.88
runBM(BOOLEAN_1000Cols_halfNulls_P256)                     62.14ms     16.09
runBM(BOOLEAN_1000Cols_halfNulls_P1024)                    62.54ms     15.99
runBM(SMALLINT_1Cols_noNulls_P4)                           83.26us    12.01K
runBM(SMALLINT_1Cols_noNulls_P16)                          70.32us    14.22K
runBM(SMALLINT_1Cols_noNulls_P64)                          65.78us    15.20K
runBM(SMALLINT_1Cols_noNulls_P256)                         64.76us    15.44K
runBM(SMALLINT_1Cols_noNulls_P1024)                        65.63us    15.24K
runBM(SMALLINT_10Cols_noNulls_P4)                         359.93us     2.78K
runBM(SMALLINT_10Cols_noNulls_P16)                        405.59us     2.47K
runBM(SMALLINT_10Cols_noNulls_P64)                        434.72us     2.30K
runBM(SMALLINT_10Cols_noNulls_P256)                       435.97us     2.29K
runBM(SMALLINT_10Cols_noNulls_P1024)                      442.84us     2.26K
runBM(SMALLINT_100Cols_noNulls_P4)                          3.20ms    312.54
runBM(SMALLINT_100Cols_noNulls_P16)                         3.90ms    256.71
runBM(SMALLINT_100Cols_noNulls_P64)                         4.23ms    236.39
runBM(SMALLINT_100Cols_noNulls_P256)                        4.45ms    224.76
runBM(SMALLINT_100Cols_noNulls_P1024)                       4.36ms    229.61
runBM(SMALLINT_1000Cols_noNulls_P4)                        32.53ms     30.74
runBM(SMALLINT_1000Cols_noNulls_P16)                       39.01ms     25.63
runBM(SMALLINT_1000Cols_noNulls_P64)                       44.51ms     22.47
runBM(SMALLINT_1000Cols_noNulls_P256)                      44.79ms     22.33
runBM(SMALLINT_1000Cols_noNulls_P1024)                     45.34ms     22.05
runBM(SMALLINT_1Cols_allNulls_P4)                          89.19us    11.21K
runBM(SMALLINT_1Cols_allNulls_P16)                         76.34us    13.10K
runBM(SMALLINT_1Cols_allNulls_P64)                         72.15us    13.86K
runBM(SMALLINT_1Cols_allNulls_P256)                        86.11us    11.61K
runBM(SMALLINT_1Cols_allNulls_P1024)                       81.55us    12.26K
runBM(SMALLINT_10Cols_allNulls_P4)                        357.14us     2.80K
runBM(SMALLINT_10Cols_allNulls_P16)                       411.68us     2.43K
runBM(SMALLINT_10Cols_allNulls_P64)                       475.68us     2.10K
runBM(SMALLINT_10Cols_allNulls_P256)                      490.76us     2.04K
runBM(SMALLINT_10Cols_allNulls_P1024)                     482.38us     2.07K
runBM(SMALLINT_100Cols_allNulls_P4)                         3.24ms    309.11
runBM(SMALLINT_100Cols_allNulls_P16)                        3.67ms    272.18
runBM(SMALLINT_100Cols_allNulls_P64)                        4.40ms    227.04
runBM(SMALLINT_100Cols_allNulls_P256)                       4.47ms    223.63
runBM(SMALLINT_100Cols_allNulls_P1024)                      4.57ms    218.62
runBM(SMALLINT_1000Cols_allNulls_P4)                       32.69ms     30.59
runBM(SMALLINT_1000Cols_allNulls_P16)                      39.23ms     25.49
runBM(SMALLINT_1000Cols_allNulls_P64)                      44.28ms     22.59
runBM(SMALLINT_1000Cols_allNulls_P256)                     44.57ms     22.44
runBM(SMALLINT_1000Cols_allNulls_P1024)                    45.39ms     22.03
runBM(SMALLINT_1Cols_halfNulls_P4)                         89.72us    11.15K
runBM(SMALLINT_1Cols_halfNulls_P16)                        81.03us    12.34K
runBM(SMALLINT_1Cols_halfNulls_P64)                        81.09us    12.33K
runBM(SMALLINT_1Cols_halfNulls_P256)                       86.09us    11.62K
runBM(SMALLINT_1Cols_halfNulls_P1024)                      81.59us    12.26K
runBM(SMALLINT_10Cols_halfNulls_P4)                       441.64us     2.26K
runBM(SMALLINT_10Cols_halfNulls_P16)                      477.09us     2.10K
runBM(SMALLINT_10Cols_halfNulls_P64)                      518.51us     1.93K
runBM(SMALLINT_10Cols_halfNulls_P256)                     559.34us     1.79K
runBM(SMALLINT_10Cols_halfNulls_P1024)                    529.84us     1.89K
runBM(SMALLINT_100Cols_halfNulls_P4)                        3.91ms    255.45
runBM(SMALLINT_100Cols_halfNulls_P16)                       4.73ms    211.21
runBM(SMALLINT_100Cols_halfNulls_P64)                       4.89ms    204.33
runBM(SMALLINT_100Cols_halfNulls_P256)                      5.06ms    197.75
runBM(SMALLINT_100Cols_halfNulls_P1024)                     5.31ms    188.46
runBM(SMALLINT_1000Cols_halfNulls_P4)                      39.34ms     25.42
runBM(SMALLINT_1000Cols_halfNulls_P16)                     47.15ms     21.21
runBM(SMALLINT_1000Cols_halfNulls_P64)                     52.01ms     19.23
runBM(SMALLINT_1000Cols_halfNulls_P256)                    52.41ms     19.08
runBM(SMALLINT_1000Cols_halfNulls_P1024)                   53.58ms     18.66
runBM(INTEGER_1Cols_noNulls_P4)                            91.42us    10.94K
runBM(INTEGER_1Cols_noNulls_P16)                           75.20us    13.30K
runBM(INTEGER_1Cols_noNulls_P64)                           66.05us    15.14K
runBM(INTEGER_1Cols_noNulls_P256)                          69.40us    14.41K
runBM(INTEGER_1Cols_noNulls_P1024)                         67.26us    14.87K
runBM(INTEGER_10Cols_noNulls_P4)                          369.51us     2.71K
runBM(INTEGER_10Cols_noNulls_P16)                         436.22us     2.29K
runBM(INTEGER_10Cols_noNulls_P64)                         436.89us     2.29K
runBM(INTEGER_10Cols_noNulls_P256)                        435.76us     2.29K
runBM(INTEGER_10Cols_noNulls_P1024)                       472.47us     2.12K
runBM(INTEGER_100Cols_noNulls_P4)                           3.26ms    307.08
runBM(INTEGER_100Cols_noNulls_P16)                          3.90ms    256.46
runBM(INTEGER_100Cols_noNulls_P64)                          4.15ms    241.25
runBM(INTEGER_100Cols_noNulls_P256)                         4.20ms    238.03
runBM(INTEGER_100Cols_noNulls_P1024)                        4.24ms    235.70
runBM(INTEGER_1000Cols_noNulls_P4)                         32.26ms     31.00
runBM(INTEGER_1000Cols_noNulls_P16)                        39.70ms     25.19
runBM(INTEGER_1000Cols_noNulls_P64)                        44.87ms     22.29
runBM(INTEGER_1000Cols_noNulls_P256)                       45.23ms     22.11
runBM(INTEGER_1000Cols_noNulls_P1024)                      45.90ms     21.79
runBM(INTEGER_1Cols_allNulls_P4)                           91.53us    10.93K
runBM(INTEGER_1Cols_allNulls_P16)                          76.34us    13.10K
runBM(INTEGER_1Cols_allNulls_P64)                          72.65us    13.76K
runBM(INTEGER_1Cols_allNulls_P256)                         86.09us    11.62K
runBM(INTEGER_1Cols_allNulls_P1024)                        87.42us    11.44K
runBM(INTEGER_10Cols_allNulls_P4)                         391.67us     2.55K
runBM(INTEGER_10Cols_allNulls_P16)                        410.64us     2.44K
runBM(INTEGER_10Cols_allNulls_P64)                        445.05us     2.25K
runBM(INTEGER_10Cols_allNulls_P256)                       477.68us     2.09K
runBM(INTEGER_10Cols_allNulls_P1024)                      482.97us     2.07K
runBM(INTEGER_100Cols_allNulls_P4)                          3.20ms    312.47
runBM(INTEGER_100Cols_allNulls_P16)                         3.71ms    269.67
runBM(INTEGER_100Cols_allNulls_P64)                         4.13ms    241.99
runBM(INTEGER_100Cols_allNulls_P256)                        4.46ms    224.01
runBM(INTEGER_100Cols_allNulls_P1024)                       4.57ms    218.89
runBM(INTEGER_1000Cols_allNulls_P4)                        32.37ms     30.89
runBM(INTEGER_1000Cols_allNulls_P16)                       39.34ms     25.42
runBM(INTEGER_1000Cols_allNulls_P64)                       45.00ms     22.22
runBM(INTEGER_1000Cols_allNulls_P256)                      45.20ms     22.13
runBM(INTEGER_1000Cols_allNulls_P1024)                     45.83ms     21.82
runBM(INTEGER_1Cols_halfNulls_P4)                          91.74us    10.90K
runBM(INTEGER_1Cols_halfNulls_P16)                         81.26us    12.31K
runBM(INTEGER_1Cols_halfNulls_P64)                         81.28us    12.30K
runBM(INTEGER_1Cols_halfNulls_P256)                        80.32us    12.45K
runBM(INTEGER_1Cols_halfNulls_P1024)                       87.45us    11.44K
runBM(INTEGER_10Cols_halfNulls_P4)                        417.30us     2.40K
runBM(INTEGER_10Cols_halfNulls_P16)                       476.93us     2.10K
runBM(INTEGER_10Cols_halfNulls_P64)                       516.80us     1.93K
runBM(INTEGER_10Cols_halfNulls_P256)                      558.09us     1.79K
runBM(INTEGER_10Cols_halfNulls_P1024)                     528.68us     1.89K
runBM(INTEGER_100Cols_halfNulls_P4)                         3.72ms    269.04
runBM(INTEGER_100Cols_halfNulls_P16)                        4.75ms    210.66
runBM(INTEGER_100Cols_halfNulls_P64)                        5.18ms    192.95
runBM(INTEGER_100Cols_halfNulls_P256)                       4.95ms    201.82
runBM(INTEGER_100Cols_halfNulls_P1024)                      5.38ms    186.03
runBM(INTEGER_1000Cols_halfNulls_P4)                       39.06ms     25.60
runBM(INTEGER_1000Cols_halfNulls_P16)                      47.69ms     20.97
runBM(INTEGER_1000Cols_halfNulls_P64)                      52.70ms     18.97
runBM(INTEGER_1000Cols_halfNulls_P256)                     51.28ms     19.50
runBM(INTEGER_1000Cols_halfNulls_P1024)                    52.81ms     18.94
runBM(BIGINT_1Cols_noNulls_P4)                             90.13us    11.09K
runBM(BIGINT_1Cols_noNulls_P16)                            70.51us    14.18K
runBM(BIGINT_1Cols_noNulls_P64)                            70.88us    14.11K
runBM(BIGINT_1Cols_noNulls_P256)                           65.49us    15.27K
runBM(BIGINT_1Cols_noNulls_P1024)                          66.97us    14.93K
runBM(BIGINT_10Cols_noNulls_P4)                           391.59us     2.55K
runBM(BIGINT_10Cols_noNulls_P16)                          426.01us     2.35K
runBM(BIGINT_10Cols_noNulls_P64)                          440.47us     2.27K
runBM(BIGINT_10Cols_noNulls_P256)                         440.38us     2.27K
runBM(BIGINT_10Cols_noNulls_P1024)                        473.68us     2.11K
runBM(BIGINT_100Cols_noNulls_P4)                            3.28ms    304.44
runBM(BIGINT_100Cols_noNulls_P16)                           3.74ms    267.38
runBM(BIGINT_100Cols_noNulls_P64)                           4.17ms    240.07
runBM(BIGINT_100Cols_noNulls_P256)                          4.50ms    222.16
runBM(BIGINT_100Cols_noNulls_P1024)                         4.43ms    225.91
runBM(BIGINT_1000Cols_noNulls_P4)                          32.66ms     30.62
runBM(BIGINT_1000Cols_noNulls_P16)                         39.70ms     25.19
runBM(BIGINT_1000Cols_noNulls_P64)                         45.73ms     21.87
runBM(BIGINT_1000Cols_noNulls_P256)                        46.72ms     21.40
runBM(BIGINT_1000Cols_noNulls_P1024)                       47.58ms     21.02
runBM(BIGINT_1Cols_allNulls_P4)                            86.26us    11.59K
runBM(BIGINT_1Cols_allNulls_P16)                           72.20us    13.85K
runBM(BIGINT_1Cols_allNulls_P64)                           77.17us    12.96K
runBM(BIGINT_1Cols_allNulls_P256)                          80.84us    12.37K
runBM(BIGINT_1Cols_allNulls_P1024)                         82.40us    12.14K
runBM(BIGINT_10Cols_allNulls_P4)                          377.97us     2.65K
runBM(BIGINT_10Cols_allNulls_P16)                         413.43us     2.42K
runBM(BIGINT_10Cols_allNulls_P64)                         450.05us     2.22K
runBM(BIGINT_10Cols_allNulls_P256)                        464.68us     2.15K
runBM(BIGINT_10Cols_allNulls_P1024)                       490.97us     2.04K
runBM(BIGINT_100Cols_allNulls_P4)                           3.28ms    305.14
runBM(BIGINT_100Cols_allNulls_P16)                          3.80ms    263.22
runBM(BIGINT_100Cols_allNulls_P64)                          4.45ms    224.67
runBM(BIGINT_100Cols_allNulls_P256)                         4.30ms    232.65
runBM(BIGINT_100Cols_allNulls_P1024)                        4.66ms    214.67
runBM(BIGINT_1000Cols_allNulls_P4)                         32.69ms     30.59
runBM(BIGINT_1000Cols_allNulls_P16)                        39.73ms     25.17
runBM(BIGINT_1000Cols_allNulls_P64)                        45.82ms     21.83
runBM(BIGINT_1000Cols_allNulls_P256)                       47.02ms     21.27
runBM(BIGINT_1000Cols_allNulls_P1024)                      47.52ms     21.04
runBM(BIGINT_1Cols_halfNulls_P4)                           85.67us    11.67K
runBM(BIGINT_1Cols_halfNulls_P16)                          76.15us    13.13K
runBM(BIGINT_1Cols_halfNulls_P64)                          77.15us    12.96K
runBM(BIGINT_1Cols_halfNulls_P256)                         81.07us    12.34K
runBM(BIGINT_1Cols_halfNulls_P1024)                        95.40us    10.48K
runBM(BIGINT_10Cols_halfNulls_P4)                         439.47us     2.28K
runBM(BIGINT_10Cols_halfNulls_P16)                        481.76us     2.08K
runBM(BIGINT_10Cols_halfNulls_P64)                        551.63us     1.81K
runBM(BIGINT_10Cols_halfNulls_P256)                       527.09us     1.90K
runBM(BIGINT_10Cols_halfNulls_P1024)                      575.05us     1.74K
runBM(BIGINT_100Cols_halfNulls_P4)                          3.93ms    254.18
runBM(BIGINT_100Cols_halfNulls_P16)                         4.79ms    208.89
runBM(BIGINT_100Cols_halfNulls_P64)                         5.19ms    192.50
runBM(BIGINT_100Cols_halfNulls_P256)                        5.05ms    197.90
runBM(BIGINT_100Cols_halfNulls_P1024)                       5.37ms    186.14
runBM(BIGINT_1000Cols_halfNulls_P4)                        39.04ms     25.61
runBM(BIGINT_1000Cols_halfNulls_P16)                       48.27ms     20.72
runBM(BIGINT_1000Cols_halfNulls_P64)                       53.45ms     18.71
runBM(BIGINT_1000Cols_halfNulls_P256)                      54.47ms     18.36
runBM(BIGINT_1000Cols_halfNulls_P1024)                     56.02ms     17.85
runBM(HUGEINT_1Cols_noNulls_P4)                            88.53us    11.30K
runBM(HUGEINT_1Cols_noNulls_P16)                           76.36us    13.10K
runBM(HUGEINT_1Cols_noNulls_P64)                           68.38us    14.62K
runBM(HUGEINT_1Cols_noNulls_P256)                          71.01us    14.08K
runBM(HUGEINT_1Cols_noNulls_P1024)                         72.86us    13.72K
runBM(HUGEINT_10Cols_noNulls_P4)                          374.34us     2.67K
runBM(HUGEINT_10Cols_noNulls_P16)                         431.93us     2.32K
runBM(HUGEINT_10Cols_noNulls_P64)                         442.05us     2.26K
runBM(HUGEINT_10Cols_noNulls_P256)                        476.18us     2.10K
runBM(HUGEINT_10Cols_noNulls_P1024)                       488.84us     2.05K
runBM(HUGEINT_100Cols_noNulls_P4)                           3.32ms    300.98
runBM(HUGEINT_100Cols_noNulls_P16)                          3.72ms    268.71
runBM(HUGEINT_100Cols_noNulls_P64)                          4.74ms    211.00
runBM(HUGEINT_100Cols_noNulls_P256)                         4.66ms    214.64
runBM(HUGEINT_100Cols_noNulls_P1024)                        4.78ms    209.35
runBM(HUGEINT_1000Cols_noNulls_P4)                         34.21ms     29.23
runBM(HUGEINT_1000Cols_noNulls_P16)                        40.77ms     24.53
runBM(HUGEINT_1000Cols_noNulls_P64)                        46.90ms     21.32
runBM(HUGEINT_1000Cols_noNulls_P256)                       51.38ms     19.46
runBM(HUGEINT_1000Cols_noNulls_P1024)                      53.75ms     18.60
runBM(HUGEINT_1Cols_allNulls_P4)                           95.26us    10.50K
runBM(HUGEINT_1Cols_allNulls_P16)                          78.65us    12.71K
runBM(HUGEINT_1Cols_allNulls_P64)                          82.34us    12.14K
runBM(HUGEINT_1Cols_allNulls_P256)                         90.44us    11.06K
runBM(HUGEINT_1Cols_allNulls_P1024)                        90.57us    11.04K
runBM(HUGEINT_10Cols_allNulls_P4)                         393.01us     2.54K
runBM(HUGEINT_10Cols_allNulls_P16)                        441.38us     2.27K
runBM(HUGEINT_10Cols_allNulls_P64)                        486.68us     2.05K
runBM(HUGEINT_10Cols_allNulls_P256)                       505.80us     1.98K
runBM(HUGEINT_10Cols_allNulls_P1024)                      527.14us     1.90K
runBM(HUGEINT_100Cols_allNulls_P4)                          3.45ms    289.76
runBM(HUGEINT_100Cols_allNulls_P16)                         4.09ms    244.61
runBM(HUGEINT_100Cols_allNulls_P64)                         4.62ms    216.35
runBM(HUGEINT_100Cols_allNulls_P256)                        4.83ms    206.91
runBM(HUGEINT_100Cols_allNulls_P1024)                       4.91ms    203.79
runBM(HUGEINT_1000Cols_allNulls_P4)                        33.19ms     30.13
runBM(HUGEINT_1000Cols_allNulls_P16)                       40.07ms     24.96
runBM(HUGEINT_1000Cols_allNulls_P64)                       46.41ms     21.55
runBM(HUGEINT_1000Cols_allNulls_P256)                      49.90ms     20.04
runBM(HUGEINT_1000Cols_allNulls_P1024)                     50.82ms     19.68
runBM(HUGEINT_1Cols_halfNulls_P4)                          90.36us    11.07K
runBM(HUGEINT_1Cols_halfNulls_P16)                         82.09us    12.18K
runBM(HUGEINT_1Cols_halfNulls_P64)                         82.80us    12.08K
runBM(HUGEINT_1Cols_halfNulls_P256)                        87.53us    11.43K
runBM(HUGEINT_1Cols_halfNulls_P1024)                       89.72us    11.15K
runBM(HUGEINT_10Cols_halfNulls_P4)                        450.26us     2.22K
runBM(HUGEINT_10Cols_halfNulls_P16)                       514.22us     1.94K
runBM(HUGEINT_10Cols_halfNulls_P64)                       555.55us     1.80K
runBM(HUGEINT_10Cols_halfNulls_P256)                      568.38us     1.76K
runBM(HUGEINT_10Cols_halfNulls_P1024)                     583.59us     1.71K
runBM(HUGEINT_100Cols_halfNulls_P4)                         4.00ms    250.18
runBM(HUGEINT_100Cols_halfNulls_P16)                        4.79ms    208.71
runBM(HUGEINT_100Cols_halfNulls_P64)                        5.25ms    190.47
runBM(HUGEINT_100Cols_halfNulls_P256)                       5.41ms    185.00
runBM(HUGEINT_100Cols_halfNulls_P1024)                      5.55ms    180.25
runBM(HUGEINT_1000Cols_halfNulls_P4)                       39.75ms     25.16
runBM(HUGEINT_1000Cols_halfNulls_P16)                      48.28ms     20.71
runBM(HUGEINT_1000Cols_halfNulls_P64)                      53.92ms     18.55
runBM(HUGEINT_1000Cols_halfNulls_P256)                     57.66ms     17.34
runBM(HUGEINT_1000Cols_halfNulls_P1024)                    61.83ms     16.17
runBM(REAL_1Cols_noNulls_P4)                               88.86us    11.25K
runBM(REAL_1Cols_noNulls_P16)                              74.76us    13.38K
runBM(REAL_1Cols_noNulls_P64)                              70.32us    14.22K
runBM(REAL_1Cols_noNulls_P256)                             65.15us    15.35K
runBM(REAL_1Cols_noNulls_P1024)                            70.36us    14.21K
runBM(REAL_10Cols_noNulls_P4)                             382.68us     2.61K
runBM(REAL_10Cols_noNulls_P16)                            434.01us     2.30K
runBM(REAL_10Cols_noNulls_P64)                            465.05us     2.15K
runBM(REAL_10Cols_noNulls_P256)                           466.01us     2.15K
runBM(REAL_10Cols_noNulls_P1024)                          472.22us     2.12K
runBM(REAL_100Cols_noNulls_P4)                              3.26ms    306.61
runBM(REAL_100Cols_noNulls_P16)                             3.91ms    256.00
runBM(REAL_100Cols_noNulls_P64)                             4.39ms    227.59
runBM(REAL_100Cols_noNulls_P256)                            4.44ms    225.16
runBM(REAL_100Cols_noNulls_P1024)                           4.50ms    222.01
runBM(REAL_1000Cols_noNulls_P4)                            32.45ms     30.82
runBM(REAL_1000Cols_noNulls_P16)                           39.53ms     25.30
runBM(REAL_1000Cols_noNulls_P64)                           45.09ms     22.18
runBM(REAL_1000Cols_noNulls_P256)                          44.93ms     22.26
runBM(REAL_1000Cols_noNulls_P1024)                         45.87ms     21.80
runBM(REAL_1Cols_allNulls_P4)                              89.07us    11.23K
runBM(REAL_1Cols_allNulls_P16)                             75.92us    13.17K
runBM(REAL_1Cols_allNulls_P64)                             76.67us    13.04K
runBM(REAL_1Cols_allNulls_P256)                            86.03us    11.62K
runBM(REAL_1Cols_allNulls_P1024)                           87.32us    11.45K
runBM(REAL_10Cols_allNulls_P4)                            355.68us     2.81K
runBM(REAL_10Cols_allNulls_P16)                           435.51us     2.30K
runBM(REAL_10Cols_allNulls_P64)                           448.84us     2.23K
runBM(REAL_10Cols_allNulls_P256)                          467.39us     2.14K
runBM(REAL_10Cols_allNulls_P1024)                         483.59us     2.07K
runBM(REAL_100Cols_allNulls_P4)                             3.23ms    309.16
runBM(REAL_100Cols_allNulls_P16)                            3.95ms    253.34
runBM(REAL_100Cols_allNulls_P64)                            4.40ms    227.21
runBM(REAL_100Cols_allNulls_P256)                           4.46ms    224.32
runBM(REAL_100Cols_allNulls_P1024)                          4.58ms    218.53
runBM(REAL_1000Cols_allNulls_P4)                           32.37ms     30.90
runBM(REAL_1000Cols_allNulls_P16)                          39.56ms     25.28
runBM(REAL_1000Cols_allNulls_P64)                          44.72ms     22.36
runBM(REAL_1000Cols_allNulls_P256)                         45.09ms     22.18
runBM(REAL_1000Cols_allNulls_P1024)                        45.88ms     21.79
runBM(REAL_1Cols_halfNulls_P4)                             84.61us    11.82K
runBM(REAL_1Cols_halfNulls_P16)                            76.36us    13.10K
runBM(REAL_1Cols_halfNulls_P64)                            81.11us    12.33K
runBM(REAL_1Cols_halfNulls_P256)                           80.47us    12.43K
runBM(REAL_1Cols_halfNulls_P1024)                          87.42us    11.44K
runBM(REAL_10Cols_halfNulls_P4)                           414.76us     2.41K
runBM(REAL_10Cols_halfNulls_P16)                          478.84us     2.09K
runBM(REAL_10Cols_halfNulls_P64)                          515.80us     1.94K
runBM(REAL_10Cols_halfNulls_P256)                         557.59us     1.79K
runBM(REAL_10Cols_halfNulls_P1024)                        566.59us     1.76K
runBM(REAL_100Cols_halfNulls_P4)                            3.92ms    254.79
runBM(REAL_100Cols_halfNulls_P16)                           4.73ms    211.21
runBM(REAL_100Cols_halfNulls_P64)                           5.18ms    193.14
runBM(REAL_100Cols_halfNulls_P256)                          5.27ms    189.73
runBM(REAL_100Cols_halfNulls_P1024)                         5.38ms    186.00
runBM(REAL_1000Cols_halfNulls_P4)                          39.47ms     25.34
runBM(REAL_1000Cols_halfNulls_P16)                         47.99ms     20.84
runBM(REAL_1000Cols_halfNulls_P64)                         52.90ms     18.90
runBM(REAL_1000Cols_halfNulls_P256)                        53.61ms     18.65
runBM(REAL_1000Cols_halfNulls_P1024)                       54.51ms     18.35
runBM(DOUBLE_1Cols_noNulls_P4)                             90.22us    11.08K
runBM(DOUBLE_1Cols_noNulls_P16)                            75.30us    13.28K
runBM(DOUBLE_1Cols_noNulls_P64)                            70.78us    14.13K
runBM(DOUBLE_1Cols_noNulls_P256)                           69.86us    14.31K
runBM(DOUBLE_1Cols_noNulls_P1024)                          71.55us    13.98K
runBM(DOUBLE_10Cols_noNulls_P4)                           373.43us     2.68K
runBM(DOUBLE_10Cols_noNulls_P16)                          430.63us     2.32K
runBM(DOUBLE_10Cols_noNulls_P64)                          469.51us     2.13K
runBM(DOUBLE_10Cols_noNulls_P256)                         472.01us     2.12K
runBM(DOUBLE_10Cols_noNulls_P1024)                        481.63us     2.08K
runBM(DOUBLE_100Cols_noNulls_P4)                            3.30ms    303.32
runBM(DOUBLE_100Cols_noNulls_P16)                           3.97ms    251.65
runBM(DOUBLE_100Cols_noNulls_P64)                           4.44ms    225.19
runBM(DOUBLE_100Cols_noNulls_P256)                          4.51ms    221.98
runBM(DOUBLE_100Cols_noNulls_P1024)                         4.60ms    217.18
runBM(DOUBLE_1000Cols_noNulls_P4)                          32.72ms     30.57
runBM(DOUBLE_1000Cols_noNulls_P16)                         40.15ms     24.90
runBM(DOUBLE_1000Cols_noNulls_P64)                         45.75ms     21.86
runBM(DOUBLE_1000Cols_noNulls_P256)                        47.27ms     21.15
runBM(DOUBLE_1000Cols_noNulls_P1024)                       47.68ms     20.97
runBM(DOUBLE_1Cols_allNulls_P4)                            90.61us    11.04K
runBM(DOUBLE_1Cols_allNulls_P16)                           76.42us    13.08K
runBM(DOUBLE_1Cols_allNulls_P64)                           73.01us    13.70K
runBM(DOUBLE_1Cols_allNulls_P256)                          89.07us    11.23K
runBM(DOUBLE_1Cols_allNulls_P1024)                         82.53us    12.12K
runBM(DOUBLE_10Cols_allNulls_P4)                          374.30us     2.67K
runBM(DOUBLE_10Cols_allNulls_P16)                         423.76us     2.36K
runBM(DOUBLE_10Cols_allNulls_P64)                         445.97us     2.24K
runBM(DOUBLE_10Cols_allNulls_P256)                        472.55us     2.12K
runBM(DOUBLE_10Cols_allNulls_P1024)                       492.26us     2.03K
runBM(DOUBLE_100Cols_allNulls_P4)                           3.29ms    303.93
runBM(DOUBLE_100Cols_allNulls_P16)                          3.93ms    254.67
runBM(DOUBLE_100Cols_allNulls_P64)                          4.46ms    224.12
runBM(DOUBLE_100Cols_allNulls_P256)                         4.41ms    226.54
runBM(DOUBLE_100Cols_allNulls_P1024)                        4.71ms    212.48
runBM(DOUBLE_1000Cols_allNulls_P4)                         33.36ms     29.98
runBM(DOUBLE_1000Cols_allNulls_P16)                        39.27ms     25.46
runBM(DOUBLE_1000Cols_allNulls_P64)                        46.18ms     21.66
runBM(DOUBLE_1000Cols_allNulls_P256)                       47.82ms     20.91
runBM(DOUBLE_1000Cols_allNulls_P1024)                      49.26ms     20.30
runBM(DOUBLE_1Cols_halfNulls_P4)                           85.63us    11.68K
runBM(DOUBLE_1Cols_halfNulls_P16)                          81.11us    12.33K
runBM(DOUBLE_1Cols_halfNulls_P64)                          81.82us    12.22K
runBM(DOUBLE_1Cols_halfNulls_P256)                         86.65us    11.54K
runBM(DOUBLE_1Cols_halfNulls_P1024)                        88.55us    11.29K
runBM(DOUBLE_10Cols_halfNulls_P4)                         446.59us     2.24K
runBM(DOUBLE_10Cols_halfNulls_P16)                        513.93us     1.95K
runBM(DOUBLE_10Cols_halfNulls_P64)                        552.09us     1.81K
runBM(DOUBLE_10Cols_halfNulls_P256)                       527.80us     1.89K
runBM(DOUBLE_10Cols_halfNulls_P1024)                      537.14us     1.86K
runBM(DOUBLE_100Cols_halfNulls_P4)                          3.96ms    252.62
runBM(DOUBLE_100Cols_halfNulls_P16)                         4.77ms    209.72
runBM(DOUBLE_100Cols_halfNulls_P64)                         5.22ms    191.52
runBM(DOUBLE_100Cols_halfNulls_P256)                        5.34ms    187.21
runBM(DOUBLE_100Cols_halfNulls_P1024)                       5.45ms    183.58
runBM(DOUBLE_1000Cols_halfNulls_P4)                        39.90ms     25.06
runBM(DOUBLE_1000Cols_halfNulls_P16)                       48.24ms     20.73
runBM(DOUBLE_1000Cols_halfNulls_P64)                       53.44ms     18.71
runBM(DOUBLE_1000Cols_halfNulls_P256)                      55.39ms     18.05
runBM(DOUBLE_1000Cols_halfNulls_P1024)                     56.14ms     17.81
runBM(TIMESTAMP_1Cols_noNulls_P4)                          90.44us    11.06K
runBM(TIMESTAMP_1Cols_noNulls_P16)                         72.40us    13.81K
runBM(TIMESTAMP_1Cols_noNulls_P64)                         71.61us    13.96K
runBM(TIMESTAMP_1Cols_noNulls_P256)                        70.57us    14.17K
runBM(TIMESTAMP_1Cols_noNulls_P1024)                       72.47us    13.80K
runBM(TIMESTAMP_10Cols_noNulls_P4)                        386.09us     2.59K
runBM(TIMESTAMP_10Cols_noNulls_P16)                       413.76us     2.42K
runBM(TIMESTAMP_10Cols_noNulls_P64)                       472.84us     2.11K
runBM(TIMESTAMP_10Cols_noNulls_P256)                      473.01us     2.11K
runBM(TIMESTAMP_10Cols_noNulls_P1024)                     482.93us     2.07K
runBM(TIMESTAMP_100Cols_noNulls_P4)                         3.35ms    298.95
runBM(TIMESTAMP_100Cols_noNulls_P16)                        3.95ms    253.22
runBM(TIMESTAMP_100Cols_noNulls_P64)                        4.47ms    223.72
runBM(TIMESTAMP_100Cols_noNulls_P256)                       4.55ms    219.61
runBM(TIMESTAMP_100Cols_noNulls_P1024)                      4.67ms    214.10
runBM(TIMESTAMP_1000Cols_noNulls_P4)                       33.31ms     30.02
runBM(TIMESTAMP_1000Cols_noNulls_P16)                      39.41ms     25.37
runBM(TIMESTAMP_1000Cols_noNulls_P64)                      46.64ms     21.44
runBM(TIMESTAMP_1000Cols_noNulls_P256)                     49.95ms     20.02
runBM(TIMESTAMP_1000Cols_noNulls_P1024)                    51.34ms     19.48
runBM(TIMESTAMP_1Cols_allNulls_P4)                         91.24us    10.96K
runBM(TIMESTAMP_1Cols_allNulls_P16)                        73.03us    13.69K
runBM(TIMESTAMP_1Cols_allNulls_P64)                        77.72us    12.87K
runBM(TIMESTAMP_1Cols_allNulls_P256)                       81.01us    12.34K
runBM(TIMESTAMP_1Cols_allNulls_P1024)                      88.57us    11.29K
runBM(TIMESTAMP_10Cols_allNulls_P4)                       365.51us     2.74K
runBM(TIMESTAMP_10Cols_allNulls_P16)                      418.18us     2.39K
runBM(TIMESTAMP_10Cols_allNulls_P64)                      481.80us     2.08K
runBM(TIMESTAMP_10Cols_allNulls_P256)                     497.97us     2.01K
runBM(TIMESTAMP_10Cols_allNulls_P1024)                    493.64us     2.03K
runBM(TIMESTAMP_100Cols_allNulls_P4)                        3.34ms    299.75
runBM(TIMESTAMP_100Cols_allNulls_P16)                       3.89ms    256.88
runBM(TIMESTAMP_100Cols_allNulls_P64)                       4.51ms    221.62
runBM(TIMESTAMP_100Cols_allNulls_P256)                      4.59ms    218.09
runBM(TIMESTAMP_100Cols_allNulls_P1024)                     4.70ms    212.71
runBM(TIMESTAMP_1000Cols_allNulls_P4)                      33.32ms     30.01
runBM(TIMESTAMP_1000Cols_allNulls_P16)                     39.69ms     25.20
runBM(TIMESTAMP_1000Cols_allNulls_P64)                     46.46ms     21.53
runBM(TIMESTAMP_1000Cols_allNulls_P256)                    49.51ms     20.20
runBM(TIMESTAMP_1000Cols_allNulls_P1024)                   51.11ms     19.56
runBM(TIMESTAMP_1Cols_halfNulls_P4)                        86.70us    11.53K
runBM(TIMESTAMP_1Cols_halfNulls_P16)                       81.63us    12.25K
runBM(TIMESTAMP_1Cols_halfNulls_P64)                       82.17us    12.17K
runBM(TIMESTAMP_1Cols_halfNulls_P256)                      81.05us    12.34K
runBM(TIMESTAMP_1Cols_halfNulls_P1024)                     88.65us    11.28K
runBM(TIMESTAMP_10Cols_halfNulls_P4)                      437.39us     2.29K
runBM(TIMESTAMP_10Cols_halfNulls_P16)                     515.39us     1.94K
runBM(TIMESTAMP_10Cols_halfNulls_P64)                     555.18us     1.80K
runBM(TIMESTAMP_10Cols_halfNulls_P256)                    565.26us     1.77K
runBM(TIMESTAMP_10Cols_halfNulls_P1024)                   573.01us     1.75K
runBM(TIMESTAMP_100Cols_halfNulls_P4)                       3.99ms    250.80
runBM(TIMESTAMP_100Cols_halfNulls_P16)                      4.80ms    208.46
runBM(TIMESTAMP_100Cols_halfNulls_P64)                      5.26ms    190.26
runBM(TIMESTAMP_100Cols_halfNulls_P256)                     5.41ms    184.74
runBM(TIMESTAMP_100Cols_halfNulls_P1024)                    5.53ms    180.73
runBM(TIMESTAMP_1000Cols_halfNulls_P4)                     40.28ms     24.82
runBM(TIMESTAMP_1000Cols_halfNulls_P16)                    48.40ms     20.66
runBM(TIMESTAMP_1000Cols_halfNulls_P64)                    54.28ms     18.42
runBM(TIMESTAMP_1000Cols_halfNulls_P256)                   58.18ms     17.19
runBM(TIMESTAMP_1000Cols_halfNulls_P1024)                  59.79ms     16.73
runBM(VARCHAR_1Cols_noNulls_P4)                            91.47us    10.93K
runBM(VARCHAR_1Cols_noNulls_P16)                           72.42us    13.81K
runBM(VARCHAR_1Cols_noNulls_P64)                           67.28us    14.86K
runBM(VARCHAR_1Cols_noNulls_P256)                          68.72us    14.55K
runBM(VARCHAR_1Cols_noNulls_P1024)                         71.82us    13.92K
runBM(VARCHAR_10Cols_noNulls_P4)                          391.68us     2.55K
runBM(VARCHAR_10Cols_noNulls_P16)                         439.72us     2.27K
runBM(VARCHAR_10Cols_noNulls_P64)                         471.01us     2.12K
runBM(VARCHAR_10Cols_noNulls_P256)                        475.80us     2.10K
runBM(VARCHAR_10Cols_noNulls_P1024)                       485.51us     2.06K
runBM(VARCHAR_100Cols_noNulls_P4)                           3.36ms    297.58
runBM(VARCHAR_100Cols_noNulls_P16)                          3.98ms    251.03
runBM(VARCHAR_100Cols_noNulls_P64)                          4.52ms    221.07
runBM(VARCHAR_100Cols_noNulls_P256)                         4.81ms    208.00
runBM(VARCHAR_100Cols_noNulls_P1024)                        4.72ms    211.90
runBM(VARCHAR_1000Cols_noNulls_P4)                         33.82ms     29.57
runBM(VARCHAR_1000Cols_noNulls_P16)                        40.73ms     24.55
runBM(VARCHAR_1000Cols_noNulls_P64)                        46.39ms     21.56
runBM(VARCHAR_1000Cols_noNulls_P256)                       50.28ms     19.89
runBM(VARCHAR_1000Cols_noNulls_P1024)                      52.10ms     19.19
runBM(VARCHAR_1Cols_allNulls_P4)                           90.40us    11.06K
runBM(VARCHAR_1Cols_allNulls_P16)                          76.97us    12.99K
runBM(VARCHAR_1Cols_allNulls_P64)                          76.99us    12.99K
runBM(VARCHAR_1Cols_allNulls_P256)                         80.67us    12.40K
runBM(VARCHAR_1Cols_allNulls_P1024)                        88.76us    11.27K
runBM(VARCHAR_10Cols_allNulls_P4)                         394.34us     2.54K
runBM(VARCHAR_10Cols_allNulls_P16)                        414.26us     2.41K
runBM(VARCHAR_10Cols_allNulls_P64)                        447.43us     2.24K
runBM(VARCHAR_10Cols_allNulls_P256)                       465.84us     2.15K
runBM(VARCHAR_10Cols_allNulls_P1024)                      490.22us     2.04K
runBM(VARCHAR_100Cols_allNulls_P4)                          3.33ms    300.51
runBM(VARCHAR_100Cols_allNulls_P16)                         3.95ms    253.03
runBM(VARCHAR_100Cols_allNulls_P64)                         4.42ms    226.47
runBM(VARCHAR_100Cols_allNulls_P256)                        4.51ms    221.66
runBM(VARCHAR_100Cols_allNulls_P1024)                       4.67ms    213.97
runBM(VARCHAR_1000Cols_allNulls_P4)                        33.02ms     30.28
runBM(VARCHAR_1000Cols_allNulls_P16)                       39.86ms     25.09
runBM(VARCHAR_1000Cols_allNulls_P64)                       45.72ms     21.87
runBM(VARCHAR_1000Cols_allNulls_P256)                      49.12ms     20.36
runBM(VARCHAR_1000Cols_allNulls_P1024)                     50.75ms     19.71
runBM(VARCHAR_1Cols_halfNulls_P4)                          92.11us    10.86K
runBM(VARCHAR_1Cols_halfNulls_P16)                         82.19us    12.17K
runBM(VARCHAR_1Cols_halfNulls_P64)                         82.07us    12.18K
runBM(VARCHAR_1Cols_halfNulls_P256)                        81.09us    12.33K
runBM(VARCHAR_1Cols_halfNulls_P1024)                       88.78us    11.26K
runBM(VARCHAR_10Cols_halfNulls_P4)                        450.34us     2.22K
runBM(VARCHAR_10Cols_halfNulls_P16)                       512.80us     1.95K
runBM(VARCHAR_10Cols_halfNulls_P64)                       538.22us     1.86K
runBM(VARCHAR_10Cols_halfNulls_P256)                      565.43us     1.77K
runBM(VARCHAR_10Cols_halfNulls_P1024)                     577.84us     1.73K
runBM(VARCHAR_100Cols_halfNulls_P4)                         4.00ms    250.30
runBM(VARCHAR_100Cols_halfNulls_P16)                        4.76ms    209.87
runBM(VARCHAR_100Cols_halfNulls_P64)                        5.14ms    194.69
runBM(VARCHAR_100Cols_halfNulls_P256)                       5.41ms    184.73
runBM(VARCHAR_100Cols_halfNulls_P1024)                      5.53ms    180.72
runBM(VARCHAR_1000Cols_halfNulls_P4)                       40.38ms     24.76
runBM(VARCHAR_1000Cols_halfNulls_P16)                      48.49ms     20.62
runBM(VARCHAR_1000Cols_halfNulls_P64)                      54.13ms     18.47
runBM(VARCHAR_1000Cols_halfNulls_P256)                     58.11ms     17.21
runBM(VARCHAR_1000Cols_halfNulls_P1024)                    59.80ms     16.72
runBM(VARBINARY_1Cols_noNulls_P4)                          91.71us    10.90K
runBM(VARBINARY_1Cols_noNulls_P16)                         71.36us    14.01K
runBM(VARBINARY_1Cols_noNulls_P64)                         66.90us    14.95K
runBM(VARBINARY_1Cols_noNulls_P256)                        65.90us    15.17K
runBM(VARBINARY_1Cols_noNulls_P1024)                       71.99us    13.89K
runBM(VARBINARY_10Cols_noNulls_P4)                        392.01us     2.55K
runBM(VARBINARY_10Cols_noNulls_P16)                       411.64us     2.43K
runBM(VARBINARY_10Cols_noNulls_P64)                       471.97us     2.12K
runBM(VARBINARY_10Cols_noNulls_P256)                      475.09us     2.10K
runBM(VARBINARY_10Cols_noNulls_P1024)                     485.47us     2.06K
runBM(VARBINARY_100Cols_noNulls_P4)                         3.36ms    297.21
runBM(VARBINARY_100Cols_noNulls_P16)                        3.97ms    251.71
runBM(VARBINARY_100Cols_noNulls_P64)                        4.55ms    219.90
runBM(VARBINARY_100Cols_noNulls_P256)                       4.81ms    207.93
runBM(VARBINARY_100Cols_noNulls_P1024)                      4.73ms    211.21
runBM(VARBINARY_1000Cols_noNulls_P4)                       33.91ms     29.49
runBM(VARBINARY_1000Cols_noNulls_P16)                      40.84ms     24.48
runBM(VARBINARY_1000Cols_noNulls_P64)                      48.92ms     20.44
runBM(VARBINARY_1000Cols_noNulls_P256)                     50.78ms     19.69
runBM(VARBINARY_1000Cols_noNulls_P1024)                    51.87ms     19.28
runBM(VARBINARY_1Cols_allNulls_P4)                         85.84us    11.65K
runBM(VARBINARY_1Cols_allNulls_P16)                        77.09us    12.97K
runBM(VARBINARY_1Cols_allNulls_P64)                        77.17us    12.96K
runBM(VARBINARY_1Cols_allNulls_P256)                       86.65us    11.54K
runBM(VARBINARY_1Cols_allNulls_P1024)                      88.86us    11.25K
runBM(VARBINARY_10Cols_allNulls_P4)                       392.88us     2.55K
runBM(VARBINARY_10Cols_allNulls_P16)                      437.59us     2.29K
runBM(VARBINARY_10Cols_allNulls_P64)                      477.55us     2.09K
runBM(VARBINARY_10Cols_allNulls_P256)                     465.80us     2.15K
runBM(VARBINARY_10Cols_allNulls_P1024)                    488.18us     2.05K
runBM(VARBINARY_100Cols_allNulls_P4)                        3.31ms    301.92
runBM(VARBINARY_100Cols_allNulls_P16)                       3.93ms    254.30
runBM(VARBINARY_100Cols_allNulls_P64)                       4.33ms    230.79
runBM(VARBINARY_100Cols_allNulls_P256)                      4.32ms    231.67
runBM(VARBINARY_100Cols_allNulls_P1024)                     4.63ms    216.14
runBM(VARBINARY_1000Cols_allNulls_P4)                      33.11ms     30.20
runBM(VARBINARY_1000Cols_allNulls_P16)                     39.13ms     25.55
runBM(VARBINARY_1000Cols_allNulls_P64)                     45.95ms     21.76
runBM(VARBINARY_1000Cols_allNulls_P256)                    48.86ms     20.47
runBM(VARBINARY_1000Cols_allNulls_P1024)                   50.96ms     19.62
runBM(VARBINARY_1Cols_halfNulls_P4)                        86.30us    11.59K
runBM(VARBINARY_1Cols_halfNulls_P16)                       82.61us    12.10K
runBM(VARBINARY_1Cols_halfNulls_P64)                       82.15us    12.17K
runBM(VARBINARY_1Cols_halfNulls_P256)                      87.26us    11.46K
runBM(VARBINARY_1Cols_halfNulls_P1024)                     83.05us    12.04K
runBM(VARBINARY_10Cols_halfNulls_P4)                      451.89us     2.21K
runBM(VARBINARY_10Cols_halfNulls_P16)                     490.76us     2.04K
runBM(VARBINARY_10Cols_halfNulls_P64)                     543.09us     1.84K
runBM(VARBINARY_10Cols_halfNulls_P256)                    565.59us     1.77K
runBM(VARBINARY_10Cols_halfNulls_P1024)                   568.76us     1.76K
runBM(VARBINARY_100Cols_halfNulls_P4)                       4.04ms    247.58
runBM(VARBINARY_100Cols_halfNulls_P16)                      4.79ms    208.75
runBM(VARBINARY_100Cols_halfNulls_P64)                      4.97ms    201.10
runBM(VARBINARY_100Cols_halfNulls_P256)                     5.39ms    185.51
runBM(VARBINARY_100Cols_halfNulls_P1024)                    5.54ms    180.64
runBM(VARBINARY_1000Cols_halfNulls_P4)                     40.17ms     24.89
runBM(VARBINARY_1000Cols_halfNulls_P16)                    48.30ms     20.70
runBM(VARBINARY_1000Cols_halfNulls_P64)                    54.37ms     18.39
runBM(VARBINARY_1000Cols_halfNulls_P256)                   58.63ms     17.05
runBM(VARBINARY_1000Cols_halfNulls_P1024)                  61.86ms     16.17
runBM(DATE_1Cols_noNulls_P4)                               91.67us    10.91K
runBM(DATE_1Cols_noNulls_P16)                              70.55us    14.17K
runBM(DATE_1Cols_noNulls_P64)                              70.42us    14.20K
runBM(DATE_1Cols_noNulls_P256)                             69.34us    14.42K
runBM(DATE_1Cols_noNulls_P1024)                            65.90us    15.17K
runBM(DATE_10Cols_noNulls_P4)                             367.30us     2.72K
runBM(DATE_10Cols_noNulls_P16)                            436.55us     2.29K
runBM(DATE_10Cols_noNulls_P64)                            434.93us     2.30K
runBM(DATE_10Cols_noNulls_P256)                           436.88us     2.29K
runBM(DATE_10Cols_noNulls_P1024)                          472.68us     2.12K
runBM(DATE_100Cols_noNulls_P4)                              3.24ms    308.30
runBM(DATE_100Cols_noNulls_P16)                             3.91ms    255.80
runBM(DATE_100Cols_noNulls_P64)                             4.37ms    228.72
runBM(DATE_100Cols_noNulls_P256)                            4.44ms    225.26
runBM(DATE_100Cols_noNulls_P1024)                           4.28ms    233.75
runBM(DATE_1000Cols_noNulls_P4)                            32.33ms     30.93
runBM(DATE_1000Cols_noNulls_P16)                           39.08ms     25.59
runBM(DATE_1000Cols_noNulls_P64)                           45.07ms     22.19
runBM(DATE_1000Cols_noNulls_P256)                          45.01ms     22.22
runBM(DATE_1000Cols_noNulls_P1024)                         45.72ms     21.87
runBM(DATE_1Cols_allNulls_P4)                              86.86us    11.51K
runBM(DATE_1Cols_allNulls_P16)                             71.84us    13.92K
runBM(DATE_1Cols_allNulls_P64)                             76.59us    13.06K
runBM(DATE_1Cols_allNulls_P256)                            86.05us    11.62K
runBM(DATE_1Cols_allNulls_P1024)                           87.36us    11.45K
runBM(DATE_10Cols_allNulls_P4)                            391.76us     2.55K
runBM(DATE_10Cols_allNulls_P16)                           438.88us     2.28K
runBM(DATE_10Cols_allNulls_P64)                           474.64us     2.11K
runBM(DATE_10Cols_allNulls_P256)                          479.09us     2.09K
runBM(DATE_10Cols_allNulls_P1024)                         482.09us     2.07K
runBM(DATE_100Cols_allNulls_P4)                             3.27ms    306.13
runBM(DATE_100Cols_allNulls_P16)                            3.79ms    263.54
runBM(DATE_100Cols_allNulls_P64)                            4.42ms    226.43
runBM(DATE_100Cols_allNulls_P256)                           4.47ms    223.59
runBM(DATE_100Cols_allNulls_P1024)                          4.44ms    225.44
runBM(DATE_1000Cols_allNulls_P4)                           32.47ms     30.80
runBM(DATE_1000Cols_allNulls_P16)                          39.27ms     25.46
runBM(DATE_1000Cols_allNulls_P64)                          44.75ms     22.35
runBM(DATE_1000Cols_allNulls_P256)                         45.22ms     22.12
runBM(DATE_1000Cols_allNulls_P1024)                        45.96ms     21.76
runBM(DATE_1Cols_halfNulls_P4)                             86.82us    11.52K
runBM(DATE_1Cols_halfNulls_P16)                            80.99us    12.35K
runBM(DATE_1Cols_halfNulls_P64)                            81.09us    12.33K
runBM(DATE_1Cols_halfNulls_P256)                           86.07us    11.62K
runBM(DATE_1Cols_halfNulls_P1024)                          81.61us    12.25K
runBM(DATE_10Cols_halfNulls_P4)                           436.09us     2.29K
runBM(DATE_10Cols_halfNulls_P16)                          479.13us     2.09K
runBM(DATE_10Cols_halfNulls_P64)                          546.89us     1.83K
runBM(DATE_10Cols_halfNulls_P256)                         537.47us     1.86K
runBM(DATE_10Cols_halfNulls_P1024)                        566.39us     1.77K
runBM(DATE_100Cols_halfNulls_P4)                            3.84ms    260.54
runBM(DATE_100Cols_halfNulls_P16)                           4.57ms    218.85
runBM(DATE_100Cols_halfNulls_P64)                           4.87ms    205.38
runBM(DATE_100Cols_halfNulls_P256)                          5.12ms    195.30
runBM(DATE_100Cols_halfNulls_P1024)                         5.37ms    186.39
runBM(DATE_1000Cols_halfNulls_P4)                          39.00ms     25.64
runBM(DATE_1000Cols_halfNulls_P16)                         47.85ms     20.90
runBM(DATE_1000Cols_halfNulls_P64)                         52.14ms     19.18
runBM(DATE_1000Cols_halfNulls_P256)                        50.30ms     19.88
runBM(DATE_1000Cols_halfNulls_P1024)                       51.69ms     19.35
runBM(ShortDecimal_1Cols_noNulls_P4)                       86.67us    11.54K
runBM(ShortDecimal_1Cols_noNulls_P16)                      76.67us    13.04K
runBM(ShortDecimal_1Cols_noNulls_P64)                      67.74us    14.76K
runBM(ShortDecimal_1Cols_noNulls_P256)                     68.17us    14.67K
runBM(ShortDecimal_1Cols_noNulls_P1024)                    78.69us    12.71K
runBM(ShortDecimal_10Cols_noNulls_P4)                     388.05us     2.58K
runBM(ShortDecimal_10Cols_noNulls_P16)                    440.30us     2.27K
runBM(ShortDecimal_10Cols_noNulls_P64)                    470.97us     2.12K
runBM(ShortDecimal_10Cols_noNulls_P256)                   447.18us     2.24K
runBM(ShortDecimal_10Cols_noNulls_P1024)                  480.97us     2.08K
runBM(ShortDecimal_100Cols_noNulls_P4)                      3.30ms    302.72
runBM(ShortDecimal_100Cols_noNulls_P16)                     3.96ms    252.37
runBM(ShortDecimal_100Cols_noNulls_P64)                     4.43ms    225.58
runBM(ShortDecimal_100Cols_noNulls_P256)                    4.50ms    222.06
runBM(ShortDecimal_100Cols_noNulls_P1024)                   4.44ms    225.32
runBM(ShortDecimal_1000Cols_noNulls_P4)                    32.81ms     30.48
runBM(ShortDecimal_1000Cols_noNulls_P16)                   39.67ms     25.21
runBM(ShortDecimal_1000Cols_noNulls_P64)                   45.99ms     21.74
runBM(ShortDecimal_1000Cols_noNulls_P256)                  45.69ms     21.89
runBM(ShortDecimal_1000Cols_noNulls_P1024)                 47.21ms     21.18
runBM(ShortDecimal_1Cols_allNulls_P4)                      91.01us    10.99K
runBM(ShortDecimal_1Cols_allNulls_P16)                     71.70us    13.95K
runBM(ShortDecimal_1Cols_allNulls_P64)                     76.94us    13.00K
runBM(ShortDecimal_1Cols_allNulls_P256)                    86.55us    11.55K
runBM(ShortDecimal_1Cols_allNulls_P1024)                   82.51us    12.12K
runBM(ShortDecimal_10Cols_allNulls_P4)                    390.89us     2.56K
runBM(ShortDecimal_10Cols_allNulls_P16)                   439.09us     2.28K
runBM(ShortDecimal_10Cols_allNulls_P64)                   479.13us     2.09K
runBM(ShortDecimal_10Cols_allNulls_P256)                  462.55us     2.16K
runBM(ShortDecimal_10Cols_allNulls_P1024)                 491.26us     2.04K
runBM(ShortDecimal_100Cols_allNulls_P4)                     3.29ms    303.94
runBM(ShortDecimal_100Cols_allNulls_P16)                    3.76ms    265.65
runBM(ShortDecimal_100Cols_allNulls_P64)                    4.46ms    223.98
runBM(ShortDecimal_100Cols_allNulls_P256)                   4.25ms    235.54
runBM(ShortDecimal_100Cols_allNulls_P1024)                  4.55ms    219.85
runBM(ShortDecimal_1000Cols_allNulls_P4)                   32.64ms     30.64
runBM(ShortDecimal_1000Cols_allNulls_P16)                  39.81ms     25.12
runBM(ShortDecimal_1000Cols_allNulls_P64)                  45.71ms     21.88
runBM(ShortDecimal_1000Cols_allNulls_P256)                 47.03ms     21.26
runBM(ShortDecimal_1000Cols_allNulls_P1024)                47.63ms     21.00
runBM(ShortDecimal_1Cols_halfNulls_P4)                     90.38us    11.06K
runBM(ShortDecimal_1Cols_halfNulls_P16)                    81.26us    12.31K
runBM(ShortDecimal_1Cols_halfNulls_P64)                    81.92us    12.21K
runBM(ShortDecimal_1Cols_halfNulls_P256)                   86.65us    11.54K
runBM(ShortDecimal_1Cols_halfNulls_P1024)                  88.47us    11.30K
runBM(ShortDecimal_10Cols_halfNulls_P4)                   447.22us     2.24K
runBM(ShortDecimal_10Cols_halfNulls_P16)                  480.47us     2.08K
runBM(ShortDecimal_10Cols_halfNulls_P64)                  553.51us     1.81K
runBM(ShortDecimal_10Cols_halfNulls_P256)                 563.89us     1.77K
runBM(ShortDecimal_10Cols_halfNulls_P1024)                574.84us     1.74K
runBM(ShortDecimal_100Cols_halfNulls_P4)                    3.75ms    266.46
runBM(ShortDecimal_100Cols_halfNulls_P16)                   4.51ms    221.73
runBM(ShortDecimal_100Cols_halfNulls_P64)                   4.90ms    204.16
runBM(ShortDecimal_100Cols_halfNulls_P256)                  5.34ms    187.42
runBM(ShortDecimal_100Cols_halfNulls_P1024)                 5.21ms    192.05
runBM(ShortDecimal_1000Cols_halfNulls_P4)                  39.42ms     25.37
runBM(ShortDecimal_1000Cols_halfNulls_P16)                 48.19ms     20.75
runBM(ShortDecimal_1000Cols_halfNulls_P64)                 53.67ms     18.63
runBM(ShortDecimal_1000Cols_halfNulls_P256)                52.76ms     18.96
runBM(ShortDecimal_1000Cols_halfNulls_P1024)               53.61ms     18.65
runBM(LongDecimal_1Cols_noNulls_P4)                        84.05us    11.90K
runBM(LongDecimal_1Cols_noNulls_P16)                       76.59us    13.06K
runBM(LongDecimal_1Cols_noNulls_P64)                       72.34us    13.82K
runBM(LongDecimal_1Cols_noNulls_P256)                      71.53us    13.98K
runBM(LongDecimal_1Cols_noNulls_P1024)                     73.67us    13.57K
runBM(LongDecimal_10Cols_noNulls_P4)                      390.59us     2.56K
runBM(LongDecimal_10Cols_noNulls_P16)                     415.05us     2.41K
runBM(LongDecimal_10Cols_noNulls_P64)                     446.26us     2.24K
runBM(LongDecimal_10Cols_noNulls_P256)                    475.97us     2.10K
runBM(LongDecimal_10Cols_noNulls_P1024)                   489.18us     2.04K
runBM(LongDecimal_100Cols_noNulls_P4)                       3.33ms    299.99
runBM(LongDecimal_100Cols_noNulls_P16)                      3.99ms    250.94
runBM(LongDecimal_100Cols_noNulls_P64)                      4.49ms    222.80
runBM(LongDecimal_100Cols_noNulls_P256)                     4.36ms    229.41
runBM(LongDecimal_100Cols_noNulls_P1024)                    4.69ms    213.25
runBM(LongDecimal_1000Cols_noNulls_P4)                     33.30ms     30.03
runBM(LongDecimal_1000Cols_noNulls_P16)                    39.85ms     25.10
runBM(LongDecimal_1000Cols_noNulls_P64)                    46.40ms     21.55
runBM(LongDecimal_1000Cols_noNulls_P256)                   49.09ms     20.37
runBM(LongDecimal_1000Cols_noNulls_P1024)                  50.46ms     19.82
runBM(LongDecimal_1Cols_allNulls_P4)                       85.78us    11.66K
runBM(LongDecimal_1Cols_allNulls_P16)                      77.67us    12.87K
runBM(LongDecimal_1Cols_allNulls_P64)                      77.99us    12.82K
runBM(LongDecimal_1Cols_allNulls_P256)                     81.84us    12.22K
runBM(LongDecimal_1Cols_allNulls_P1024)                    89.80us    11.14K
runBM(LongDecimal_10Cols_allNulls_P4)                     392.88us     2.55K
runBM(LongDecimal_10Cols_allNulls_P16)                    413.14us     2.42K
runBM(LongDecimal_10Cols_allNulls_P64)                    450.89us     2.22K
runBM(LongDecimal_10Cols_allNulls_P256)                   475.09us     2.10K
runBM(LongDecimal_10Cols_allNulls_P1024)                  500.34us     2.00K
runBM(LongDecimal_100Cols_allNulls_P4)                      3.33ms    300.29
runBM(LongDecimal_100Cols_allNulls_P16)                     3.97ms    252.02
runBM(LongDecimal_100Cols_allNulls_P64)                     4.45ms    224.71
runBM(LongDecimal_100Cols_allNulls_P256)                    4.57ms    218.69
runBM(LongDecimal_100Cols_allNulls_P1024)                   4.61ms    217.00
runBM(LongDecimal_1000Cols_allNulls_P4)                    33.06ms     30.25
runBM(LongDecimal_1000Cols_allNulls_P16)                   40.03ms     24.98
runBM(LongDecimal_1000Cols_allNulls_P64)                   46.32ms     21.59
runBM(LongDecimal_1000Cols_allNulls_P256)                  48.99ms     20.41
runBM(LongDecimal_1000Cols_allNulls_P1024)                 50.88ms     19.65
runBM(LongDecimal_1Cols_halfNulls_P4)                      90.13us    11.09K
runBM(LongDecimal_1Cols_halfNulls_P16)                     82.05us    12.19K
runBM(LongDecimal_1Cols_halfNulls_P64)                     78.82us    12.69K
runBM(LongDecimal_1Cols_halfNulls_P256)                    81.90us    12.21K
runBM(LongDecimal_1Cols_halfNulls_P1024)                   84.92us    11.78K
runBM(LongDecimal_10Cols_halfNulls_P4)                    449.34us     2.23K
runBM(LongDecimal_10Cols_halfNulls_P16)                   513.47us     1.95K
runBM(LongDecimal_10Cols_halfNulls_P64)                   555.64us     1.80K
runBM(LongDecimal_10Cols_halfNulls_P256)                  530.55us     1.88K
runBM(LongDecimal_10Cols_halfNulls_P1024)                 583.18us     1.71K
runBM(LongDecimal_100Cols_halfNulls_P4)                     3.98ms    251.56
runBM(LongDecimal_100Cols_halfNulls_P16)                    4.78ms    209.22
runBM(LongDecimal_100Cols_halfNulls_P64)                    5.25ms    190.56
runBM(LongDecimal_100Cols_halfNulls_P256)                   5.39ms    185.62
runBM(LongDecimal_100Cols_halfNulls_P1024)                  5.55ms    180.30
runBM(LongDecimal_1000Cols_halfNulls_P4)                   39.89ms     25.07
runBM(LongDecimal_1000Cols_halfNulls_P16)                  48.39ms     20.67
runBM(LongDecimal_1000Cols_halfNulls_P64)                  53.84ms     18.57
runBM(LongDecimal_1000Cols_halfNulls_P256)                 56.30ms     17.76
runBM(LongDecimal_1000Cols_halfNulls_P1024)                58.18ms     17.19
runBM(Mixed_1Cols_noNulls_P4)                              83.65us    11.95K
runBM(Mixed_1Cols_noNulls_P16)                             81.55us    12.26K
runBM(Mixed_1Cols_noNulls_P64)                             81.76us    12.23K
runBM(Mixed_1Cols_noNulls_P256)                            87.80us    11.39K
runBM(Mixed_1Cols_noNulls_P1024)                           95.15us    10.51K
runBM(Mixed_10Cols_noNulls_P4)                            472.01us     2.12K
runBM(Mixed_10Cols_noNulls_P16)                           485.26us     2.06K
runBM(Mixed_10Cols_noNulls_P64)                           487.39us     2.05K
runBM(Mixed_10Cols_noNulls_P256)                          487.47us     2.05K
runBM(Mixed_10Cols_noNulls_P1024)                         483.22us     2.07K
runBM(Mixed_100Cols_noNulls_P4)                             3.39ms    295.02
runBM(Mixed_100Cols_noNulls_P16)                            4.17ms    239.95
runBM(Mixed_100Cols_noNulls_P64)                            4.62ms    216.24
runBM(Mixed_100Cols_noNulls_P256)                           4.80ms    208.32
runBM(Mixed_100Cols_noNulls_P1024)                          4.96ms    201.60
runBM(Mixed_1000Cols_noNulls_P4)                           33.74ms     29.64
runBM(Mixed_1000Cols_noNulls_P16)                          40.62ms     24.62
runBM(Mixed_1000Cols_noNulls_P64)                          47.07ms     21.25
runBM(Mixed_1000Cols_noNulls_P256)                         49.18ms     20.33
runBM(Mixed_1000Cols_noNulls_P1024)                        52.07ms     19.21
runBM(Mixed_1Cols_allNulls_P4)                             72.57us    13.78K
runBM(Mixed_1Cols_allNulls_P16)                            75.34us    13.27K
runBM(Mixed_1Cols_allNulls_P64)                            76.22us    13.12K
runBM(Mixed_1Cols_allNulls_P256)                           93.92us    10.65K
runBM(Mixed_1Cols_allNulls_P1024)                          88.92us    11.25K
runBM(Mixed_10Cols_allNulls_P4)                           456.68us     2.19K
runBM(Mixed_10Cols_allNulls_P16)                          450.59us     2.22K
runBM(Mixed_10Cols_allNulls_P64)                          483.01us     2.07K
runBM(Mixed_10Cols_allNulls_P256)                         467.09us     2.14K
runBM(Mixed_10Cols_allNulls_P1024)                        487.84us     2.05K
runBM(Mixed_100Cols_allNulls_P4)                            3.46ms    288.77
runBM(Mixed_100Cols_allNulls_P16)                           3.89ms    257.04
runBM(Mixed_100Cols_allNulls_P64)                           4.47ms    223.92
runBM(Mixed_100Cols_allNulls_P256)                          4.28ms    233.65
runBM(Mixed_100Cols_allNulls_P1024)                         4.53ms    220.78
runBM(Mixed_1000Cols_allNulls_P4)                          32.84ms     30.45
runBM(Mixed_1000Cols_allNulls_P16)                         39.83ms     25.11
runBM(Mixed_1000Cols_allNulls_P64)                         45.63ms     21.92
runBM(Mixed_1000Cols_allNulls_P256)                        46.46ms     21.52
runBM(Mixed_1000Cols_allNulls_P1024)                       46.21ms     21.64
runBM(Mixed_1Cols_halfNulls_P4)                            78.22us    12.79K
runBM(Mixed_1Cols_halfNulls_P16)                           86.40us    11.57K
runBM(Mixed_1Cols_halfNulls_P64)                           88.99us    11.24K
runBM(Mixed_1Cols_halfNulls_P256)                          87.78us    11.39K
runBM(Mixed_1Cols_halfNulls_P1024)                         95.32us    10.49K
runBM(Mixed_10Cols_halfNulls_P4)                          524.01us     1.91K
runBM(Mixed_10Cols_halfNulls_P16)                         527.14us     1.90K
runBM(Mixed_10Cols_halfNulls_P64)                         527.43us     1.90K
runBM(Mixed_10Cols_halfNulls_P256)                        533.80us     1.87K
runBM(Mixed_10Cols_halfNulls_P1024)                       544.68us     1.84K
runBM(Mixed_100Cols_halfNulls_P4)                           4.17ms    239.72
runBM(Mixed_100Cols_halfNulls_P16)                          4.93ms    202.82
runBM(Mixed_100Cols_halfNulls_P64)                          5.11ms    195.78
runBM(Mixed_100Cols_halfNulls_P256)                         5.40ms    185.10
runBM(Mixed_100Cols_halfNulls_P1024)                        5.17ms    193.51
runBM(Mixed_1000Cols_halfNulls_P4)                         40.30ms     24.81
runBM(Mixed_1000Cols_halfNulls_P16)                        48.52ms     20.61
runBM(Mixed_1000Cols_halfNulls_P64)                        51.97ms     19.24
runBM(Mixed_1000Cols_halfNulls_P256)                       53.53ms     18.68
runBM(Mixed_1000Cols_halfNulls_P1024)                      55.39ms     18.05
WARNING: Benchmark running in DEBUG mode
```
</details>