### PR TITLE
Add VARCHAR ↔ TIMESTAMPUTC cast support

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -26,7 +26,9 @@
 #include "velox/expression/ScopedVarSetter.h"
 #include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
+#include "velox/functions/lib/string/StringImpl.h"
 #include "velox/type/CastRegistry.h"
+#include "velox/type/TimestampConversion.h"
 #include "velox/type/Type.h"
 #include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/ComplexVector.h"
@@ -875,6 +877,9 @@ void CastExpr::applyPeeled(
             toType);
     }
   } else if (
+      fromType->kind() == TypeKind::VARCHAR && toType->isTimestampUtc()) {
+    result = applyVarcharToTimestampUtcCast(rows, context, input);
+  } else if (
       fromType->kind() == TypeKind::TIMESTAMP &&
       (toType->kind() == TypeKind::VARCHAR ||
        toType->kind() == TypeKind::VARBINARY)) {
@@ -976,6 +981,43 @@ VectorPtr CastExpr::applyTimestampToVarcharCast(
 
   // Update the exact buffer size.
   buffer->setSize(rawBuffer - buffer->asMutable<char>());
+  return result;
+}
+
+VectorPtr CastExpr::applyVarcharToTimestampUtcCast(
+    const SelectivityVector& rows,
+    exec::EvalCtx& context,
+    const BaseVector& input) {
+  VectorPtr result;
+  context.ensureWritable(rows, TIMESTAMP_UTC(), result);
+  (*result).clearNulls(rows);
+  auto* resultVector = result->asFlatVector<Timestamp>();
+  const auto& inputVector = *input.as<SimpleVector<StringView>>();
+
+  applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
+    StringView view = inputVector.valueAt(row);
+    StringView trimmed;
+    stringImpl::trimUnicodeWhiteSpace<true, true, StringView, StringView>(
+        trimmed, view);
+
+    if (trimmed.size() == 0) {
+      VELOX_USER_FAIL(
+          "Cannot cast VARCHAR '{}' to TIMESTAMP UTC. Empty string", view);
+    }
+
+    // Spark allows timezone in the input string for TIMESTAMP UTC but ignores
+    // it — use fromTimestampWithTimezoneString and discard the zone.
+    auto conversionResult = util::fromTimestampWithTimezoneString(
+        trimmed.data(), trimmed.size(), util::TimestampParseMode::kSparkCast);
+    if (conversionResult.hasError()) {
+      VELOX_USER_FAIL(
+          "Cannot cast VARCHAR '{}' to TIMESTAMP UTC. {}",
+          view,
+          conversionResult.error().message());
+    }
+    resultVector->set(row, conversionResult.value().timestamp);
+  });
+
   return result;
 }
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -877,6 +877,11 @@ void CastExpr::applyPeeled(
             toType);
     }
   } else if (
+      fromType->isTimestampUtc() &&
+      (toType->kind() == TypeKind::VARCHAR ||
+       toType->kind() == TypeKind::VARBINARY)) {
+    result = applyTimestampUtcToVarcharCast(toType, rows, context, input);
+  } else if (
       fromType->kind() == TypeKind::VARCHAR && toType->isTimestampUtc()) {
     result = applyVarcharToTimestampUtcCast(rows, context, input);
   } else if (
@@ -1018,6 +1023,43 @@ VectorPtr CastExpr::applyVarcharToTimestampUtcCast(
     resultVector->set(row, conversionResult.value().timestamp);
   });
 
+  return result;
+}
+
+static const TimestampToStringOptions kTimestampUtcToStringOptions = {
+    .precision = TimestampToStringOptions::Precision::kMicroseconds,
+    .leadingPositiveSign = true,
+    .skipTrailingZeros = true,
+    .zeroPaddingYear = true,
+    .dateTimeSeparator = ' ',
+    .timeZone = nullptr,
+};
+
+VectorPtr CastExpr::applyTimestampUtcToVarcharCast(
+    const TypePtr& toType,
+    const SelectivityVector& rows,
+    exec::EvalCtx& context,
+    const BaseVector& input) {
+  VectorPtr result;
+  context.ensureWritable(rows, toType, result);
+  (*result).clearNulls(rows);
+  auto* flatResult = result->asFlatVector<StringView>();
+  const auto& inputVector = *input.as<SimpleVector<Timestamp>>();
+
+  const uint32_t rowSize = getMaxStringLength(kTimestampUtcToStringOptions);
+  Buffer* buffer =
+      flatResult->getBufferWithSpace(rows.countSelected() * rowSize, true);
+  char* rawBuffer = buffer->asMutable<char>() + buffer->size();
+
+  applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
+    // No timezone adjustment: Timestamp represents wall-clock time.
+    const auto stringView = Timestamp::tsToStringView(
+        inputVector.valueAt(row), kTimestampUtcToStringOptions, rawBuffer);
+    flatResult->setNoCopy(row, stringView);
+    rawBuffer += stringView.size();
+  });
+
+  buffer->setSize(rawBuffer - buffer->asMutable<char>());
   return result;
 }
 

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -312,6 +312,13 @@ class CastExpr : public SpecialForm {
       exec::EvalCtx& context,
       const BaseVector& input);
 
+  /// Casts TIMESTAMP UTC to VARCHAR without session timezone adjustment.
+  VectorPtr applyTimestampUtcToVarcharCast(
+      const TypePtr& toType,
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      const BaseVector& input);
+
   // Casts basic numeric types to wider types.
   template <TypeKind ToKind, TypeKind FromKind>
   void applyNumericUpcast(

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -306,6 +306,12 @@ class CastExpr : public SpecialForm {
       exec::EvalCtx& context,
       const BaseVector& input);
 
+  /// Casts VARCHAR to TIMESTAMP UTC, ignoring any timezone in the input string.
+  VectorPtr applyVarcharToTimestampUtcCast(
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      const BaseVector& input);
+
   // Casts basic numeric types to wider types.
   template <TypeKind ToKind, TypeKind FromKind>
   void applyNumericUpcast(

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -656,6 +656,8 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
 
   bool isDate() const;
 
+  bool isTimestampUtc() const;
+
   bool containsUnknown() const;
 
   template <typename T>
@@ -1610,6 +1612,11 @@ FOLLY_ALWAYS_INLINE bool isDateName(const std::string& name) {
 FOLLY_ALWAYS_INLINE bool Type::isDate() const {
   // The pointers can be compared since DATE is a singleton.
   return this == DATE().get();
+}
+
+FOLLY_ALWAYS_INLINE bool Type::isTimestampUtc() const {
+  // The pointers can be compared since TIMESTAMP_UTC is a singleton.
+  return this == TIMESTAMP_UTC().get();
 }
 
 enum class TimePrecision : int8_t {


### PR DESCRIPTION
Add CastOperator for TimestampUtcType. Supports casting from/to VARCHAR — parsing ignores timezone in the input string and formatting skips session timezone. Registered through CustomTypeFactory under "TIMESTAMP UTC".