### PR TITLE
fix(PartitionedOutput): wire optimized partitioned output to OutputBu…

### DIFF
--- a/velox/exec/OptimizedPartitionedOutput.cpp
+++ b/velox/exec/OptimizedPartitionedOutput.cpp
@@ -69,7 +69,17 @@ OptimizedPartitionedOutput::OptimizedPartitionedOutput(
 
   serializer_ = std::make_unique<
       serializer::presto::PrestoIterativePartitioningSerializer>(
-      inputType_, numDestinations_, options, pool_);
+      inputType_,
+      numDestinations_,
+      options,
+      pool_,
+      [bufferManager =
+           bufferManager_]() -> std::unique_ptr<OutputStreamListener> {
+        auto lockedBufferManager = bufferManager.lock();
+        VELOX_CHECK_NOT_NULL(
+            lockedBufferManager, "OutputBufferManager was already destructed");
+        return lockedBufferManager->newListener();
+      });
 }
 
 void OptimizedPartitionedOutput::addInput(RowVectorPtr input) {

--- a/velox/serializers/PrestoIterativePartitioningSerializer.cpp
+++ b/velox/serializers/PrestoIterativePartitioningSerializer.cpp
@@ -51,9 +51,11 @@ inline void writeInt64(OutputStream* out, int64_t value) {
   out->write(reinterpret_cast<const char*>(&value), sizeof(value));
 }
 
-char getCodecMarker() {
+char getCodecMarker(bool checksumEnabled) {
   char marker = 0;
-  marker |= kCheckSumBitMask;
+  if (checksumEnabled) {
+    marker |= kCheckSumBitMask;
+  }
   return marker;
 }
 
@@ -233,11 +235,13 @@ PrestoIterativePartitioningSerializer::PrestoIterativePartitioningSerializer(
     RowTypePtr inputType,
     uint32_t numPartitions,
     const SerdeOpts& opts,
-    memory::MemoryPool* pool)
+    memory::MemoryPool* pool,
+    std::function<std::unique_ptr<OutputStreamListener>()> listenerFactory)
     : type_(std::move(inputType)),
       numPartitions_(numPartitions),
       opts_(opts),
       pool_(pool),
+      listenerFactory_(std::move(listenerFactory)),
       rowsPerPartition_(numPartitions, 0) {
   VELOX_CHECK_GT(numPartitions_, 0);
   VELOX_CHECK_NOT_NULL(pool_);
@@ -306,8 +310,6 @@ PrestoIterativePartitioningSerializer::flushUncompressed() {
     return {};
   }
 
-  const char codecMask = getCodecMarker();
-
   // 1. Determine non-empty partitions.
   std::vector<uint32_t> nonEmptyPartitions;
   for (uint32_t p = 0; p < numPartitions_; ++p) {
@@ -335,10 +337,23 @@ PrestoIterativePartitioningSerializer::flushUncompressed() {
         numPartitions_);
   }
 
-  // 3. Create output streams sized to the exact bytes each partition will need,
+  // 3. Create per-partition listeners first so the codec mask can be derived
+  // from whether the factory actually produced a listener. The factory may
+  // return nullptr (e.g. when OutputBufferManager has no listener factory
+  // set), in which case checksumming is skipped and the checksum bit must not
+  // be set in the codec byte.
+  std::vector<std::unique_ptr<OutputStreamListener>> listeners(numPartitions_);
+  for (uint32_t p : nonEmptyPartitions) {
+    if (listenerFactory_) {
+      listeners[p] = listenerFactory_();
+    }
+  }
+  const bool checksumEnabled = !nonEmptyPartitions.empty() &&
+      listeners[nonEmptyPartitions[0]] != nullptr;
+  const char codecMask = getCodecMarker(checksumEnabled);
+
+  // 4. Create output streams sized to the exact bytes each partition will need,
   // so that the entire payload fits. This avoids multiple resizing and copying.
-  std::vector<std::unique_ptr<PrestoOutputStreamListener>> listeners(
-      numPartitions_);
   std::vector<std::unique_ptr<IOBufOutputStream>> outputStreams(numPartitions_);
   std::vector<IOBufOutputStream*> rawOutputStreams(numPartitions_);
   std::vector<std::streampos> beginStreamPositions(numPartitions_);
@@ -348,7 +363,6 @@ PrestoIterativePartitioningSerializer::flushUncompressed() {
     for (uint32_t col = 0; col < rowSchema.size(); ++col) {
       initialSize += flushSizes_[col][p];
     }
-    listeners[p] = std::make_unique<PrestoOutputStreamListener>();
     outputStreams[p] = std::make_unique<IOBufOutputStream>(
         *pool_, listeners[p].get(), initialSize);
     rawOutputStreams[p] = outputStreams[p].get();
@@ -357,11 +371,11 @@ PrestoIterativePartitioningSerializer::flushUncompressed() {
     flushStart(*outputStreams[p], p, codecMask);
   }
 
-  // 4. Flush column data.
+  // 5. Flush column data.
   flushRowChildren(
       partitionedRowVectors_, rowSchema, nonEmptyPartitions, rawOutputStreams);
 
-  // 5. Finalize the page by seeking back to fill in sizes and CRC, and get the
+  // 6. Finalize the page by seeking back to fill in sizes and CRC, and get the
   // IOBuf and numOfRows from each stream.
   std::map<uint32_t, std::pair<std::unique_ptr<folly::IOBuf>, vector_size_t>>
       result;
@@ -371,7 +385,7 @@ PrestoIterativePartitioningSerializer::flushUncompressed() {
         p,
         beginStreamPositions[p],
         codecMask,
-        *listeners[p]);
+        listeners[p].get());
     result[p] =
         std::make_pair(outputStreams[p]->getIOBuf(), rowsPerPartition_[p]);
   }
@@ -438,17 +452,23 @@ void PrestoIterativePartitioningSerializer::flushFinish(
     uint32_t partition,
     std::streampos beginOffset,
     char codecMask,
-    PrestoOutputStreamListener& listener) const {
-  listener.pause();
+    OutputStreamListener* listener) const {
+  auto* prestoListener = dynamic_cast<PrestoOutputStreamListener*>(listener);
+  if (prestoListener) {
+    prestoListener->pause();
+  }
 
   const std::streampos totalSize =
       static_cast<int32_t>(out.tellp() - beginOffset);
   const std::streampos uncompressedSize = totalSize - kHeaderSize;
-  const int64_t crc = computeChecksum(
-      listener,
-      static_cast<int8_t>(codecMask),
-      static_cast<int32_t>(rowsPerPartition_[partition]),
-      uncompressedSize);
+  int64_t crc = 0;
+  if (prestoListener) {
+    crc = computeChecksum(
+        *prestoListener,
+        static_cast<int8_t>(codecMask),
+        static_cast<int32_t>(rowsPerPartition_[partition]),
+        uncompressedSize);
+  }
 
   out.seekp(beginOffset + kUncompressedSizeOffset);
   writeInt32(&out, uncompressedSize);

--- a/velox/serializers/PrestoIterativePartitioningSerializer.h
+++ b/velox/serializers/PrestoIterativePartitioningSerializer.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <vector>
@@ -38,11 +39,20 @@ using SerdeOpts = PrestoVectorSerde::PrestoOptions;
 /// internal state so the serializer can be reused for the next cycle.
 class PrestoIterativePartitioningSerializer {
  public:
+  /// Constructs the serializer. If `listenerFactory` is non-null it is called
+  /// once per non-empty partition on each flush to create an
+  /// OutputStreamListener that accumulates the CRC32 checksum; the checksum
+  /// bit is then set in the Presto page codec byte and the computed value is
+  /// written into the page header. Pass nullptr to skip checksum computation,
+  /// which matches the behavior of kNormal PartitionedOutput when
+  /// OutputBufferManager has no listener factory set.
   PrestoIterativePartitioningSerializer(
       RowTypePtr inputType,
       uint32_t numPartitions,
       const SerdeOpts& opts,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      std::function<std::unique_ptr<OutputStreamListener>()> listenerFactory =
+          nullptr);
 
   /// Routes each row in `input` to the partition indicated by `partitions`.
   /// `partitions.size()` must equal `input->size()`.
@@ -87,7 +97,7 @@ class PrestoIterativePartitioningSerializer {
       uint32_t partition,
       std::streampos beginOffset,
       char codecMask,
-      PrestoOutputStreamListener& listener) const;
+      OutputStreamListener* listener) const;
 
   void flushRowChildren(
       const std::vector<PartitionedVectorPtr>& partitionedVectors,
@@ -162,6 +172,7 @@ class PrestoIterativePartitioningSerializer {
   uint32_t numPartitions_;
   SerdeOpts opts_;
   memory::MemoryPool* pool_;
+  std::function<std::unique_ptr<OutputStreamListener>()> listenerFactory_;
 
   /// Cumulative row count per partition across all appended batches.
   std::vector<vector_size_t> rowsPerPartition_;

--- a/velox/serializers/tests/PrestoIterativePartitioningSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoIterativePartitioningSerializerTest.cpp
@@ -84,6 +84,42 @@ class PrestoIterativePartitioningSerializerTestBase : public VectorTestBase {
         type, numPartitions, opts, pool_.get());
   }
 
+  /// Builds a serializer that computes a CRC32 checksum on each flush via a
+  /// PrestoOutputStreamListener factory, matching the kOptimized path when
+  /// OutputBufferManager has a listener factory set.
+  std::unique_ptr<PrestoIterativePartitioningSerializer>
+  makeSerializerWithListener(const RowTypePtr& type, uint32_t numPartitions) {
+    SerdeOpts opts;
+    return std::make_unique<PrestoIterativePartitioningSerializer>(
+        type,
+        numPartitions,
+        opts,
+        pool_.get(),
+        []() -> std::unique_ptr<OutputStreamListener> {
+          return std::make_unique<PrestoOutputStreamListener>();
+        });
+  }
+
+  // Presto page header layout: [numRows:4][codec:1][uncompressedSize:4]
+  //                             [compressedSize:4][checksum:8]
+  static constexpr int kCodecByteOffset = 4;
+  static constexpr int kChecksumOffset = 13;
+  static constexpr int8_t kChecksumBitMask = 4;
+
+  /// Returns the codec byte from the Presto page header in `iobuf`.
+  static int8_t codecByte(const folly::IOBuf& iobuf) {
+    VELOX_CHECK_GE(iobuf.length(), kChecksumOffset + 8);
+    return reinterpret_cast<const int8_t*>(iobuf.data())[kCodecByteOffset];
+  }
+
+  /// Returns the 8-byte checksum field from the Presto page header in `iobuf`.
+  static int64_t checksumField(const folly::IOBuf& iobuf) {
+    VELOX_CHECK_GE(iobuf.length(), kChecksumOffset + 8);
+    int64_t value;
+    std::memcpy(&value, iobuf.data() + kChecksumOffset, sizeof(value));
+    return value;
+  }
+
   PrestoVectorSerde serde_;
 };
 
@@ -749,6 +785,39 @@ TEST_F(
     }
   }
 }
+
+// ── Checksum (CRC32)
+// ──────────────────────────────────────────────────────
+
+// Verify the checksum bit is set and a non-zero checksum is written when a
+// PrestoOutputStreamListener factory is provided, and that the standard
+// deserializer (which validates the checksum) accepts the page.
+TEST_P(PrestoIterativePartitioningSerializerParamTest, checksumRoundTrip) {
+  auto colType = GetParam();
+  auto type = ROW({"a"}, {colType});
+  auto col = BaseVector::create(colType, 6, pool_.get());
+  col->setNull(1, true);
+  col->setNull(4, true);
+
+  auto serializer = makeSerializerWithListener(type, 2);
+  serializer->append(makeRowVector({"a"}, {col}), {0, 1, 0, 1, 0, 1});
+  auto ioBufs = serializer->flush();
+  ASSERT_EQ(ioBufs.size(), 2);
+
+  for (auto& [partition, pageData] : ioBufs) {
+    auto& iobuf = *pageData.first;
+    EXPECT_NE(codecByte(iobuf) & kChecksumBitMask, 0)
+        << "checksum bit must be set in codec byte";
+    EXPECT_NE(checksumField(iobuf), 0) << "checksum field must be non-zero";
+    // Deserializer validates the checksum internally; throws if wrong.
+    auto result = deserialize(iobuf, type);
+    EXPECT_GT(result->size(), 0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Non-typed fixture (TEST_F) — lifecycle, structural, regression
+// ---------------------------------------------------------------------------
 
 // Regression: flushNulls previously wrote null bitmaps by obtaining a raw
 // pointer via writePosition() then advancing the stream via seekp(). This


### PR DESCRIPTION
Pass an OutputBufferManager-backed listener factory into
PrestoIterativePartitioningSerializer so the optimized path uses the same
listener source as normal PartitionedOutput. Create per-partition listeners
during flush, set the checksum bit only when a listener is present, and
compute the page checksum only for PrestoOutputStreamListener instances.
Also add tests that verify checksum headers are written and that the
serialized pages round-trip through the standard deserializer.