### PR TITLE
feat: Enable the hash join to accept a pre-built hash table for joining

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1693,6 +1693,7 @@ folly::dynamic HashJoinNode::serialize() const {
   obj["nullAware"] = nullAware_;
   obj["nullAsValue"] = nullAsValue_;
   obj["useHashTableCache"] = useHashTableCache_;
+  obj["joinHasNullKeys"] = joinHasNullKeys_;
   if (cacheKey_.has_value()) {
     obj["cacheKey"] = cacheKey_.value();
   }
@@ -1713,6 +1714,7 @@ PlanNodePtr HashJoinNode::create(const folly::dynamic& obj, void* context) {
   auto nullAware = obj["nullAware"].asBool();
   auto nullAsValue = obj.getDefault("nullAsValue", false).asBool();
   auto useHashTableCache = obj.getDefault("useHashTableCache", false).asBool();
+  auto joinHasNullKeys = obj.getDefault("joinHasNullKeys", false).asBool();
   std::optional<std::string> cacheKey = std::nullopt;
   if (obj.count("cacheKey")) {
     cacheKey = obj["cacheKey"].asString();
@@ -1739,6 +1741,8 @@ PlanNodePtr HashJoinNode::create(const folly::dynamic& obj, void* context) {
       outputType,
       useHashTableCache,
       nullAsValue,
+      joinHasNullKeys,
+      nullptr,
       std::move(cacheKey));
 }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -30,6 +30,12 @@ struct ArrowArrayStream;
 
 namespace facebook::velox::core {
 
+/// Direct access to HashTable from HashJoinNode would introduce a dependency
+/// cycle. We resolved this by defining an OpaqueHashTable interface,
+/// effectively decoupling the node logic from the specific table
+/// implementation.
+struct OpaqueHashTable;
+
 class PlanNodeVisitor;
 class PlanNodeVisitorContext;
 
@@ -3310,6 +3316,8 @@ class HashJoinNode : public AbstractJoinNode {
       RowTypePtr outputType,
       bool useHashTableCache = false,
       bool nullAsValue = false,
+      bool joinHasNullKeys = false,
+      std::shared_ptr<OpaqueHashTable> reusableHashTable = nullptr,
       std::optional<std::string> cacheKey = std::nullopt)
       : AbstractJoinNode(
             id,
@@ -3323,6 +3331,8 @@ class HashJoinNode : public AbstractJoinNode {
         nullAware_{nullAware},
         nullAsValue_{nullAsValue},
         useHashTableCache_{useHashTableCache},
+        joinHasNullKeys_{joinHasNullKeys},
+        reusableHashTable_(std::move(reusableHashTable)),
         cacheKey_{std::move(cacheKey)} {
     validate();
 
@@ -3366,6 +3376,8 @@ class HashJoinNode : public AbstractJoinNode {
       nullAware_ = other.isNullAware();
       nullAsValue_ = other.isNullAsValue();
       useHashTableCache_ = other.useHashTableCache();
+      joinHasNullKeys_ = other.joinHasNullKeys();
+      reusableHashTable_ = other.reusableHashTable();
       cacheKey_ = other.cacheKey();
     }
 
@@ -3386,6 +3398,17 @@ class HashJoinNode : public AbstractJoinNode {
 
     Builder& cacheKey(std::optional<std::string> value) {
       cacheKey_ = std::move(value);
+      return *this;
+    }
+
+    Builder& joinHasNullKeys(bool joinHasNullKeys) {
+      joinHasNullKeys_ = joinHasNullKeys;
+      return *this;
+    }
+
+    Builder& reusableHashTable(
+        std::shared_ptr<OpaqueHashTable> opaqueHashTable) {
+      reusableHashTable_ = std::move(opaqueHashTable);
       return *this;
     }
 
@@ -3418,6 +3441,8 @@ class HashJoinNode : public AbstractJoinNode {
           outputType_.value(),
           useHashTableCache_.value_or(false),
           nullAsValue_.value_or(false),
+          joinHasNullKeys_.value_or(false),
+          reusableHashTable_.value_or(nullptr),
           cacheKey_);
     }
 
@@ -3425,6 +3450,8 @@ class HashJoinNode : public AbstractJoinNode {
     std::optional<bool> nullAware_;
     std::optional<bool> nullAsValue_;
     std::optional<bool> useHashTableCache_;
+    std::optional<bool> joinHasNullKeys_;
+    std::optional<std::shared_ptr<OpaqueHashTable>> reusableHashTable_;
     std::optional<std::string> cacheKey_;
   };
 
@@ -3469,6 +3496,14 @@ class HashJoinNode : public AbstractJoinNode {
     return cacheKey_;
   }
 
+  bool joinHasNullKeys() const {
+    return joinHasNullKeys_;
+  }
+
+  std::shared_ptr<OpaqueHashTable> reusableHashTable() const {
+    return reusableHashTable_;
+  }
+
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
@@ -3479,6 +3514,8 @@ class HashJoinNode : public AbstractJoinNode {
   const bool nullAware_;
   const bool nullAsValue_;
   const bool useHashTableCache_;
+  const bool joinHasNullKeys_;
+  std::shared_ptr<OpaqueHashTable> reusableHashTable_;
   const std::optional<std::string> cacheKey_;
 };
 

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -49,6 +49,25 @@ BlockingReason fromStateToBlockingReason(HashBuild::State state) {
 }
 } // namespace
 
+void HashBuild::setReusableHashTable(
+    std::shared_ptr<core::OpaqueHashTable> opaqueHashTable) {
+  joinBridge_->start();
+  setState(State::kFinish);
+
+  if (joinNode_->joinHasNullKeys() && isAntiJoin(joinType_) && nullAware_ &&
+      !joinNode_->filter()) {
+    joinBridge_->setAntiJoinHasNullKeys();
+    return;
+  }
+
+  auto reusableHashTable =
+      std::reinterpret_pointer_cast<exec::BaseHashTable>(opaqueHashTable);
+
+  joinBridge_->setHashTable(
+      std::move(reusableHashTable), {}, joinNode_->joinHasNullKeys(), nullptr);
+  reuseHashTable_ = true;
+}
+
 HashBuild::HashBuild(
     int32_t operatorId,
     DriverCtx* driverCtx,
@@ -82,6 +101,12 @@ HashBuild::HashBuild(
   VELOX_CHECK_NOT_NULL(joinBridge_);
 
   joinBridge_->addBuilder();
+
+  if (auto opaqueHashTable = joinNode_->reusableHashTable()) {
+    TestValue::adjust("facebook::velox::exec::HashBuild::HashBuild", this);
+    setReusableHashTable(opaqueHashTable);
+    return;
+  }
 
   const auto& inputType = joinNode_->sources()[1]->outputType();
 
@@ -124,7 +149,7 @@ HashBuild::HashBuild(
 void HashBuild::initialize() {
   Operator::initialize();
 
-  if (setupCachedHashTable()) {
+  if (setupCachedHashTable() || reuseHashTable_) {
     return;
   }
 

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -124,6 +124,10 @@ class HashBuild final : public Operator {
   // Invoked to set up hash table to build.
   void setupTable();
 
+  // Reuse the pre-built hash table.
+  void setReusableHashTable(
+      std::shared_ptr<core::OpaqueHashTable> opaqueHashTable);
+
   // Sets up hash table caching if enabled. Returns true if the cached table
   // is already available or if this operator should wait for another task
   // to build it, in which case further initialization should be skipped.
@@ -414,6 +418,8 @@ class HashBuild final : public Operator {
   // Count the number of hash table input rows for building deduped
   // hash table. It will not be updated after abandonBuildNoDupHash_ is true.
   int64_t numHashInputRows_ = 0;
+
+  bool reuseHashTable_ = false;
 };
 
 inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1004,7 +1004,8 @@ bool HashProbe::canSpill() const {
   // Hash table caching is incompatible with spilling. When the table is
   // cached and shared across tasks, clearing it after probe would corrupt
   // the cache for subsequent tasks.
-  if (joinNode_->useHashTableCache()) {
+  if (joinNode_->useHashTableCache() ||
+      joinNode_->reusableHashTable() != nullptr) {
     return false;
   }
   if (operatorCtx_->task()->hasMixedExecutionGroupJoin(joinNode_.get())) {

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1793,6 +1793,105 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterEmptyBatch) {
       .run();
 }
 
+DEBUG_ONLY_TEST_P(HashJoinTest, reuseHashTable) {
+  // Create build and probe vectors.
+  std::vector<RowVectorPtr> buildVectors = makeBatches(1, [&](int32_t) {
+    return makeRowVector(
+        {"u_0"},
+        {
+            makeFlatVector<int64_t>(100, [](auto row) { return row % 23; }),
+        });
+  });
+
+  std::vector<RowVectorPtr> probeVectors = makeBatches(5, [&](int32_t) {
+    return makeRowVector(
+        {"t_0"},
+        {
+            makeFlatVector<int64_t>(100, [](auto row) { return row % 23; }),
+        });
+  });
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto buildPlanNode =
+      PlanBuilder(planNodeIdGenerator).values(buildVectors).planNode();
+  auto probePlanNode =
+      PlanBuilder(planNodeIdGenerator).values(probeVectors).planNode();
+
+  auto outputType = ROW({"t_0", "u_0"}, {BIGINT(), BIGINT()});
+
+  // Build the HashTable for build side data
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  hashers.push_back(std::make_unique<VectorHasher>(BIGINT(), 0));
+
+  std::shared_ptr<facebook::velox::exec::BaseHashTable> table =
+      HashTable<false>::createForJoin(
+          std::move(hashers),
+          {}, /*dependentTypes*/
+          true /*allowDuplicates*/,
+          true /*hasProbedFlag*/,
+          false /*hasCountFlag*/,
+          1 /*minTableSizeForParallelJoinBuild*/,
+          pool());
+
+  auto rowContainer = table->rows();
+  uint32_t numColumns = buildVectors[0]->childrenSize();
+  std::vector<DecodedVector> decodedVectors;
+  decodedVectors.reserve(numColumns);
+  for (const auto& rowVector : buildVectors) {
+    if (!rowVector || rowVector->size() == 0)
+      continue;
+
+    decodedVectors.clear();
+    SelectivityVector rows(rowVector->size());
+    for (auto& child : rowVector->children()) {
+      decodedVectors.emplace_back(*child, rows);
+    }
+
+    for (auto i = 0; i < rowVector->size(); ++i) {
+      auto* row = rowContainer->newRow();
+      for (auto j = 0; j < numColumns; ++j) {
+        rowContainer->store(decodedVectors[j], i, row, j);
+      }
+    }
+  }
+
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  auto opaqueSharedHashTable = std::shared_ptr<core::OpaqueHashTable>(
+      table, reinterpret_cast<core::OpaqueHashTable*>(table.get()));
+
+  auto joinNode =
+      core::HashJoinNode::Builder()
+          .id(planNodeIdGenerator->next())
+          .joinType(core::JoinType::kInner)
+          .nullAware(false)
+          .leftKeys(
+              {std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "t_0")})
+          .rightKeys(
+              {std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "u_0")})
+          .left(probePlanNode)
+          .right(buildPlanNode)
+          .outputType(outputType)
+          .reusableHashTable(opaqueSharedHashTable)
+          .build();
+
+  std::atomic_bool reusedHashTable{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::HashBuild::HashBuild",
+      std::function<void(HashBuild*)>(
+          [&](HashBuild* windowBuild) { reusedHashTable.store(true); }));
+
+  auto task =
+      AssertQueryBuilder(joinNode, duckDbQueryRunner_)
+          .maxDrivers(1)
+          .assertResults("SELECT t.t_0, u.u_0 FROM t, u WHERE t.t_0 = u.u_0");
+  ASSERT_TRUE(reusedHashTable.load());
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     MultiThreadedHashJoinTest,
     MultiThreadedHashJoinTest,


### PR DESCRIPTION
In Spark, the hash table is constructed only once in the driver and then broadcasted to each executor. In Gluten, we replace the broadcast hash join with a hash join, which leads to performance issues when the broadcast threshold increases. This is because each task must build its own hash table when using hash join.

This PR enables HashBuild to accept pre-built HashTable, thereby bypassing the hash table construction process. Additionally, it modifies HashProbe to avoid clearing the shared hash table after use.