### PR TITLE
feat: Add PartitioningSerializer for Presto serialization

### DIFF
--- a/velox/serializers/CMakeLists.txt
+++ b/velox/serializers/CMakeLists.txt
@@ -29,6 +29,7 @@ velox_add_library(
   UnsafeRowSerializer.cpp
   PrestoBatchVectorSerializer.cpp
   PrestoHeader.cpp
+  PrestoIterativePartitioningSerializer.cpp
   PrestoIterativeVectorSerializer.cpp
   PrestoSerializerDeserializationUtils.cpp
   PrestoSerializerEstimationUtils.cpp

--- a/velox/serializers/PrestoIterativePartitioningSerializer.cpp
+++ b/velox/serializers/PrestoIterativePartitioningSerializer.cpp
@@ -1,0 +1,732 @@
+/*
+ * Copyright (c) International Business Machines Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/serializers/PrestoIterativePartitioningSerializer.h"
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::serializer::presto {
+
+namespace {
+
+constexpr int8_t kCheckSumBitMask = 4;
+constexpr int64_t kVectorSizeTypeSize{sizeof(vector_size_t)};
+// [numRows:4][codec:1]
+constexpr int64_t kUncompressedSizeOffset{kVectorSizeTypeSize + 1};
+// [numRows:4][codec:1][uncompressedSize:4][compressedSize:4][checksum:8]
+constexpr int64_t kHeaderSize{kUncompressedSizeOffset + 4 + 4 + 8};
+
+static inline const std::string_view kByteArray{"BYTE_ARRAY"};
+static inline const std::string_view kShortArray{"SHORT_ARRAY"};
+static inline const std::string_view kIntArray{"INT_ARRAY"};
+static inline const std::string_view kLongArray{"LONG_ARRAY"};
+static inline const std::string_view kInt128Array{"INT128_ARRAY"};
+static inline const std::string_view kVariableWidth{"VARIABLE_WIDTH"};
+static inline const std::string_view kRow{"ROW"};
+
+inline void writeInt32(OutputStream* out, int32_t value) {
+  out->write(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+inline void writeInt64(OutputStream* out, int64_t value) {
+  out->write(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+char getCodecMarker() {
+  char marker = 0;
+  marker |= kCheckSumBitMask;
+  return marker;
+}
+
+std::string_view typeToEncodingName(const TypePtr& type) {
+  switch (type->kind()) {
+    case TypeKind::BOOLEAN:
+    case TypeKind::TINYINT:
+      return kByteArray;
+    case TypeKind::SMALLINT:
+      return kShortArray;
+    case TypeKind::INTEGER:
+    case TypeKind::REAL:
+      return kIntArray;
+    case TypeKind::BIGINT:
+    case TypeKind::DOUBLE:
+    case TypeKind::TIMESTAMP:
+      return kLongArray;
+    case TypeKind::HUGEINT:
+      return kInt128Array;
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+      return kVariableWidth;
+    case TypeKind::ROW:
+      return kRow;
+    default:
+      VELOX_FAIL("Unsupported type kind: {}", static_cast<int>(type->kind()));
+  }
+}
+
+/// Finalizes the Presto page CRC by mixing in the codec marker, row count,
+/// and uncompressed size on top of the listener's accumulated data checksum.
+int64_t computeChecksum(
+    PrestoOutputStreamListener& listener,
+    int8_t codecMarker,
+    int32_t numRows,
+    int32_t uncompressedSize) {
+  auto crc = listener.crc();
+  crc.process_bytes(&codecMarker, 1);
+  crc.process_bytes(&numRows, 4);
+  crc.process_bytes(&uncompressedSize, 4);
+  return static_cast<int64_t>(crc.checksum());
+}
+
+/// Returns the serialized byte width of a fixed-width type, matching the
+/// sizeof(T) used in flushFlatValues.
+int32_t fixedTypeWidth(TypeKind kind) {
+  switch (kind) {
+    case TypeKind::BOOLEAN:
+    case TypeKind::TINYINT:
+      return 1;
+    case TypeKind::SMALLINT:
+      return 2;
+    case TypeKind::INTEGER:
+    case TypeKind::REAL:
+      return 4;
+    case TypeKind::BIGINT:
+    case TypeKind::DOUBLE:
+      return 8;
+    case TypeKind::TIMESTAMP:
+    case TypeKind::HUGEINT:
+      return 16;
+    default:
+      return 0;
+  }
+}
+
+/// Returns the exact bytes for one fixed-width column in one partition.
+int64_t
+simpleColumnBytes(const TypePtr& colType, int64_t numRows, int64_t numNulls) {
+  const auto encodingName = typeToEncodingName(colType);
+  return 4 + static_cast<int64_t>(encodingName.size()) + // header
+      4 + // rowCount
+      1 + // nullFlag
+      (numNulls > 0 ? bits::nbytes(numRows) : 0) + // null bitmap
+      (numRows - numNulls) * fixedTypeWidth(colType->kind()); // values
+}
+
+/// Returns per-partition exact byte counts for one column (all partitions).
+/// Recurses into nested ROW columns.
+///
+/// Byte layout per column type:
+///   Fixed-width: simpleColumnBytes(colType, numRows, numNulls)
+///   ROW:         7 (header) + 4 (numFields)
+///                + sum(child sizes)
+///                + 4 (numRows) + 4*(numRows+1) (offsets) + 1 (hasNulls)
+///                + (rowNulls>0 ? bits::nbytes(numRows) : 0)
+std::vector<int64_t> computeColumnFlushSizes(
+    const std::vector<PartitionedVectorPtr>& columnVectors,
+    const TypePtr& colType,
+    const std::vector<uint32_t>& nonEmptyPartitions,
+    const std::vector<vector_size_t>& rowsPerPartition,
+    uint32_t numPartitions) {
+  std::vector<int64_t> sizes(numPartitions, 0);
+
+  // Compute per-partition null counts by summing across batches.
+  std::vector<int64_t> nullCounts(numPartitions, 0);
+  for (uint32_t p : nonEmptyPartitions) {
+    for (const auto& pv : columnVectors) {
+      nullCounts[p] += pv->numNullsAt(p);
+    }
+  }
+
+  switch (colType->kind()) {
+    case TypeKind::BOOLEAN:
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE:
+    case TypeKind::HUGEINT:
+      for (uint32_t p : nonEmptyPartitions) {
+        sizes[p] =
+            simpleColumnBytes(colType, rowsPerPartition[p], nullCounts[p]);
+      }
+      break;
+
+    case TypeKind::TIMESTAMP:
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+    case TypeKind::ARRAY:
+    case TypeKind::MAP:
+      VELOX_NYI(
+          "computeColumnFlushSizes: unsupported type kind {}",
+          TypeKindName::toName(colType->kind()));
+
+    case TypeKind::ROW: {
+      const auto& rowSchema = colType->asRow();
+      const int32_t numFields = static_cast<int32_t>(rowSchema.size());
+
+      // Fixed per-partition overhead: header(7) + numFields(4) + footer:
+      // numRows(4)
+      // + sequential offsets 4*(numRows+1) + hasNulls(1)
+      // + null bitmap for the ROW vector itself if any rows in this partition
+      // are null.
+      for (uint32_t p : nonEmptyPartitions) {
+        const int64_t numRows = rowsPerPartition[p];
+        const int64_t rowNullBitmapBytes =
+            nullCounts[p] > 0 ? bits::nbytes(numRows) : 0;
+        sizes[p] = 7 + 4 + // "ROW" header + numFields
+            4 + 4 * (numRows + 1) + 1 + // footer: numRows + offsets + hasNulls
+            rowNullBitmapBytes;
+      }
+      // Add child column sizes recursively.
+      for (uint32_t col = 0; col < static_cast<uint32_t>(numFields); ++col) {
+        std::vector<PartitionedVectorPtr> childVectors;
+        childVectors.reserve(columnVectors.size());
+        for (const auto& pv : columnVectors) {
+          childVectors.push_back(
+              std::dynamic_pointer_cast<PartitionedRowVector>(pv)->childAt(
+                  col));
+        }
+        const auto childSizes = computeColumnFlushSizes(
+            childVectors,
+            rowSchema.childAt(col),
+            nonEmptyPartitions,
+            rowsPerPartition,
+            numPartitions);
+        for (uint32_t p : nonEmptyPartitions) {
+          sizes[p] += childSizes[p];
+        }
+      }
+      break;
+    }
+
+    default:
+      VELOX_UNSUPPORTED(
+          "computeColumnFlushSizes: unsupported type kind {}",
+          TypeKindName::toName(colType->kind()));
+  }
+  return sizes;
+}
+
+} // namespace
+
+PrestoIterativePartitioningSerializer::PrestoIterativePartitioningSerializer(
+    RowTypePtr inputType,
+    uint32_t numPartitions,
+    const SerdeOpts& opts,
+    memory::MemoryPool* pool)
+    : type_(std::move(inputType)),
+      numPartitions_(numPartitions),
+      opts_(opts),
+      pool_(pool),
+      rowsPerPartition_(numPartitions, 0) {
+  VELOX_CHECK_GT(numPartitions_, 0);
+  VELOX_CHECK_NOT_NULL(pool_);
+
+  numColumns_ = type_->size();
+}
+
+void PrestoIterativePartitioningSerializer::append(
+    const RowVectorPtr& input,
+    const std::vector<uint32_t>& partitions) {
+  VELOX_CHECK_NOT_NULL(input);
+  VELOX_CHECK_EQ(
+      input->size(),
+      partitions.size(),
+      "partitions.size() must equal input->size()");
+
+  if (input->size() == 0) {
+    return;
+  }
+
+  PartitionBuildContext ctx;
+  auto partitionedRowVector = PartitionedVector::create(
+      std::static_pointer_cast<BaseVector>(input),
+      partitions,
+      numPartitions_,
+      ctx,
+      pool_);
+
+  const vector_size_t* partitionOffsets =
+      partitionedRowVector->rawPartitionOffsets();
+  vector_size_t prevOffset = 0;
+  for (uint32_t p = 0; p < numPartitions_; ++p) {
+    rowsPerPartition_[p] += partitionOffsets[p] - prevOffset;
+    prevOffset = partitionOffsets[p];
+  }
+
+  partitionedRowVectors_.push_back(std::move(partitionedRowVector));
+
+  bytesBuffered_ += input->retainedSize();
+  rowsBuffered_ += static_cast<int64_t>(input->size());
+}
+
+// ---------------------------------------------------------------------------
+// Top-level flush
+// ---------------------------------------------------------------------------
+
+std::map<uint32_t, std::pair<std::unique_ptr<folly::IOBuf>, vector_size_t>>
+PrestoIterativePartitioningSerializer::flush() {
+  auto pages =
+      (opts_.compressionKind == common::CompressionKind::CompressionKind_NONE)
+      ? flushUncompressed()
+      : flushCompressed();
+
+  partitionedRowVectors_.clear();
+  flushSizes_.clear();
+  std::fill(rowsPerPartition_.begin(), rowsPerPartition_.end(), 0);
+  bytesBuffered_ = 0;
+  rowsBuffered_ = 0;
+
+  return pages;
+}
+
+std::map<uint32_t, std::pair<std::unique_ptr<folly::IOBuf>, vector_size_t>>
+PrestoIterativePartitioningSerializer::flushUncompressed() {
+  if (partitionedRowVectors_.empty()) {
+    return {};
+  }
+
+  const char codecMask = getCodecMarker();
+
+  // 1. Determine non-empty partitions.
+  std::vector<uint32_t> nonEmptyPartitions;
+  for (uint32_t p = 0; p < numPartitions_; ++p) {
+    if (rowsPerPartition_[p] > 0) {
+      nonEmptyPartitions.push_back(p);
+    }
+  }
+
+  // 2. Pre-compute exact byte sizes per top-level column and partition.
+  const auto& rowSchema = type_->asRow();
+  flushSizes_.assign(rowSchema.size(), std::vector<int64_t>(numPartitions_, 0));
+  for (uint32_t col = 0; col < rowSchema.size(); ++col) {
+    std::vector<PartitionedVectorPtr> columnVectors;
+    columnVectors.reserve(partitionedRowVectors_.size());
+    for (const auto& pRowVector : partitionedRowVectors_) {
+      columnVectors.push_back(
+          std::dynamic_pointer_cast<PartitionedRowVector>(pRowVector)
+              ->childAt(col));
+    }
+    flushSizes_[col] = computeColumnFlushSizes(
+        columnVectors,
+        rowSchema.childAt(col),
+        nonEmptyPartitions,
+        rowsPerPartition_,
+        numPartitions_);
+  }
+
+  // 3. Create output streams sized to the exact bytes each partition will need,
+  // so that the entire payload fits. This avoids multiple resizing and copying.
+  std::vector<std::unique_ptr<PrestoOutputStreamListener>> listeners(
+      numPartitions_);
+  std::vector<std::unique_ptr<IOBufOutputStream>> outputStreams(numPartitions_);
+  std::vector<IOBufOutputStream*> rawOutputStreams(numPartitions_);
+  std::vector<std::streampos> beginStreamPositions(numPartitions_);
+
+  for (uint32_t p : nonEmptyPartitions) {
+    int64_t initialSize = kHeaderSize + 4; // page header + numCols
+    for (uint32_t col = 0; col < rowSchema.size(); ++col) {
+      initialSize += flushSizes_[col][p];
+    }
+    listeners[p] = std::make_unique<PrestoOutputStreamListener>();
+    outputStreams[p] = std::make_unique<IOBufOutputStream>(
+        *pool_, listeners[p].get(), initialSize);
+    rawOutputStreams[p] = outputStreams[p].get();
+    beginStreamPositions[p] = outputStreams[p]->tellp();
+
+    flushStart(*outputStreams[p], p, codecMask);
+  }
+
+  // 4. Flush column data.
+  flushRowChildren(
+      partitionedRowVectors_, rowSchema, nonEmptyPartitions, rawOutputStreams);
+
+  // 5. Finalize the page by seeking back to fill in sizes and CRC, and get the
+  // IOBuf and numOfRows from each stream.
+  std::map<uint32_t, std::pair<std::unique_ptr<folly::IOBuf>, vector_size_t>>
+      result;
+  for (uint32_t p : nonEmptyPartitions) {
+    flushFinish(
+        *outputStreams[p],
+        p,
+        beginStreamPositions[p],
+        codecMask,
+        *listeners[p]);
+    result[p] =
+        std::make_pair(outputStreams[p]->getIOBuf(), rowsPerPartition_[p]);
+  }
+
+  return result;
+}
+
+std::map<uint32_t, std::pair<std::unique_ptr<folly::IOBuf>, vector_size_t>>
+PrestoIterativePartitioningSerializer::flushCompressed() {
+  VELOX_NYI();
+}
+
+// ---------------------------------------------------------------------------
+// Second level functions: start, columns and finish
+// ---------------------------------------------------------------------------
+
+void PrestoIterativePartitioningSerializer::flushStart(
+    IOBufOutputStream& out,
+    uint32_t partition,
+    char codecMask) const {
+  auto* listener = dynamic_cast<PrestoOutputStreamListener*>(out.listener());
+  if (listener) {
+    listener->pause();
+  }
+
+  // Write 21-byte Presto page header; sizes and CRC are filled in later.
+  const int32_t numRows = static_cast<int32_t>(rowsPerPartition_[partition]);
+  char header[kHeaderSize] = {};
+  std::memcpy(&header[0], &numRows, 4);
+  std::memcpy(&header[4], &codecMask, 1);
+  out.write(header, kHeaderSize);
+
+  if (listener) {
+    listener->resume();
+  }
+
+  // Number of columns is included in the CRC.
+  const int32_t numCols = static_cast<int32_t>(numColumns_);
+  out.write(reinterpret_cast<const char*>(&numCols), 4);
+}
+
+void PrestoIterativePartitioningSerializer::flushRowChildren(
+    const std::vector<PartitionedVectorPtr>& partitionedVectors,
+    const RowType& rowSchema,
+    const std::vector<uint32_t>& nonEmptyPartitions,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  for (uint32_t col = 0; col < rowSchema.size(); ++col) {
+    std::vector<PartitionedVectorPtr> column;
+    column.reserve(partitionedVectors.size());
+    for (const auto& partitionedVector : partitionedVectors) {
+      const auto& partitionedRowVector =
+          std::dynamic_pointer_cast<PartitionedRowVector>(partitionedVector);
+      VELOX_DCHECK_NOT_NULL(partitionedRowVector.get());
+      column.push_back(partitionedRowVector->childAt(col));
+    }
+
+    flushColumn(
+        column, rowSchema.childAt(col), nonEmptyPartitions, outputStreams);
+  }
+}
+
+void PrestoIterativePartitioningSerializer::flushFinish(
+    IOBufOutputStream& out,
+    uint32_t partition,
+    std::streampos beginOffset,
+    char codecMask,
+    PrestoOutputStreamListener& listener) const {
+  listener.pause();
+
+  const std::streampos totalSize =
+      static_cast<int32_t>(out.tellp() - beginOffset);
+  const std::streampos uncompressedSize = totalSize - kHeaderSize;
+  const int64_t crc = computeChecksum(
+      listener,
+      static_cast<int8_t>(codecMask),
+      static_cast<int32_t>(rowsPerPartition_[partition]),
+      uncompressedSize);
+
+  out.seekp(beginOffset + kUncompressedSizeOffset);
+  writeInt32(&out, uncompressedSize);
+  writeInt32(&out, uncompressedSize); // TODO: compressedSize
+  writeInt64(&out, crc);
+  out.seekp(beginOffset + totalSize);
+}
+
+// ---------------------------------------------------------------------------
+// Column-level dispatch
+// ---------------------------------------------------------------------------
+
+void PrestoIterativePartitioningSerializer::flushColumn(
+    const std::vector<PartitionedVectorPtr>& partitionedVectors,
+    const TypePtr& colType,
+    const std::vector<uint32_t>& nonEmptyPartitions,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  VELOX_CHECK_GT(partitionedVectors.size(), 0);
+
+  auto typeKind = partitionedVectors[0]->baseVector()->typeKind();
+  switch (typeKind) {
+    case TypeKind::BOOLEAN:
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE:
+    case TypeKind::HUGEINT:
+      flushSimpleColumn(
+          partitionedVectors, colType, nonEmptyPartitions, outputStreams);
+      break;
+
+    case TypeKind::TIMESTAMP:
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+    case TypeKind::ROW:
+    case TypeKind::ARRAY:
+    case TypeKind::MAP:
+      VELOX_NYI();
+
+    default:
+      VELOX_UNSUPPORTED(
+          "Invalid vector encoding for PrestoIterativePartitioningSerializer: ",
+          typeKind);
+  }
+}
+
+void PrestoIterativePartitioningSerializer::flushSimpleColumn(
+    const std::vector<PartitionedVectorPtr>& partitionedVectors,
+    const TypePtr& colType,
+    const std::vector<uint32_t>& nonEmptyPartitions,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  flushHeader(typeToEncodingName(colType), nonEmptyPartitions, outputStreams);
+  flushRowCounts(nonEmptyPartitions, outputStreams);
+  flushNulls(partitionedVectors, nonEmptyPartitions, outputStreams);
+
+  for (size_t i = 0; i < partitionedVectors.size(); i++) {
+    flushSingleSimpleVector(partitionedVectors[i], outputStreams);
+  }
+}
+
+template <TypeKind kind>
+void PrestoIterativePartitioningSerializer::flushSingleFlatVector(
+    const PartitionedVectorPtr& partitionedVector,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  using T = typename TypeTraits<kind>::NativeType;
+  auto* flatVector = partitionedVector->as<PartitionedFlatVector<T>>();
+  VELOX_DCHECK_NOT_NULL(flatVector);
+
+  const auto* rawValues =
+      flatVector->baseVector()->template as<FlatVector<T>>()->rawValues();
+  const auto* rawNulls = flatVector->baseVector()->rawNulls();
+  const auto* partitionOffsets = flatVector->rawPartitionOffsets();
+
+  flushFlatValues<T>(rawValues, rawNulls, partitionOffsets, outputStreams);
+}
+
+// BOOLEAN columns use kByteArray encoding: FlatVector<bool> stores bits
+// packed, so rawValues() is unsupported. Each non-null value is written as
+// one byte (0x00 or 0x01).
+template <>
+void PrestoIterativePartitioningSerializer::flushSingleFlatVector<
+    TypeKind::BOOLEAN>(
+    const PartitionedVectorPtr& partitionedVector,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  auto* flatVector = partitionedVector->as<PartitionedFlatVector<bool>>();
+  VELOX_DCHECK_NOT_NULL(flatVector);
+
+  const auto* rawBoolValues =
+      flatVector->baseVector()->as<FlatVector<bool>>()->rawValues<uint64_t>();
+  const auto* rawNulls = flatVector->baseVector()->rawNulls();
+  const auto* partitionOffsets = flatVector->rawPartitionOffsets();
+
+  // TODO: Improve performance
+  vector_size_t lastOffset = 0;
+  for (uint32_t p = 0; p < numPartitions_; ++p) {
+    const auto offset = partitionOffsets[p];
+    const auto numValues = offset - lastOffset;
+    const auto numNulls = partitionedVector->numNullsAt(p);
+    if (outputStreams[p] != nullptr && numValues > 0) {
+      if (numNulls == 0) {
+        for (vector_size_t i = lastOffset; i < offset; ++i) {
+          const int8_t val = bits::isBitSet(rawBoolValues, i) ? 1 : 0;
+          outputStreams[p]->write(reinterpret_cast<const char*>(&val), 1);
+        }
+      } else {
+        VELOX_DCHECK_NOT_NULL(rawNulls);
+        for (vector_size_t i = lastOffset; i < offset; ++i) {
+          if (!bits::isBitNull(rawNulls, i)) {
+            const int8_t val = bits::isBitSet(rawBoolValues, i) ? 1 : 0;
+            outputStreams[p]->write(reinterpret_cast<const char*>(&val), 1);
+          }
+        }
+      }
+    }
+    lastOffset = offset;
+  }
+}
+
+void PrestoIterativePartitioningSerializer::flushSingleSimpleVector(
+    const PartitionedVectorPtr& partitionedVector,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  auto encoding = partitionedVector->baseVector()->encoding();
+  auto typeKind = partitionedVector->baseVector()->typeKind();
+
+  switch (encoding) {
+    case VectorEncoding::Simple::FLAT:
+      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          flushSingleFlatVector, typeKind, partitionedVector, outputStreams);
+      break;
+    case VectorEncoding::Simple::BIASED:
+    case VectorEncoding::Simple::CONSTANT:
+    case VectorEncoding::Simple::DICTIONARY:
+    case VectorEncoding::Simple::SEQUENCE:
+      VELOX_NYI(
+          "Unsupported vector encoding for PrestoIterativePartitioningSerializer: ",
+          encoding);
+    default:
+      VELOX_UNSUPPORTED(
+          "Invalid vector encoding for PrestoIterativePartitioningSerializer:flushSingleSimpleVector ",
+          encoding);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Column building blocks
+// ---------------------------------------------------------------------------
+
+void PrestoIterativePartitioningSerializer::flushHeader(
+    std::string_view name,
+    const std::vector<uint32_t>& nonEmptyPartitions,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  const int32_t nameLen = static_cast<int32_t>(name.size());
+  for (uint32_t p : nonEmptyPartitions) {
+    writeInt32(outputStreams[p], nameLen);
+    outputStreams[p]->write(name.data(), nameLen);
+  }
+}
+
+void PrestoIterativePartitioningSerializer::flushRowCounts(
+    const std::vector<uint32_t>& nonEmptyPartitions,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  for (uint32_t p : nonEmptyPartitions) {
+    writeInt32(outputStreams[p], static_cast<int32_t>(rowsPerPartition_[p]));
+  }
+}
+
+void PrestoIterativePartitioningSerializer::flushNulls(
+    const std::vector<PartitionedVectorPtr>& partitionedVectors,
+    const std::vector<uint32_t>& nonEmptyPartitions,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  std::vector<vector_size_t> nullCounts(numPartitions_, 0);
+  for (uint32_t p : nonEmptyPartitions) {
+    for (const auto& pv : partitionedVectors) {
+      nullCounts[p] += pv->numNullsAt(p);
+    }
+    const char flagByte = nullCounts[p] > 0 ? 1 : 0;
+    outputStreams[p]->write(&flagByte, 1);
+  }
+
+  const bool hasAnyNulls = std::any_of(
+      nonEmptyPartitions.begin(), nonEmptyPartitions.end(), [&](uint32_t p) {
+        return nullCounts[p] > 0;
+      });
+  if (!hasAnyNulls) {
+    return;
+  }
+
+  // Build each partition's null bitmap in a temporary buffer, accumulating
+  // bits across all batches. Writing via write() correctly handles range
+  // boundaries in the output stream without requiring seekp().
+  // TODO: Avoid this extra memory allocation and copy
+  std::vector<std::vector<uint8_t>> bitmaps(numPartitions_);
+  for (uint32_t p : nonEmptyPartitions) {
+    if (nullCounts[p] > 0) {
+      bitmaps[p].assign(bits::nbytes(rowsPerPartition_[p]), bits::kNotNullByte);
+    }
+  }
+
+  std::vector<vector_size_t> destBitOffsets(numPartitions_, 0);
+  for (const auto& pv : partitionedVectors) {
+    const uint64_t* rawNulls = pv->baseVector()->rawNulls();
+    const auto* partitionOffsets = pv->rawPartitionOffsets();
+
+    vector_size_t startBit = 0;
+    for (uint32_t p : nonEmptyPartitions) {
+      const vector_size_t numBits = partitionOffsets[p] - startBit;
+      if (rawNulls && numBits > 0 && !bitmaps[p].empty()) {
+        bits::copyBits(
+            rawNulls,
+            startBit,
+            reinterpret_cast<uint64_t*>(bitmaps[p].data()),
+            destBitOffsets[p],
+            numBits);
+      }
+      if (!bitmaps[p].empty()) {
+        destBitOffsets[p] += numBits;
+      }
+      startBit = partitionOffsets[p];
+    }
+  }
+
+  for (uint32_t p : nonEmptyPartitions) {
+    if (nullCounts[p] == 0) {
+      continue;
+    }
+
+    // Convert Velox format (LSB-first, 1=not-null) to Presto wire format
+    // (MSB-first, 1=null) in-place.
+    const int32_t numBytes = bits::nbytes(rowsPerPartition_[p]);
+    for (int32_t i = 0; i < numBytes; ++i) {
+      bitmaps[p][i] = ~bitmaps[p][i];
+      bits::reverseBits(&bitmaps[p][i], 1);
+    }
+
+    outputStreams[p]->write(
+        reinterpret_cast<const char*>(bitmaps[p].data()), numBytes);
+  }
+}
+
+template <typename T>
+void PrestoIterativePartitioningSerializer::flushFlatValues(
+    const T* partitionedValues,
+    const uint64_t* rawNulls,
+    const vector_size_t* partitionOffsets,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  const auto typeWidth = sizeof(T);
+  vector_size_t lastOffset = 0;
+  for (uint32_t p = 0; p < numPartitions_; ++p) {
+    const auto offset = partitionOffsets[p];
+    const auto numValues = offset - lastOffset;
+    if (outputStreams[p] != nullptr && numValues > 0) {
+      if (!rawNulls) {
+        outputStreams[p]->write(
+            reinterpret_cast<const char*>(&partitionedValues[lastOffset]),
+            numValues * typeWidth);
+      } else {
+        // Presto writes only non-null values; null slots are omitted.
+        // TODO: Improve performance
+        for (vector_size_t i = lastOffset; i < offset; ++i) {
+          if (!bits::isBitNull(rawNulls, i)) {
+            outputStreams[p]->write(
+                reinterpret_cast<const char*>(&partitionedValues[i]),
+                typeWidth);
+          }
+        }
+      }
+    }
+    lastOffset = offset;
+  }
+}
+
+void PrestoIterativePartitioningSerializer::flushSequentialOffsets(
+    const std::vector<uint32_t>& nonEmptyPartitions,
+    const std::vector<IOBufOutputStream*>& outputStreams) const {
+  for (uint32_t p : nonEmptyPartitions) {
+    const int32_t numRows = static_cast<int32_t>(rowsPerPartition_[p]);
+    for (int32_t i = 0; i <= numRows; ++i) {
+      writeInt32(outputStreams[p], i);
+    }
+  }
+}
+
+} // namespace facebook::velox::serializer::presto

--- a/velox/serializers/PrestoIterativePartitioningSerializer.h
+++ b/velox/serializers/PrestoIterativePartitioningSerializer.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) International Business Machines Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <folly/io/IOBuf.h>
+
+#include "velox/common/memory/ByteStream.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/type/Type.h"
+#include "velox/vector/PartitionedVector.h"
+
+namespace facebook::velox::serializer::presto {
+
+/// Convenience alias matching PrestoSerializer.cpp convention.
+using SerdeOpts = PrestoVectorSerde::PrestoOptions;
+
+/// Serializes a stream of RowVectors into per-partition Presto pages.
+///
+/// Each call to append() routes rows to their assigned partition. flush()
+/// produces one Presto-format IOBuf per non-empty partition and resets the
+/// internal state so the serializer can be reused for the next cycle.
+class PrestoIterativePartitioningSerializer {
+ public:
+  PrestoIterativePartitioningSerializer(
+      RowTypePtr inputType,
+      uint32_t numPartitions,
+      const SerdeOpts& opts,
+      memory::MemoryPool* pool);
+
+  /// Routes each row in `input` to the partition indicated by `partitions`.
+  /// `partitions.size()` must equal `input->size()`.
+  void append(
+      const RowVectorPtr& input,
+      const std::vector<uint32_t>& partitions);
+
+  /// Serializes all buffered data into one Presto page per non-empty partition
+  /// and resets internal state. Returns an empty map if nothing has been
+  /// appended since the last flush.
+  std::map<uint32_t, std::pair<std::unique_ptr<folly::IOBuf>, vector_size_t>>
+  flush();
+
+  /// Returns the total retained bytes of all appended input vectors.
+  int64_t bytesBuffered() const {
+    return bytesBuffered_;
+  }
+
+  /// Returns the total number of rows appended since the last flush.
+  int64_t rowsBuffered() const {
+    return rowsBuffered_;
+  }
+
+  /// Returns the number of rows buffered for the given partition.
+  /// Must be called before flush(), which resets per-partition counts.
+  int64_t rowsPerPartition(uint32_t partition) const {
+    VELOX_DCHECK_LT(partition, numPartitions_);
+    return rowsPerPartition_[partition];
+  }
+
+ private:
+  std::map<uint32_t, std::pair<std::unique_ptr<folly::IOBuf>, vector_size_t>>
+  flushUncompressed();
+  std::map<uint32_t, std::pair<std::unique_ptr<folly::IOBuf>, vector_size_t>>
+  flushCompressed();
+
+  void flushStart(IOBufOutputStream& out, uint32_t partition, char codecMask)
+      const;
+
+  void flushFinish(
+      IOBufOutputStream& out,
+      uint32_t partition,
+      std::streampos beginOffset,
+      char codecMask,
+      PrestoOutputStreamListener& listener) const;
+
+  void flushRowChildren(
+      const std::vector<PartitionedVectorPtr>& partitionedVectors,
+      const RowType& rowSchema,
+      const std::vector<uint32_t>& nonEmptyPartitions,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  void flushColumn(
+      const std::vector<PartitionedVectorPtr>& partitionedVectors,
+      const TypePtr& colType,
+      const std::vector<uint32_t>& nonEmptyPartitions,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  void flushSimpleColumn(
+      const std::vector<PartitionedVectorPtr>& partitionedVectors,
+      const TypePtr& colType,
+      const std::vector<uint32_t>& nonEmptyPartitions,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  void flushSingleSimpleVector(
+      const PartitionedVectorPtr& partitionedVector,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  template <TypeKind kind>
+  void flushSingleFlatVector(
+      const PartitionedVectorPtr& partitionedVector,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  void flushHeader(
+      std::string_view name,
+      const std::vector<uint32_t>& nonEmptyPartitions,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  void flushRowCounts(
+      const std::vector<uint32_t>& nonEmptyPartitions,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  void flushNulls(
+      const std::vector<PartitionedVectorPtr>& partitionedVectors,
+      const std::vector<uint32_t>& nonEmptyPartitions,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  template <typename T>
+  void flushFlatValues(
+      const T* partitionedValues,
+      const uint64_t* rawNulls,
+      const vector_size_t* partitionOffsets,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  void flushSequentialOffsets(
+      const std::vector<uint32_t>& nonEmptyPartitions,
+      const std::vector<IOBufOutputStream*>& outputStreams) const;
+
+  RowTypePtr type_;
+  uint32_t numPartitions_;
+  SerdeOpts opts_;
+  memory::MemoryPool* pool_;
+
+  /// Cumulative row count per partition across all appended batches.
+  std::vector<vector_size_t> rowsPerPartition_;
+
+  /// Number of top-level columns in `type_`.
+  uint32_t numColumns_{0};
+
+  std::vector<PartitionedVectorPtr> partitionedRowVectors_;
+
+  int64_t bytesBuffered_{0};
+  int64_t rowsBuffered_{0};
+
+  /// Per-column, per-partition exact byte counts computed during flush.
+  std::vector<std::vector<int64_t>> flushSizes_;
+};
+
+} // namespace facebook::velox::serializer::presto

--- a/velox/serializers/benchmarks/CMakeLists.txt
+++ b/velox/serializers/benchmarks/CMakeLists.txt
@@ -21,3 +21,17 @@ target_link_libraries(
   Folly::folly
   Folly::follybenchmark
 )
+
+add_executable(
+  velox_presto_iterative_partitioning_serializer_benchmark
+  PrestoIterativePartitioningSerializerBenchmark.cpp
+)
+
+target_link_libraries(
+  velox_presto_iterative_partitioning_serializer_benchmark
+  velox_presto_serializer
+  velox_vector_test_lib
+  velox_memory
+  Folly::folly
+  Folly::follybenchmark
+)

--- a/velox/serializers/benchmarks/PrestoIterativePartitioningSerializerBenchmark.cpp
+++ b/velox/serializers/benchmarks/PrestoIterativePartitioningSerializerBenchmark.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) International Business Machines Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/serializers/PrestoIterativePartitioningSerializer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::serializer::presto;
+
+constexpr int64_t kBufferSize = 2 * 1024 * 1024;
+
+namespace {
+
+class PrestoIterativePartitioningSerializerBenchmark
+    : public test::VectorTestBase {
+ public:
+  /// Creates a flat vector of type T with deterministic null pattern.
+  /// Rows where (row % 100) < nullPct are null.
+  template <typename T>
+  VectorPtr makeColumnOfType(vector_size_t size, int32_t nullPct) {
+    if (nullPct == 0) {
+      return makeFlatVector<T>(
+          size, [](auto row) { return static_cast<T>(row); });
+    }
+    return makeFlatVector<T>(
+        size,
+        [](auto row) { return static_cast<T>(row); },
+        [nullPct](auto row) { return (row % 100) < nullPct; });
+  }
+
+  /// Creates a flat vector of the given TypeKind with the given null ratio.
+  VectorPtr makeColumn(vector_size_t size, TypeKind colKind, int32_t nullPct) {
+    switch (colKind) {
+      case TypeKind::BOOLEAN:
+        return makeColumnOfType<bool>(size, nullPct);
+      case TypeKind::INTEGER:
+        return makeColumnOfType<int32_t>(size, nullPct);
+      case TypeKind::BIGINT:
+        return makeColumnOfType<int64_t>(size, nullPct);
+      case TypeKind::HUGEINT:
+        return makeColumnOfType<int128_t>(size, nullPct);
+      default:
+        VELOX_UNSUPPORTED(
+            "Unsupported TypeKind: {}", TypeKindName::toName(colKind));
+    }
+  }
+
+  /// Creates a RowVector with numCols columns of the given TypeKind.
+  RowVectorPtr makeInput(
+      vector_size_t size,
+      TypeKind colKind,
+      uint32_t numCols,
+      int32_t nullPct) {
+    std::vector<std::string> names;
+    std::vector<VectorPtr> children;
+    names.reserve(numCols);
+    children.reserve(numCols);
+    for (uint32_t i = 0; i < numCols; ++i) {
+      names.push_back(fmt::format("c{}", i));
+      children.push_back(makeColumn(size, colKind, nullPct));
+    }
+    return makeRowVector(names, children);
+  }
+
+  std::vector<uint32_t> makePartitions(
+      vector_size_t size,
+      uint32_t numPartitions) {
+    std::vector<uint32_t> partitions(size);
+    for (vector_size_t i = 0; i < size; ++i) {
+      partitions[i] = i % numPartitions;
+    }
+    return partitions;
+  }
+
+  std::unique_ptr<PrestoIterativePartitioningSerializer> makeSerializer(
+      const RowTypePtr& type,
+      uint32_t numPartitions) {
+    SerdeOpts opts;
+    return std::make_unique<PrestoIterativePartitioningSerializer>(
+        type, numPartitions, opts, pool_.get());
+  }
+};
+
+} // namespace
+
+/// Single benchmark function parameterized by (colKind, numCols, nullPct,
+/// numPartitions). Registered via BENCHMARK_NAMED_PARAM below.
+///
+/// All runs use 10'000 rows. Setup (input creation, serializer construction,
+/// append) is excluded from the measured time.
+void benchmarkFlush(
+    uint32_t /* iters */,
+    TypeKind colKind,
+    uint32_t numCols,
+    int32_t nullPct,
+    uint32_t numPartitions) {
+  folly::BenchmarkSuspender suspender;
+  PrestoIterativePartitioningSerializerBenchmark benchmark;
+  auto input = benchmark.makeInput(10'000, colKind, numCols, nullPct);
+  auto parts = benchmark.makePartitions(10'000, numPartitions);
+  auto serializer = benchmark.makeSerializer(
+      std::static_pointer_cast<const RowType>(input->type()), numPartitions);
+
+  while (serializer->bytesBuffered() < kBufferSize) {
+    serializer->append(input, parts);
+  }
+
+  suspender.dismiss();
+
+  auto result = serializer->flush();
+  folly::doNotOptimizeAway(result);
+}
+
+// clang-format off
+// Dimensions:
+//   col type:       {bool, int, bigint, hugeint}
+//   num cols:       {1, 4, 16, 64}
+//   null pct:       {0, 25, 50, 75, 100}
+//   num partitions: {1, 4, 16, 64, 256, 1024}
+//
+// Naming: flush_<type>_<N>cols_<P>pct_<K>parts
+
+#define FLUSH_PARAM(type_name, kind, num_cols, null_pct, num_parts) \
+  BENCHMARK_NAMED_PARAM(                                            \
+      benchmarkFlush,                                               \
+      type_name## _## num_cols## cols_## null_pct## pct_## num_parts## parts, \
+      TypeKind::kind, num_cols, null_pct, num_parts)
+
+#define FLUSH_FOR_PARTS(type_name, kind, num_cols, null_pct) \
+  FLUSH_PARAM(type_name, kind, num_cols, null_pct, 1)        \
+  FLUSH_PARAM(type_name, kind, num_cols, null_pct, 4)        \
+  FLUSH_PARAM(type_name, kind, num_cols, null_pct, 16)       \
+  FLUSH_PARAM(type_name, kind, num_cols, null_pct, 64)       \
+  FLUSH_PARAM(type_name, kind, num_cols, null_pct, 256)      \
+  FLUSH_PARAM(type_name, kind, num_cols, null_pct, 1024)
+
+#define FLUSH_FOR_NULLS(type_name, kind, num_cols) \
+  FLUSH_FOR_PARTS(type_name, kind, num_cols, 0)    \
+  FLUSH_FOR_PARTS(type_name, kind, num_cols, 25)   \
+  FLUSH_FOR_PARTS(type_name, kind, num_cols, 50)   \
+  FLUSH_FOR_PARTS(type_name, kind, num_cols, 75)   \
+  FLUSH_FOR_PARTS(type_name, kind, num_cols, 100)
+
+#define FLUSH_FOR_COLS(type_name, kind) \
+  FLUSH_FOR_NULLS(type_name, kind, 1)   \
+  FLUSH_FOR_NULLS(type_name, kind, 4)   \
+  FLUSH_FOR_NULLS(type_name, kind, 16)  \
+  FLUSH_FOR_NULLS(type_name, kind, 64)
+
+FLUSH_FOR_COLS(bool, BOOLEAN)
+FLUSH_FOR_COLS(int, INTEGER)
+FLUSH_FOR_COLS(bigint, BIGINT)
+FLUSH_FOR_COLS(ldec, HUGEINT)
+// clang-format on
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  PrestoVectorSerde::registerVectorSerde();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
 set(
   VELOX_SERIALIZER_TEST_SOURCES
   CompactRowSerializerTest.cpp
+  PrestoIterativePartitioningSerializerTest.cpp
   PrestoOutputStreamListenerTest.cpp
   PrestoSerializerTest.cpp
   SerializedPageFileTest.cpp
@@ -51,6 +52,7 @@ set(
   velox_row_fast
   GTest::gtest
   GTest::gtest_main
+  GTest::gmock
   glog::glog
 )
 

--- a/velox/serializers/tests/PrestoIterativePartitioningSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoIterativePartitioningSerializerTest.cpp
@@ -1,0 +1,661 @@
+/*
+ * Copyright (c) International Business Machines Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <random>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/serializers/PrestoIterativePartitioningSerializer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::serializer::presto;
+using namespace facebook::velox::test;
+
+// ---------------------------------------------------------------------------
+// Shared base fixture
+// ---------------------------------------------------------------------------
+
+class PrestoIterativePartitioningSerializerTestBase : public VectorTestBase {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    if (!isRegisteredVectorSerde()) {
+      PrestoVectorSerde::registerVectorSerde();
+    }
+  }
+
+  /// Deserializes an IOBuf produced by PartitioningSerializer::flush().
+  RowVectorPtr deserialize(folly::IOBuf& iobuf, const RowTypePtr& type) {
+    auto ranges = byteRangesFromIOBuf(&iobuf);
+    BufferInputStream stream(std::move(ranges));
+    RowVectorPtr result;
+    serde_.deserialize(&stream, pool_.get(), type, &result, nullptr);
+    return result;
+  }
+
+  /// Extracts flat values from a column into a sorted vector.
+  template <typename T>
+  std::vector<T> sortedValues(const RowVectorPtr& row, int column) {
+    auto* flat = row->childAt(column)->as<FlatVector<T>>();
+    std::vector<T> vals(flat->rawValues(), flat->rawValues() + row->size());
+    std::sort(vals.begin(), vals.end());
+    return vals;
+  }
+
+  /// Extracts values from a nullable column, preserving order and nulls.
+  template <typename T>
+  std::vector<std::optional<T>> nullableValues(
+      const RowVectorPtr& row,
+      int column) {
+    auto* vec = row->childAt(column).get();
+    std::vector<std::optional<T>> result;
+    result.reserve(row->size());
+    for (int i = 0; i < row->size(); ++i) {
+      if (vec->isNullAt(i)) {
+        result.push_back(std::nullopt);
+      } else {
+        result.push_back(vec->as<FlatVector<T>>()->valueAt(i));
+      }
+    }
+    return result;
+  }
+
+  /// Builds a PrestoIterativePartitioningSerializer with default serde options.
+  std::unique_ptr<PrestoIterativePartitioningSerializer> makeSerializer(
+      const RowTypePtr& type,
+      uint32_t numPartitions) {
+    SerdeOpts opts;
+    return std::make_unique<PrestoIterativePartitioningSerializer>(
+        type, numPartitions, opts, pool_.get());
+  }
+
+  PrestoVectorSerde serde_;
+};
+
+// ---------------------------------------------------------------------------
+// Value-parameterized fixture — routing, null-handling over scalar TypePtrs.
+// Uses BaseVector::create() + setNull() so no C++ type dispatch is needed.
+// ---------------------------------------------------------------------------
+
+class PrestoIterativePartitioningSerializerParamTest
+    : public ::testing::TestWithParam<TypePtr>,
+      public PrestoIterativePartitioningSerializerTestBase {
+ public:
+  static void SetUpTestSuite() {
+    PrestoIterativePartitioningSerializerTestBase::SetUpTestSuite();
+  }
+};
+
+// Short lowercase names for test output, matching the benchmark convention.
+std::string scalarTypeName(const TypePtr& type) {
+  if (type->kind() == TypeKind::BOOLEAN)
+    return "bool";
+  if (type->kind() == TypeKind::INTEGER)
+    return "int";
+  if (type->kind() == TypeKind::BIGINT)
+    return "bigint";
+  if (type->kind() == TypeKind::HUGEINT)
+    return "hugeint";
+  return type->toString();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ScalarTypes,
+    PrestoIterativePartitioningSerializerParamTest,
+    ::testing::Values(BOOLEAN(), INTEGER(), BIGINT(), HUGEINT()),
+    [](const ::testing::TestParamInfo<TypePtr>& info) {
+      return scalarTypeName(info.param);
+    });
+
+// ── Routing ──────────────────────────────────────────────────────────────────
+
+// Single append, two equal-sized partitions; also verifies rowsBuffered and
+// bytesBuffered lifecycle counters.
+TEST_P(PrestoIterativePartitioningSerializerParamTest, basicTwoPartitions) {
+  auto colType = GetParam();
+  auto type = ROW({"a"}, {colType});
+  auto col = BaseVector::create(colType, 6, pool_.get());
+  auto input = makeRowVector({"a"}, {col});
+
+  // Even rows → partition 0, odd rows → partition 1.
+  auto serializer = makeSerializer(type, 2);
+  serializer->append(input, {0, 1, 0, 1, 0, 1});
+
+  EXPECT_EQ(serializer->rowsBuffered(), 6);
+
+  auto ioBufs = serializer->flush();
+  ASSERT_EQ(ioBufs.size(), 2);
+
+  EXPECT_EQ(serializer->rowsBuffered(), 0);
+  EXPECT_EQ(serializer->bytesBuffered(), 0);
+
+  auto p0 = deserialize(*ioBufs.at(0).first, type);
+  auto p1 = deserialize(*ioBufs.at(1).first, type);
+
+  EXPECT_EQ(p0->size(), 3);
+  EXPECT_EQ(p1->size(), 3);
+}
+
+// All rows routed to one non-zero partition; other partitions are absent.
+TEST_P(PrestoIterativePartitioningSerializerParamTest, allRowsToOnePartition) {
+  auto colType = GetParam();
+  auto type = ROW({"x"}, {colType});
+  auto col = BaseVector::create(colType, 5, pool_.get());
+  auto input = makeRowVector({"x"}, {col});
+
+  auto serializer = makeSerializer(type, 4);
+  serializer->append(input, {2, 2, 2, 2, 2});
+  auto ioBufs = serializer->flush();
+
+  ASSERT_EQ(ioBufs.size(), 1);
+  ASSERT_TRUE(ioBufs.count(2));
+  EXPECT_EQ(deserialize(*ioBufs.at(2).first, type)->size(), 5);
+}
+
+// Single partition (numPartitions=1): all rows go to partition 0.
+TEST_P(PrestoIterativePartitioningSerializerParamTest, singlePartition) {
+  auto colType = GetParam();
+  auto type = ROW({"a"}, {colType});
+  auto col = BaseVector::create(colType, 5, pool_.get());
+  auto input = makeRowVector({"a"}, {col});
+
+  auto serializer = makeSerializer(type, 1);
+  serializer->append(input, std::vector<uint32_t>(5, 0));
+  auto ioBufs = serializer->flush();
+
+  ASSERT_EQ(ioBufs.size(), 1);
+  EXPECT_EQ(deserialize(*ioBufs.at(0).first, type)->size(), 5);
+}
+
+// Multiple columns of the same type: each is serialized independently by
+// flushRowChildren.
+TEST_P(PrestoIterativePartitioningSerializerParamTest, multipleColumns) {
+  auto colType = GetParam();
+  auto type = ROW({"a", "b"}, {colType, colType});
+  auto colA = BaseVector::create(colType, 4, pool_.get());
+  auto colB = BaseVector::create(colType, 4, pool_.get());
+  auto input = makeRowVector({"a", "b"}, {colA, colB});
+
+  auto serializer = makeSerializer(type, 2);
+  serializer->append(input, {0, 0, 1, 1});
+  auto ioBufs = serializer->flush();
+
+  ASSERT_EQ(ioBufs.size(), 2);
+
+  auto r0 = deserialize(*ioBufs.at(0).first, type);
+  EXPECT_EQ(r0->size(), 2);
+  EXPECT_EQ(r0->childAt(0)->size(), 2);
+  EXPECT_EQ(r0->childAt(1)->size(), 2);
+
+  auto r1 = deserialize(*ioBufs.at(1).first, type);
+  EXPECT_EQ(r1->size(), 2);
+  EXPECT_EQ(r1->childAt(0)->size(), 2);
+  EXPECT_EQ(r1->childAt(1)->size(), 2);
+}
+
+// ── Null handling
+// ─────────────────────────────────────────────────────────────
+
+// Nulls appear only in one partition; the other partition is null-free.
+// Rows 0,1,2 → p0; rows 3,4 → p1. Row 1 is null.
+// p0: [not-null, null, not-null]; p1: [not-null, not-null].
+TEST_P(PrestoIterativePartitioningSerializerParamTest, nullsInOnePartition) {
+  auto colType = GetParam();
+  auto type = ROW({"a"}, {colType});
+  auto col = BaseVector::create(colType, 5, pool_.get());
+  col->setNull(1, true);
+  auto input = makeRowVector({"a"}, {col});
+
+  auto serializer = makeSerializer(type, 2);
+  serializer->append(input, {0, 0, 0, 1, 1});
+  auto ioBufs = serializer->flush();
+
+  ASSERT_EQ(ioBufs.size(), 2);
+
+  auto r0 = deserialize(*ioBufs.at(0).first, type);
+  ASSERT_EQ(r0->size(), 3);
+  EXPECT_FALSE(r0->childAt(0)->isNullAt(0));
+  EXPECT_TRUE(r0->childAt(0)->isNullAt(1));
+  EXPECT_FALSE(r0->childAt(0)->isNullAt(2));
+
+  auto r1 = deserialize(*ioBufs.at(1).first, type);
+  ASSERT_EQ(r1->size(), 2);
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(0));
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(1));
+}
+
+// Nulls contributed by different appends to the same partition.
+// Append 1: rows 0,1 → p0 (row 1 null); row 2 → p1.
+// Append 2: row 0 → p0 (null); row 1 → p1.
+// p0: [not-null, null, null]; p1: [not-null, not-null].
+TEST_P(
+    PrestoIterativePartitioningSerializerParamTest,
+    nullsAcrossMultipleAppends) {
+  auto colType = GetParam();
+  auto type = ROW({"a"}, {colType});
+  auto serializer = makeSerializer(type, 2);
+
+  auto col1 = BaseVector::create(colType, 3, pool_.get());
+  col1->setNull(1, true);
+  serializer->append(makeRowVector({"a"}, {col1}), {0, 0, 1});
+
+  auto col2 = BaseVector::create(colType, 2, pool_.get());
+  col2->setNull(0, true);
+  serializer->append(makeRowVector({"a"}, {col2}), {0, 1});
+
+  auto ioBufs = serializer->flush();
+  ASSERT_EQ(ioBufs.size(), 2);
+
+  auto r0 = deserialize(*ioBufs.at(0).first, type);
+  ASSERT_EQ(r0->size(), 3);
+  EXPECT_FALSE(r0->childAt(0)->isNullAt(0));
+  EXPECT_TRUE(r0->childAt(0)->isNullAt(1));
+  EXPECT_TRUE(r0->childAt(0)->isNullAt(2));
+
+  auto r1 = deserialize(*ioBufs.at(1).first, type);
+  ASSERT_EQ(r1->size(), 2);
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(0));
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(1));
+}
+
+// Partition boundary falls in the middle of a null-bitmap byte, exercising the
+// bit-extraction carry-over logic. 5 rows → p0, 4 rows → p1. The boundary at
+// bit 5 is inside the first byte of the null bitmap. Rows 1,3,5,7 are null.
+// p0: [not-null, null, not-null, null, not-null].
+// p1: [null, not-null, null, not-null].
+TEST_P(PrestoIterativePartitioningSerializerParamTest, nullsUnalignedBoundary) {
+  auto colType = GetParam();
+  auto type = ROW({"a"}, {colType});
+  auto col = BaseVector::create(colType, 9, pool_.get());
+  col->setNull(1, true);
+  col->setNull(3, true);
+  col->setNull(5, true);
+  col->setNull(7, true);
+  auto input = makeRowVector({"a"}, {col});
+
+  auto serializer = makeSerializer(type, 2);
+  serializer->append(input, {0, 0, 0, 0, 0, 1, 1, 1, 1});
+  auto ioBufs = serializer->flush();
+
+  ASSERT_EQ(ioBufs.size(), 2);
+
+  auto r0 = deserialize(*ioBufs.at(0).first, type);
+  ASSERT_EQ(r0->size(), 5);
+  EXPECT_FALSE(r0->childAt(0)->isNullAt(0));
+  EXPECT_TRUE(r0->childAt(0)->isNullAt(1));
+  EXPECT_FALSE(r0->childAt(0)->isNullAt(2));
+  EXPECT_TRUE(r0->childAt(0)->isNullAt(3));
+  EXPECT_FALSE(r0->childAt(0)->isNullAt(4));
+
+  auto r1 = deserialize(*ioBufs.at(1).first, type);
+  ASSERT_EQ(r1->size(), 4);
+  EXPECT_TRUE(r1->childAt(0)->isNullAt(0));
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(1));
+  EXPECT_TRUE(r1->childAt(0)->isNullAt(2));
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(3));
+}
+
+// Both partitions contain nulls.
+// Input: 4 rows, rows 1 and 2 null; rows 0,1 → p0; rows 2,3 → p1.
+// p0: [not-null, null]; p1: [null, not-null].
+TEST_P(PrestoIterativePartitioningSerializerParamTest, nullsInBothPartitions) {
+  auto colType = GetParam();
+  auto type = ROW({"a"}, {colType});
+  auto col = BaseVector::create(colType, 4, pool_.get());
+  col->setNull(1, true);
+  col->setNull(2, true);
+  auto input = makeRowVector({"a"}, {col});
+
+  auto serializer = makeSerializer(type, 2);
+  serializer->append(input, {0, 0, 1, 1});
+  auto ioBufs = serializer->flush();
+
+  ASSERT_EQ(ioBufs.size(), 2);
+
+  auto r0 = deserialize(*ioBufs.at(0).first, type);
+  ASSERT_EQ(r0->size(), 2);
+  EXPECT_FALSE(r0->childAt(0)->isNullAt(0));
+  EXPECT_TRUE(r0->childAt(0)->isNullAt(1));
+
+  auto r1 = deserialize(*ioBufs.at(1).first, type);
+  ASSERT_EQ(r1->size(), 2);
+  EXPECT_TRUE(r1->childAt(0)->isNullAt(0));
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(1));
+}
+
+// All rows in one partition are null; the other partition is non-null.
+// Input: 3 rows, rows 0,1 null; rows 0,1 → p0; row 2 → p1.
+TEST_P(PrestoIterativePartitioningSerializerParamTest, allNullsInPartition) {
+  auto colType = GetParam();
+  auto type = ROW({"a"}, {colType});
+  auto col = BaseVector::create(colType, 3, pool_.get());
+  col->setNull(0, true);
+  col->setNull(1, true);
+  auto input = makeRowVector({"a"}, {col});
+
+  auto serializer = makeSerializer(type, 2);
+  serializer->append(input, {0, 0, 1});
+  auto ioBufs = serializer->flush();
+
+  ASSERT_EQ(ioBufs.size(), 2);
+
+  auto r0 = deserialize(*ioBufs.at(0).first, type);
+  ASSERT_EQ(r0->size(), 2);
+  EXPECT_TRUE(r0->childAt(0)->isNullAt(0));
+  EXPECT_TRUE(r0->childAt(0)->isNullAt(1));
+
+  auto r1 = deserialize(*ioBufs.at(1).first, type);
+  ASSERT_EQ(r1->size(), 1);
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(0));
+}
+
+// A null batch followed by a null-free batch for the same partition.
+// Regression: bitmaps must be initialized to all-not-null so that rows from
+// the null-free batch (rawNulls == nullptr) are not decoded as null.
+TEST_P(
+    PrestoIterativePartitioningSerializerParamTest,
+    nullBatchFollowedByNullFreeBatch) {
+  auto colType = GetParam();
+  auto type = ROW({"a"}, {colType});
+  auto serializer = makeSerializer(type, 2);
+
+  // Append 1: row 0 → p0 (null); row 1 → p1 (not-null).  rawNulls non-null.
+  auto col1 = BaseVector::create(colType, 2, pool_.get());
+  col1->setNull(0, true);
+  serializer->append(makeRowVector({"a"}, {col1}), {0, 1});
+
+  // Append 2: all not-null (rawNulls == nullptr).  row 0 → p0; row 1 → p1.
+  auto col2 = BaseVector::create(colType, 2, pool_.get());
+  serializer->append(makeRowVector({"a"}, {col2}), {0, 1});
+
+  auto ioBufs = serializer->flush();
+  ASSERT_EQ(ioBufs.size(), 2);
+
+  // p0: [null (append 1), not-null (append 2)]
+  auto r0 = deserialize(*ioBufs.at(0).first, type);
+  ASSERT_EQ(r0->size(), 2);
+  EXPECT_TRUE(r0->childAt(0)->isNullAt(0));
+  EXPECT_FALSE(r0->childAt(0)->isNullAt(1));
+
+  // p1: [not-null (append 1), not-null (append 2)]
+  auto r1 = deserialize(*ioBufs.at(1).first, type);
+  ASSERT_EQ(r1->size(), 2);
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(0));
+  EXPECT_FALSE(r1->childAt(0)->isNullAt(1));
+}
+
+// ---------------------------------------------------------------------------
+// Non-typed fixture (TEST_F) — lifecycle, structural, regression
+// ---------------------------------------------------------------------------
+
+class PrestoIterativePartitioningSerializerTest
+    : public ::testing::Test,
+      public PrestoIterativePartitioningSerializerTestBase {
+ public:
+  static void SetUpTestSuite() {
+    PrestoIterativePartitioningSerializerTestBase::SetUpTestSuite();
+  }
+};
+
+// Appending an empty RowVector produces no ioBufs on flush.
+TEST_F(PrestoIterativePartitioningSerializerTest, appendEmptyVector) {
+  auto type = ROW({"a"}, {BIGINT()});
+  auto serializer = makeSerializer(type, 2);
+  serializer->append(makeRowVector({"a"}, {makeFlatVector<int64_t>({})}), {});
+  EXPECT_TRUE(serializer->flush().empty());
+}
+
+// ── Lifecycle
+// ─────────────────────────────────────────────────────────────────
+
+// Multiple append() calls accumulate correctly before flush.
+TEST_F(PrestoIterativePartitioningSerializerTest, multipleAppends) {
+  auto type = ROW({"v"}, {BIGINT()});
+  auto serializer = makeSerializer(type, 3);
+
+  serializer->append(
+      makeRowVector({"v"}, {makeFlatVector<int64_t>({100, 200, 300})}),
+      {0, 1, 2});
+  serializer->append(
+      makeRowVector({"v"}, {makeFlatVector<int64_t>({400, 500, 600})}),
+      {2, 0, 1});
+
+  EXPECT_EQ(serializer->rowsBuffered(), 6);
+
+  auto ioBufs = serializer->flush();
+  ASSERT_EQ(ioBufs.size(), 3);
+
+  auto r0 = deserialize(*ioBufs.at(0).first, type);
+  auto r1 = deserialize(*ioBufs.at(1).first, type);
+  auto r2 = deserialize(*ioBufs.at(2).first, type);
+
+  ASSERT_EQ(r0->size(), 2);
+  ASSERT_EQ(r1->size(), 2);
+  ASSERT_EQ(r2->size(), 2);
+
+  EXPECT_EQ(sortedValues<int64_t>(r0, 0), (std::vector<int64_t>{100, 500}));
+  EXPECT_EQ(sortedValues<int64_t>(r1, 0), (std::vector<int64_t>{200, 600}));
+  EXPECT_EQ(sortedValues<int64_t>(r2, 0), (std::vector<int64_t>{300, 400}));
+}
+
+// Flush twice: second flush on empty state returns an empty map.
+TEST_F(PrestoIterativePartitioningSerializerTest, flushTwice) {
+  auto type = ROW({"a"}, {BIGINT()});
+  auto serializer = makeSerializer(type, 2);
+  serializer->append(
+      makeRowVector({"a"}, {makeFlatVector<int64_t>({10, 20})}), {0, 1});
+
+  auto ioBufs1 = serializer->flush();
+  ASSERT_EQ(ioBufs1.size(), 2);
+
+  EXPECT_TRUE(serializer->flush().empty());
+}
+
+// Append and flush multiple independent cycles.
+TEST_F(PrestoIterativePartitioningSerializerTest, multipleCycles) {
+  auto type = ROW({"a"}, {INTEGER()});
+  auto serializer = makeSerializer(type, 2);
+
+  for (int cycle = 0; cycle < 3; ++cycle) {
+    serializer->append(
+        makeRowVector(
+            {"a"}, {makeFlatVector<int32_t>({cycle * 2, cycle * 2 + 1})}),
+        {0, 1});
+    auto ioBufs = serializer->flush();
+    ASSERT_EQ(ioBufs.size(), 2) << "cycle " << cycle;
+
+    auto r0 = deserialize(*ioBufs.at(0).first, type);
+    auto r1 = deserialize(*ioBufs.at(1).first, type);
+    ASSERT_EQ(r0->size(), 1) << "cycle " << cycle;
+    ASSERT_EQ(r1->size(), 1) << "cycle " << cycle;
+    EXPECT_EQ(r0->childAt(0)->as<FlatVector<int32_t>>()->valueAt(0), cycle * 2);
+    EXPECT_EQ(
+        r1->childAt(0)->as<FlatVector<int32_t>>()->valueAt(0), cycle * 2 + 1);
+  }
+}
+
+// ── Scale and regression
+// ───────────────────────────────────────────────────────
+
+// 1024 partitions with random int64 values: verify every value reaches
+// exactly the right partition and nothing is lost or duplicated.
+TEST_F(PrestoIterativePartitioningSerializerTest, manyPartitionsRandom) {
+  constexpr uint32_t kNumPartitions = 1024;
+  constexpr int32_t kNumRows = 64'000;
+
+  std::mt19937_64 rng(42);
+  std::uniform_int_distribution<int64_t> valueDist;
+  std::uniform_int_distribution<uint32_t> partDist(0, kNumPartitions - 1);
+
+  std::vector<int64_t> inputValues(kNumRows);
+  std::vector<uint32_t> partitions(kNumRows);
+  // expected[p] holds the sorted values assigned to partition p.
+  std::vector<std::vector<int64_t>> expected(kNumPartitions);
+
+  for (int i = 0; i < kNumRows; ++i) {
+    inputValues[i] = valueDist(rng);
+    partitions[i] = partDist(rng);
+    expected[partitions[i]].push_back(inputValues[i]);
+  }
+  for (auto& v : expected) {
+    std::sort(v.begin(), v.end());
+  }
+
+  auto type = ROW({"v"}, {BIGINT()});
+  auto input = makeRowVector({"v"}, {makeFlatVector<int64_t>(inputValues)});
+
+  auto serializer = makeSerializer(type, kNumPartitions);
+  serializer->append(input, partitions);
+  auto ioBufs = serializer->flush();
+
+  // Every non-empty partition must have a page; empty partitions must not.
+  for (uint32_t p = 0; p < kNumPartitions; ++p) {
+    if (expected[p].empty()) {
+      EXPECT_EQ(ioBufs.count(p), 0) << "partition " << p;
+    } else {
+      ASSERT_EQ(ioBufs.count(p), 1) << "partition " << p;
+      auto result = deserialize(*ioBufs.at(p).first, type);
+      ASSERT_EQ(result->size(), static_cast<int32_t>(expected[p].size()))
+          << "partition " << p;
+      EXPECT_EQ(sortedValues<int64_t>(result, 0), expected[p])
+          << "partition " << p;
+    }
+  }
+}
+
+// 1024 partitions with random int64 values and ~25% nulls: verify every
+// value and null reaches exactly the right partition in input order, and
+// nothing is lost or duplicated.
+TEST_F(
+    PrestoIterativePartitioningSerializerTest,
+    manyPartitionsRandomWithNulls) {
+  constexpr uint32_t kNumPartitions = 1024;
+  constexpr int32_t kNumRows = 64'000;
+  constexpr int32_t kNullPct = 25;
+
+  std::mt19937_64 rng(43);
+  std::uniform_int_distribution<int64_t> valueDist;
+  std::uniform_int_distribution<uint32_t> partDist(0, kNumPartitions - 1);
+  std::uniform_int_distribution<int32_t> nullDist(0, 99);
+
+  std::vector<std::optional<int64_t>> inputValues(kNumRows);
+  std::vector<uint32_t> partitions(kNumRows);
+  // expected[p] holds the sequence of (value-or-null) assigned to partition p
+  // in input order.
+  std::vector<std::vector<std::optional<int64_t>>> expected(kNumPartitions);
+
+  for (int i = 0; i < kNumRows; ++i) {
+    partitions[i] = partDist(rng);
+    if (nullDist(rng) < kNullPct) {
+      inputValues[i] = std::nullopt;
+    } else {
+      inputValues[i] = valueDist(rng);
+    }
+    expected[partitions[i]].push_back(inputValues[i]);
+  }
+
+  auto type = ROW({"v"}, {BIGINT()});
+  auto input =
+      makeRowVector({"v"}, {makeNullableFlatVector<int64_t>(inputValues)});
+
+  auto serializer = makeSerializer(type, kNumPartitions);
+  serializer->append(input, partitions);
+  auto ioBufs = serializer->flush();
+
+  // Partition rearranges values within each partition, so compare sorted.
+  // std::optional<T> sorts with nullopt < any value, preserving null count.
+  for (uint32_t p = 0; p < kNumPartitions; ++p) {
+    if (expected[p].empty()) {
+      EXPECT_EQ(ioBufs.count(p), 0) << "partition " << p;
+    } else {
+      ASSERT_EQ(ioBufs.count(p), 1) << "partition " << p;
+      auto result = deserialize(*ioBufs.at(p).first, type);
+      ASSERT_EQ(result->size(), static_cast<int32_t>(expected[p].size()))
+          << "partition " << p;
+
+      auto expectedSorted = expected[p];
+      std::sort(expectedSorted.begin(), expectedSorted.end());
+
+      auto actual = nullableValues<int64_t>(result, 0);
+      std::sort(actual.begin(), actual.end());
+
+      EXPECT_EQ(actual, expectedSorted) << "partition " << p;
+    }
+  }
+}
+
+// Regression: flushNulls previously wrote null bitmaps by obtaining a raw
+// pointer via writePosition() then advancing the stream via seekp(). This
+// assumed the pre-allocated IOBufOutputStream had a single contiguous range,
+// but StreamArena::newRange caps each range at the size of one allocator run,
+// which can be smaller than the requested size. seekp() then failed because
+// the target position exceeded the end of the first (and only) range.
+//
+// Reproducing condition: 16 columns × 10'000 rows × 50% nulls in one
+// partition generates enough output (~100 KB) to trigger the run-size cap.
+TEST_F(
+    PrestoIterativePartitioningSerializerTest,
+    flushNullsBitmapManyColumnsLargeRowCount) {
+  constexpr int32_t kNumCols = 16;
+  constexpr int32_t kNumRows = 10'000;
+
+  std::vector<std::string> names;
+  std::vector<VectorPtr> children;
+  names.reserve(kNumCols);
+  children.reserve(kNumCols);
+
+  for (int col = 0; col < kNumCols; ++col) {
+    names.push_back(fmt::format("c{}", col));
+    // Rows where (row % 2 == 0) are null; the rest hold (row * kNumCols + col).
+    children.push_back(
+        makeFlatVector<int64_t>(
+            kNumRows,
+            [col](auto row) {
+              return static_cast<int64_t>(row * kNumCols + col);
+            },
+            [](auto row) { return (row % 2) == 0; }));
+  }
+
+  auto input = makeRowVector(names, children);
+  auto rowType = std::static_pointer_cast<const RowType>(input->type());
+
+  auto serializer = makeSerializer(rowType, 1);
+  serializer->append(input, std::vector<uint32_t>(kNumRows, 0));
+  auto ioBufs = serializer->flush();
+
+  ASSERT_EQ(ioBufs.size(), 1);
+
+  auto result = deserialize(*ioBufs.at(0).first, rowType);
+  ASSERT_EQ(result->size(), kNumRows);
+
+  for (int col = 0; col < kNumCols; ++col) {
+    auto* flat = result->childAt(col)->as<FlatVector<int64_t>>();
+    for (int row = 0; row < kNumRows; ++row) {
+      if ((row % 2) == 0) {
+        EXPECT_TRUE(result->childAt(col)->isNullAt(row))
+            << "col=" << col << " row=" << row;
+      } else {
+        ASSERT_FALSE(result->childAt(col)->isNullAt(row))
+            << "col=" << col << " row=" << row;
+        EXPECT_EQ(
+            flat->valueAt(row), static_cast<int64_t>(row * kNumCols + col))
+            << "col=" << col << " row=" << row;
+      }
+    }
+  }
+}

--- a/velox/vector/PartitionedVector.cpp
+++ b/velox/vector/PartitionedVector.cpp
@@ -214,9 +214,9 @@ PartitionedVectorPtr createPartitionedFlatVector(
   auto partitionedFlatVector = std::make_shared<PartitionedFlatVector<T>>(
       flatVector, numPartitions, endPartitionOffsets, pool);
 
-  if (numPartitions > 1) {
-    partitionedFlatVector->partition(partitions, ctx);
-  }
+  // Always call partition() so that numNullsPerPartition_ is populated,
+  // even when numPartitions == 1 and no data movement is required.
+  partitionedFlatVector->partition(partitions, ctx);
 
   return partitionedFlatVector;
 }
@@ -364,6 +364,18 @@ void PartitionedFlatVector<T>::partition(
       numPartitions_,
       ctx,
       pool_);
+
+  // Count nulls per partition from the now-partitioned null bitmap.
+  if (const uint64_t* rawNulls = vector_->rawNulls()) {
+    for (uint32_t p = 0; p < numPartitions_; ++p) {
+      const vector_size_t begin = p == 0 ? 0 : rawEndPartitionOffsets_[p - 1];
+      const vector_size_t end = rawEndPartitionOffsets_[p];
+      if (begin < end) {
+        numNullsPerPartition_[p] =
+            static_cast<vector_size_t>(bits::countNulls(rawNulls, begin, end));
+      }
+    }
+  }
 }
 
 template <typename T>
@@ -399,6 +411,18 @@ void PartitionedRowVector::partition(
     Byte* rawNulls = reinterpret_cast<Byte*>(vector_->mutableRawNulls());
     partitionBitsInPlace(
         rawNulls, partitions, numPartitions_, ctx, endPartitionOffsets_, pool_);
+  }
+
+  // Count nulls per partition from the now-partitioned null bitmap.
+  if (const uint64_t* rawNulls = vector_->rawNulls()) {
+    for (uint32_t p = 0; p < numPartitions_; ++p) {
+      const vector_size_t begin = p == 0 ? 0 : rawEndPartitionOffsets_[p - 1];
+      const vector_size_t end = rawEndPartitionOffsets_[p];
+      if (begin < end) {
+        numNullsPerPartition_[p] =
+            static_cast<vector_size_t>(bits::countNulls(rawNulls, begin, end));
+      }
+    }
   }
 }
 

--- a/velox/vector/PartitionedVector.h
+++ b/velox/vector/PartitionedVector.h
@@ -149,6 +149,12 @@ class PartitionedVector {
     return dynamic_cast<T*>(this);
   }
 
+  /// Returns the number of null rows in the given partition.
+  vector_size_t numNullsAt(uint32_t partition) const {
+    VELOX_DCHECK_LT(partition, numPartitions_);
+    return numNullsPerPartition_[partition];
+  }
+
   TypeKind typeKind() const {
     return vector_->typeKind();
   }
@@ -181,6 +187,7 @@ class PartitionedVector {
       : vector_(vector),
         numPartitions_(numPartitions),
         endPartitionOffsets_(endPartitionOffsets),
+        numNullsPerPartition_(numPartitions, 0),
         pool_(pool) {
     VELOX_CHECK_NOT_NULL(vector_);
     VELOX_CHECK_GT(numPartitions_, 0);
@@ -214,6 +221,9 @@ class PartitionedVector {
   // The raw pointer to the endPartitionOffsets_ buffer for easy access during
   // partitioning.
   vector_size_t* rawEndPartitionOffsets_;
+
+  /// Null row counts per partition, computed during partition().
+  std::vector<vector_size_t> numNullsPerPartition_;
 
   velox::memory::MemoryPool* pool_;
 };
@@ -258,6 +268,12 @@ class PartitionedRowVector : public PartitionedVector {
       PartitionBuildContext& ctx) override;
 
   VectorPtr partitionAt(uint32_t partition) const override;
+
+  /// Returns the partitioned child vector at the given column index.
+  PartitionedVectorPtr childAt(uint32_t col) const {
+    VELOX_DCHECK_LT(col, partitionedChildren_.size());
+    return partitionedChildren_[col];
+  }
 
   const vector_size_t* rawSizes() override {
     VELOX_UNREACHABLE("PartitionedRowVector does not implement rawSizes()");

--- a/velox/vector/tests/PartitionedVectorTest.cpp
+++ b/velox/vector/tests/PartitionedVectorTest.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include <algorithm>
-#include <iostream>
 #include <random>
 
 #include <gtest/gtest.h>
@@ -277,6 +276,135 @@ TEST_P(PartitioningVectorTest, noNullBufferAllocatedForNullFreeRow) {
       << "partition() must not allocate a null buffer for null-free child 0";
   EXPECT_FALSE(base->childAt(1)->mayHaveNulls())
       << "partition() must not allocate a null buffer for null-free child 1";
+}
+
+// numNullsAt() tests
+// ---------------------------------------------------------------------------
+
+// A null-free flat vector must report zero nulls for every partition.
+TEST_P(PartitioningVectorTest, numNullsAtFlatNoNulls) {
+  const int numValues = GetParam();
+  auto flat = makeFlatVector<int32_t>(numValues, [](auto row) { return row; });
+
+  std::vector<uint32_t> partitions(numValues);
+  for (int i = 0; i < numValues; ++i) {
+    partitions[i] = i % 3;
+  }
+  auto pv = PartitionedVector::create(flat, partitions, 3, ctx_, pool_.get());
+  for (uint32_t p = 0; p < 3; ++p) {
+    EXPECT_EQ(pv->numNullsAt(p), 0) << "partition " << p;
+  }
+}
+
+// A flat vector with every other row null must report the exact per-partition
+// null count. The sum across all partitions must equal the total null count.
+TEST_P(PartitioningVectorTest, numNullsAtFlatSomeNulls) {
+  const int numValues = GetParam();
+  auto flat = makeFlatVector<int32_t>(
+      numValues, [](auto row) { return row; }, nullEvery(2));
+
+  std::vector<uint32_t> partitions(numValues);
+  for (int i = 0; i < numValues; ++i) {
+    partitions[i] = i % 3;
+  }
+  auto pv = PartitionedVector::create(flat, partitions, 3, ctx_, pool_.get());
+
+  // Per-partition counts must agree with manual bit-scan of the base vector.
+  const auto* rawNulls = pv->baseVector()->rawNulls();
+  const auto* rawOffsets = pv->rawPartitionOffsets();
+  for (uint32_t p = 0; p < 3; ++p) {
+    const vector_size_t begin = p == 0 ? 0 : rawOffsets[p - 1];
+    const vector_size_t end = rawOffsets[p];
+    const vector_size_t expected = rawNulls
+        ? BaseVector::countNulls(pv->baseVector()->nulls(), begin, end)
+        : 0;
+    EXPECT_EQ(pv->numNullsAt(p), expected) << "partition " << p;
+  }
+
+  // Sum across partitions must equal the total null count in the source vector.
+  const vector_size_t total =
+      pv->numNullsAt(0) + pv->numNullsAt(1) + pv->numNullsAt(2);
+  EXPECT_EQ(total, BaseVector::countNulls(flat->nulls(), 0, numValues));
+}
+
+// An all-null flat vector must report numNullsAt(p) == rows in that partition.
+TEST_P(PartitioningVectorTest, numNullsAtFlatAllNulls) {
+  const int numValues = GetParam();
+  auto flat = makeAllNullFlatVector<int32_t>(numValues);
+
+  std::vector<uint32_t> partitions(numValues);
+  for (int i = 0; i < numValues; ++i) {
+    partitions[i] = i % 3;
+  }
+  auto pv = PartitionedVector::create(flat, partitions, 3, ctx_, pool_.get());
+
+  const auto* rawOffsets = pv->rawPartitionOffsets();
+  for (uint32_t p = 0; p < 3; ++p) {
+    const vector_size_t begin = p == 0 ? 0 : rawOffsets[p - 1];
+    const vector_size_t numRowsInPartition = rawOffsets[p] - begin;
+    EXPECT_EQ(pv->numNullsAt(p), numRowsInPartition) << "partition " << p;
+  }
+}
+
+// A row vector with no row-level nulls must report zero per-partition nulls at
+// the row level, even when child columns have nulls.
+TEST_P(PartitioningVectorTest, numNullsAtRowNoRowLevelNulls) {
+  const int numValues = GetParam();
+  auto row = makeRowVector({
+      makeFlatVector<int32_t>(
+          numValues, [](auto row) { return row; }, nullEvery(2)),
+  });
+  ASSERT_FALSE(row->mayHaveNulls());
+
+  std::vector<uint32_t> partitions(numValues);
+  for (int i = 0; i < numValues; ++i) {
+    partitions[i] = i % 3;
+  }
+  auto pv = PartitionedVector::create(row, partitions, 3, ctx_, pool_.get());
+  for (uint32_t p = 0; p < 3; ++p) {
+    EXPECT_EQ(pv->numNullsAt(p), 0)
+        << "Row-level numNullsAt() must not count child nulls, partition " << p;
+  }
+}
+
+// A row vector with row-level nulls must report per-partition counts that match
+// a manual bit-scan. Child null counts must be counted independently.
+TEST_P(PartitioningVectorTest, numNullsAtRowRowLevelNulls) {
+  const int numValues = GetParam();
+  auto row = makeRowVector(
+      {makeFlatVector<int32_t>(
+          numValues, [](auto row) { return row; }, nullEvery(3))},
+      nullEvery(2));
+
+  std::vector<uint32_t> partitions(numValues);
+  for (int i = 0; i < numValues; ++i) {
+    partitions[i] = i % 3;
+  }
+  auto pv = PartitionedVector::create(row, partitions, 3, ctx_, pool_.get());
+
+  const auto* rawOffsets = pv->rawPartitionOffsets();
+  for (uint32_t p = 0; p < 3; ++p) {
+    const vector_size_t begin = p == 0 ? 0 : rawOffsets[p - 1];
+    const vector_size_t end = rawOffsets[p];
+    const vector_size_t expected =
+        BaseVector::countNulls(pv->baseVector()->nulls(), begin, end);
+    EXPECT_EQ(pv->numNullsAt(p), expected)
+        << "Row-level null count mismatch, partition " << p;
+  }
+
+  // Child null counts must be tracked independently of row-level nulls.
+  auto* prv = dynamic_cast<PartitionedRowVector*>(pv.get());
+  ASSERT_NE(prv, nullptr);
+  auto child = prv->childAt(0);
+  const auto* childOffsets = child->rawPartitionOffsets();
+  for (uint32_t p = 0; p < 3; ++p) {
+    const vector_size_t begin = p == 0 ? 0 : childOffsets[p - 1];
+    const vector_size_t end = childOffsets[p];
+    const vector_size_t expected =
+        BaseVector::countNulls(child->baseVector()->nulls(), begin, end);
+    EXPECT_EQ(child->numNullsAt(p), expected)
+        << "Child null count mismatch, partition " << p;
+  }
 }
 
 // Test with different vector sizes, including edge cases like 0 and 1.


### PR DESCRIPTION
This commit introduces PrestoIterativePartitioningSerializer, which buffers RowVectors across
multiple append() calls, partitions rows in-place using PartitionedVector,
and on flush() serializes each non-empty partition into a Presto
wire-format IOBuf. The serializer has no dependency on velox_exec —
it returns raw folly::IOBuf objects, leaving SerializedPage creation
to the caller.