### PR TITLE
perf: Improve ConstantVector performance in OptimizedHashPartitionFunction

### DIFF
--- a/velox/exec/OptimizedHashPartitionFunction.cpp
+++ b/velox/exec/OptimizedHashPartitionFunction.cpp
@@ -170,6 +170,18 @@ void applyHashBitRange(
   }
 }
 
+bool allConstantKeys(
+    const RowVector& input,
+    const std::vector<std::unique_ptr<OptimizedVectorHasher>>& hashers) {
+  for (const auto& hasher : hashers) {
+    if (hasher->channel() != kConstantChannel &&
+        !input.childAt(hasher->channel())->isConstantEncoding()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace
 
 void rangeReduction(
@@ -222,6 +234,28 @@ std::optional<uint32_t> OptimizedHashPartitionFunction::partition(
 
   rows_.resize(size);
   rows_.setAll();
+
+  if (allConstantKeys(input, hashers_)) {
+    uint64_t hash{0};
+    for (auto i = 0; i < hashers_.size(); ++i) {
+      auto& hasher = hashers_[i];
+      if (hasher->channel() != kConstantChannel) {
+        hasher->decode(*input.childAt(hasher->channel()), rows_);
+        const auto hashValue = hasher->hashConstant(i > 0, hash);
+        VELOX_DCHECK(hashValue.has_value());
+        hash = hashValue.value();
+      } else {
+        hash = hasher->hashPrecomputed(i > 0, hash);
+      }
+    }
+
+    if (localExchange_) {
+      hash = localExchangeHash(hash);
+    }
+
+    return hashBitRange_.has_value() ? hashBitRange_->partition(hash)
+                                     : reduceRange(hash, numPartitions_);
+  }
 
   hashes_.resize(size);
   for (auto i = 0; i < hashers_.size(); ++i) {

--- a/velox/exec/OptimizedPartitionedOutput.cpp
+++ b/velox/exec/OptimizedPartitionedOutput.cpp
@@ -101,21 +101,15 @@ void OptimizedPartitionedOutput::addInput(RowVectorPtr input) {
     flush();
   }
 
-  const auto numRows = input->size();
-  partitions_.resize(numRows);
+  auto singlePartition = numDestinations_ == 1
+      ? std::optional<uint32_t>{0u}
+      : partitionFunction_->partition(*input, partitions_);
 
-  if (numDestinations_ == 1) {
-    std::fill(partitions_.begin(), partitions_.end(), 0u);
+  if (singlePartition.has_value()) {
+    serializer_->append(serializerInput, *singlePartition);
   } else {
-    std::optional<uint32_t> partition =
-        partitionFunction_->partition(*input, partitions_);
-    if (partition.has_value()) {
-      // All rows go to the same partition
-      std::fill(partitions_.begin(), partitions_.end(), partition.value());
-    }
+    serializer_->append(serializerInput, partitions_);
   }
-
-  serializer_->append(serializerInput, partitions_);
 
   auto lockedStats = stats_.wlock();
   ++numAppends_;

--- a/velox/exec/OptimizedVectorHasher.cpp
+++ b/velox/exec/OptimizedVectorHasher.cpp
@@ -383,6 +383,32 @@ void OptimizedVectorHasher::hashPrecomputed(
   });
 }
 
+uint64_t OptimizedVectorHasher::hashPrecomputed(bool mix, uint64_t previousHash)
+    const {
+  return mix ? bits::hashMix(previousHash, precomputedHash_) : precomputedHash_;
+}
+
+std::optional<uint64_t> OptimizedVectorHasher::hashConstant(
+    bool mix,
+    uint64_t previousHash) const {
+  if (!decoded_.isConstantMapping() || decoded_.size() == 0) {
+    return std::nullopt;
+  }
+
+  uint64_t hash;
+  if (decoded_.isNullAt(0) || typeKind_ == TypeKind::UNKNOWN) {
+    hash = kNullHash;
+  } else if (typeProvidesCustomComparison_) {
+    hash = VELOX_DYNAMIC_TEMPLATE_TYPE_DISPATCH(
+        hashOne, true, typeKind_, decoded_, 0);
+  } else {
+    hash = VELOX_DYNAMIC_TEMPLATE_TYPE_DISPATCH(
+        hashOne, false, typeKind_, decoded_, 0);
+  }
+
+  return mix ? bits::hashMix(previousHash, hash) : hash;
+}
+
 void OptimizedVectorHasher::precompute(const BaseVector& value) {
   if (value.isNullAt(0)) {
     precomputedHash_ = kNullHash;

--- a/velox/exec/OptimizedVectorHasher.h
+++ b/velox/exec/OptimizedVectorHasher.h
@@ -47,6 +47,12 @@ class OptimizedVectorHasher {
 
   void hashPrecomputed(bool mix, raw_vector<uint64_t>& result) const;
 
+  // Computes one hash from a precomputed single value.
+  uint64_t hashPrecomputed(bool mix, uint64_t previousHash) const;
+
+  // Computes one hash when the decoded vector has constant mapping.
+  std::optional<uint64_t> hashConstant(bool mix, uint64_t previousHash) const;
+
   void precompute(const BaseVector& value);
 
   static constexpr uint64_t kNullHash = BaseVector::kNullHash;

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -256,7 +256,7 @@ ExchangeInputSpec makeInputSpec(ExchangeInputKind kind) {
 
 ExchangeInputSpec makeInputSpec(SimpleColType colType, int32_t numCols) {
   return {
-      fmt::format("Simple10K_{}_col{}", simpleColTypeName(colType), numCols),
+      fmt::format("10K_{}_col{}", simpleColTypeName(colType), numCols),
       makeSimpleType(simpleColTypeToType(colType), numCols),
       10,
       10'000};
@@ -407,13 +407,27 @@ class ExchangeBenchmark : public VectorTestBase {
     }
   }
 
+  VectorPtr makeConstantColumn(
+      const TypePtr& type,
+      int32_t numRows,
+      int32_t nullPct,
+      int32_t vectorIndex) {
+    const auto baseNullPct =
+        nullPct > 0 && (vectorIndex % 100) < nullPct ? 100 : 0;
+    return BaseVector::wrapInConstant(
+        numRows, 0, makeColumn(type, 1, baseNullPct));
+  }
+
   /// Generates input batches for the exchange benchmark.
   ///
   /// `dictPct` is the percentage of vectors for each column that should be
   /// wrapped in dictionary encoding across the full set of generated batches.
+  /// `constantPct` works similarly, but creates ConstantVector columns.
+  /// Constant vectors take precedence over dictionary wrapping.
   /// For example, with `numVectors = 10` and `dictPct = 30`, each top-level
-  /// column will have 3 dictionary-encoded vectors and 7 simple vectors.
-  /// Nested children of complex columns use the same rule recursively.
+  /// column will have 3 dictionary-encoded vectors and 7 simple vectors,
+  /// unless those vectors are selected for constant encoding. Nested children
+  /// of complex columns use the same rule recursively.
   ///
   /// `nullPct` controls what fraction of values in each column are null:
   /// 0 = no nulls, 50 = half the rows null, 100 = all rows null.
@@ -422,18 +436,25 @@ class ExchangeBenchmark : public VectorTestBase {
       int32_t numVectors,
       int32_t rowsPerVector,
       int32_t dictPct = 0,
+      int32_t constantPct = 0,
       int32_t nullPct = 0) {
     std::vector<RowVectorPtr> vectors;
     vectors.reserve(numVectors);
     for (int32_t i = 0; i < numVectors; ++i) {
+      const auto useConstant = shouldWrapVector(i, numVectors, constantPct);
       std::vector<VectorPtr> children;
       children.reserve(type->size());
       for (int32_t col = 0; col < type->size(); ++col) {
-        children.push_back(
-            makeColumn(type->childAt(col), rowsPerVector, nullPct));
+        if (useConstant) {
+          children.push_back(makeConstantColumn(
+              type->childAt(col), rowsPerVector, nullPct, i));
+        } else {
+          children.push_back(
+              makeColumn(type->childAt(col), rowsPerVector, nullPct));
+        }
       }
       auto vector = makeRowVector(type->names(), children);
-      if (shouldWrapVector(i, numVectors, dictPct)) {
+      if (!useConstant && shouldWrapVector(i, numVectors, dictPct)) {
         for (auto child = 0; child < vector->childrenSize(); ++child) {
           wrapDictionaryRecursive(vector->childAt(child));
         }
@@ -616,18 +637,25 @@ void benchmarkExchange(
     int32_t numDestinations,
     ExchangeMode mode,
     int32_t dictPct,
+    int32_t constantPct,
     int32_t nullPct) {
   auto vectors = bm->makeRows(
-      input.type, input.numVectors, input.rowsPerVector, dictPct, nullPct);
+      input.type,
+      input.numVectors,
+      input.rowsPerVector,
+      dictPct,
+      constantPct,
+      nullPct);
   auto stats = runBenchmarkIterations(iters, [&]() {
     return bm->run(vectors, numDestinations, FLAGS_task_width, mode);
   });
   benchmarkResults.push_back(
       {fmt::format(
-           "{}_p{}_dict{}_null{}",
+           "{}_p{}_d{}_c{}_n{}",
            input.name,
            numDestinations,
            dictPct,
+           constantPct,
            nullPct),
        mode,
        std::move(stats)});
@@ -656,141 +684,315 @@ void benchmarkExchange(
     name(iters, ##__VA_ARGS__);                                        \
   }
 
-// ── Benchmarks: input spec × p (numDestinations) × nullPct × mode ─────────
+// ── Benchmarks: input spec × p (numDestinations) × dictPct × constantPct ×
+// nullPct × mode ─
 
-#define EXCHANGE_BENCHMARK_INPUT(                                                           \
-    _case_name,                                                                             \
-    _input_expr,                                                                            \
-    _num_destinations,                                                                      \
-    _mode_name,                                                                             \
-    _dict_pct,                                                                              \
-    _null_pct,                                                                              \
-    _mode)                                                                                  \
-  EXCHANGE_BENCHMARK_NAMED_PARAM(                                                           \
-      benchmarkExchange,                                                                    \
-      _case_name##_p##_num_destinations##_dict##_dict_pct##_null##_null_pct##_##_mode_name, \
-      _input_expr,                                                                          \
-      _num_destinations,                                                                    \
-      ExchangeMode::_mode,                                                                  \
-      _dict_pct,                                                                            \
+#define EXCHANGE_BENCHMARK_INPUT_IMPL(                                                                   \
+    _register,                                                                                           \
+    _case_name,                                                                                          \
+    _input_expr,                                                                                         \
+    _num_destinations,                                                                                   \
+    _mode_name,                                                                                          \
+    _dict_pct,                                                                                           \
+    _constant_pct,                                                                                       \
+    _null_pct,                                                                                           \
+    _mode)                                                                                               \
+  _register(                                                                                             \
+      benchmarkExchange,                                                                                 \
+      _case_name##_p##_num_destinations##_d##_dict_pct##_c##_constant_pct##_n##_null_pct##_##_mode_name, \
+      _input_expr,                                                                                       \
+      _num_destinations,                                                                                 \
+      ExchangeMode::_mode,                                                                               \
+      _dict_pct,                                                                                         \
+      _constant_pct,                                                                                     \
       _null_pct)
 
-#define EXCHANGE_BENCHMARK_INPUT_RELATIVE(                                                  \
-    _case_name,                                                                             \
-    _input_expr,                                                                            \
-    _num_destinations,                                                                      \
-    _mode_name,                                                                             \
-    _dict_pct,                                                                              \
-    _null_pct,                                                                              \
-    _mode)                                                                                  \
-  EXCHANGE_BENCHMARK_NAMED_PARAM_RELATIVE(                                                  \
-      benchmarkExchange,                                                                    \
-      _case_name##_p##_num_destinations##_dict##_dict_pct##_null##_null_pct##_##_mode_name, \
-      _input_expr,                                                                          \
-      _num_destinations,                                                                    \
-      ExchangeMode::_mode,                                                                  \
-      _dict_pct,                                                                            \
-      _null_pct)
+#define EXCHANGE_BENCHMARK_INPUT(     \
+    _case_name,                       \
+    _input_expr,                      \
+    _num_destinations,                \
+    _mode_name,                       \
+    _dict_pct,                        \
+    _constant_pct,                    \
+    _null_pct,                        \
+    _mode)                            \
+  EXCHANGE_BENCHMARK_INPUT_IMPL(      \
+      EXCHANGE_BENCHMARK_NAMED_PARAM, \
+      _case_name,                     \
+      _input_expr,                    \
+      _num_destinations,              \
+      _mode_name,                     \
+      _dict_pct,                      \
+      _constant_pct,                  \
+      _null_pct,                      \
+      _mode)
+
+#define EXCHANGE_BENCHMARK_RELATIVE_INPUT(     \
+    _case_name,                                \
+    _input_expr,                               \
+    _num_destinations,                         \
+    _mode_name,                                \
+    _dict_pct,                                 \
+    _constant_pct,                             \
+    _null_pct,                                 \
+    _mode)                                     \
+  EXCHANGE_BENCHMARK_INPUT_IMPL(               \
+      EXCHANGE_BENCHMARK_NAMED_PARAM_RELATIVE, \
+      _case_name,                              \
+      _input_expr,                             \
+      _num_destinations,                       \
+      _mode_name,                              \
+      _dict_pct,                               \
+      _constant_pct,                           \
+      _null_pct,                               \
+      _mode)
 
 // `normal` is the baseline (regular BENCHMARK); `optimized` is reported
 // relative to it via the "%" prefix folly recognizes, so the "relative"
 // column in the output shows optimized's speedup over normal.
-#define EXCHANGE_BENCHMARK_MODES(                                     \
-    _case_name, _input_expr, _num_destinations, _dict_pct, _null_pct) \
-  EXCHANGE_BENCHMARK_INPUT(                                           \
-      _case_name,                                                     \
-      _input_expr,                                                    \
-      _num_destinations,                                              \
-      normal,                                                         \
-      _dict_pct,                                                      \
-      _null_pct,                                                      \
-      kNormal);                                                       \
-  EXCHANGE_BENCHMARK_INPUT_RELATIVE(                                  \
-      _case_name,                                                     \
-      _input_expr,                                                    \
-      _num_destinations,                                              \
-      optimized,                                                      \
-      _dict_pct,                                                      \
-      _null_pct,                                                      \
+#define EXCHANGE_BENCHMARK_MODES(    \
+    _case_name,                      \
+    _input_expr,                     \
+    _num_destinations,               \
+    _dict_pct,                       \
+    _constant_pct,                   \
+    _null_pct)                       \
+  EXCHANGE_BENCHMARK_INPUT(          \
+      _case_name,                    \
+      _input_expr,                   \
+      _num_destinations,             \
+      normal,                        \
+      _dict_pct,                     \
+      _constant_pct,                 \
+      _null_pct,                     \
+      kNormal);                      \
+  EXCHANGE_BENCHMARK_RELATIVE_INPUT( \
+      _case_name,                    \
+      _input_expr,                   \
+      _num_destinations,             \
+      optimized,                     \
+      _dict_pct,                     \
+      _constant_pct,                 \
+      _null_pct,                     \
       kOptimized)
 
-#define EXCHANGE_BENCHMARK_NULLS(_case_name, _input_expr, _num_destinations)   \
-  EXCHANGE_BENCHMARK_MODES(_case_name, _input_expr, _num_destinations, 0, 0);  \
-  EXCHANGE_BENCHMARK_MODES(_case_name, _input_expr, _num_destinations, 0, 50); \
-  EXCHANGE_BENCHMARK_MODES(_case_name, _input_expr, _num_destinations, 0, 100)
+#define EXCHANGE_BENCHMARK_DESTINATIONS(                                  \
+    _case_name, _input_expr, _dict_pct, _constant_pct, _null_pct)         \
+  EXCHANGE_BENCHMARK_MODES(                                               \
+      _case_name, _input_expr, 1, _dict_pct, _constant_pct, _null_pct);   \
+  EXCHANGE_BENCHMARK_MODES(                                               \
+      _case_name, _input_expr, 4, _dict_pct, _constant_pct, _null_pct);   \
+  EXCHANGE_BENCHMARK_MODES(                                               \
+      _case_name, _input_expr, 16, _dict_pct, _constant_pct, _null_pct);  \
+  EXCHANGE_BENCHMARK_MODES(                                               \
+      _case_name, _input_expr, 100, _dict_pct, _constant_pct, _null_pct); \
+  EXCHANGE_BENCHMARK_MODES(                                               \
+      _case_name, _input_expr, 1000, _dict_pct, _constant_pct, _null_pct)
 
-#define EXCHANGE_BENCHMARK_DESTINATIONS(_case_name, _input_expr) \
-  EXCHANGE_BENCHMARK_NULLS(_case_name, _input_expr, 1);          \
-  EXCHANGE_BENCHMARK_NULLS(_case_name, _input_expr, 4);          \
-  EXCHANGE_BENCHMARK_NULLS(_case_name, _input_expr, 16);         \
-  EXCHANGE_BENCHMARK_NULLS(_case_name, _input_expr, 100);        \
-  EXCHANGE_BENCHMARK_NULLS(_case_name, _input_expr, 1000)
+#define EXCHANGE_BENCHMARK_CASE(_case_name, _input_expr)               \
+  EXCHANGE_BENCHMARK_DESTINATIONS(_case_name, _input_expr, 0, 0, 0);   \
+  EXCHANGE_BENCHMARK_DESTINATIONS(_case_name, _input_expr, 0, 0, 50);  \
+  EXCHANGE_BENCHMARK_DESTINATIONS(_case_name, _input_expr, 0, 0, 100); \
+  BENCHMARK_DRAW_LINE();
 
-#define EXCHANGE_BENCHMARK_CASE(_case_name, _input_expr) \
-  EXCHANGE_BENCHMARK_DESTINATIONS(_case_name, _input_expr)
+#define EXCHANGE_BENCHMARK_CONSTANT_CASE(_case_name, _input_expr)        \
+  EXCHANGE_BENCHMARK_DESTINATIONS(_case_name, _input_expr, 0, 100, 0);   \
+  EXCHANGE_BENCHMARK_DESTINATIONS(_case_name, _input_expr, 0, 100, 100); \
+  BENCHMARK_DRAW_LINE();
+
+#define EXCHANGE_BENCHMARK_DICTIONARY_CASE(_case_name, _input_expr)      \
+  EXCHANGE_BENCHMARK_DESTINATIONS(_case_name, _input_expr, 100, 0, 0);   \
+  EXCHANGE_BENCHMARK_DESTINATIONS(_case_name, _input_expr, 100, 0, 100); \
+  BENCHMARK_DRAW_LINE();
 
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Boolean_col1,
+    10K_Boolean_col1,
     makeInputSpec(SimpleColType::kBoolean, 1));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Boolean_col4,
+    10K_Boolean_col4,
     makeInputSpec(SimpleColType::kBoolean, 4));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Boolean_col16,
+    10K_Boolean_col16,
+    makeInputSpec(SimpleColType::kBoolean, 16));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Boolean_col1,
+    makeInputSpec(SimpleColType::kBoolean, 1));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Boolean_col4,
+    makeInputSpec(SimpleColType::kBoolean, 4));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Boolean_col16,
+    makeInputSpec(SimpleColType::kBoolean, 16));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Boolean_col1,
+    makeInputSpec(SimpleColType::kBoolean, 1));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Boolean_col4,
+    makeInputSpec(SimpleColType::kBoolean, 4));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Boolean_col16,
     makeInputSpec(SimpleColType::kBoolean, 16));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Tinyint_col1,
+    10K_Tinyint_col1,
     makeInputSpec(SimpleColType::kTinyint, 1));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Tinyint_col4,
+    10K_Tinyint_col4,
     makeInputSpec(SimpleColType::kTinyint, 4));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Tinyint_col16,
+    10K_Tinyint_col16,
+    makeInputSpec(SimpleColType::kTinyint, 16));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Tinyint_col1,
+    makeInputSpec(SimpleColType::kTinyint, 1));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Tinyint_col4,
+    makeInputSpec(SimpleColType::kTinyint, 4));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Tinyint_col16,
+    makeInputSpec(SimpleColType::kTinyint, 16));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Tinyint_col1,
+    makeInputSpec(SimpleColType::kTinyint, 1));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Tinyint_col4,
+    makeInputSpec(SimpleColType::kTinyint, 4));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Tinyint_col16,
     makeInputSpec(SimpleColType::kTinyint, 16));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Integer_col1,
+    10K_Integer_col1,
     makeInputSpec(SimpleColType::kInteger, 1));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Integer_col4,
+    10K_Integer_col4,
     makeInputSpec(SimpleColType::kInteger, 4));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Integer_col16,
+    10K_Integer_col16,
+    makeInputSpec(SimpleColType::kInteger, 16));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Integer_col1,
+    makeInputSpec(SimpleColType::kInteger, 1));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Integer_col4,
+    makeInputSpec(SimpleColType::kInteger, 4));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Integer_col16,
+    makeInputSpec(SimpleColType::kInteger, 16));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Integer_col1,
+    makeInputSpec(SimpleColType::kInteger, 1));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Integer_col4,
+    makeInputSpec(SimpleColType::kInteger, 4));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Integer_col16,
     makeInputSpec(SimpleColType::kInteger, 16));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Bigint_col1,
+    10K_Bigint_col1,
     makeInputSpec(SimpleColType::kBigint, 1));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Bigint_col4,
+    10K_Bigint_col4,
     makeInputSpec(SimpleColType::kBigint, 4));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Bigint_col16,
+    10K_Bigint_col16,
+    makeInputSpec(SimpleColType::kBigint, 16));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Bigint_col1,
+    makeInputSpec(SimpleColType::kBigint, 1));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Bigint_col4,
+    makeInputSpec(SimpleColType::kBigint, 4));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Bigint_col16,
+    makeInputSpec(SimpleColType::kBigint, 16));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Bigint_col1,
+    makeInputSpec(SimpleColType::kBigint, 1));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Bigint_col4,
+    makeInputSpec(SimpleColType::kBigint, 4));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Bigint_col16,
     makeInputSpec(SimpleColType::kBigint, 16));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Hugeint_col1,
+    10K_Hugeint_col1,
     makeInputSpec(SimpleColType::kHugeint, 1));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Hugeint_col4,
+    10K_Hugeint_col4,
     makeInputSpec(SimpleColType::kHugeint, 4));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Hugeint_col16,
+    10K_Hugeint_col16,
+    makeInputSpec(SimpleColType::kHugeint, 16));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Hugeint_col1,
+    makeInputSpec(SimpleColType::kHugeint, 1));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Hugeint_col4,
+    makeInputSpec(SimpleColType::kHugeint, 4));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Hugeint_col16,
+    makeInputSpec(SimpleColType::kHugeint, 16));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Hugeint_col1,
+    makeInputSpec(SimpleColType::kHugeint, 1));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Hugeint_col4,
+    makeInputSpec(SimpleColType::kHugeint, 4));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Hugeint_col16,
     makeInputSpec(SimpleColType::kHugeint, 16));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_LongDecimal_col1,
+    10K_LongDecimal_col1,
     makeInputSpec(SimpleColType::kLongDecimal, 1));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_LongDecimal_col4,
+    10K_LongDecimal_col4,
     makeInputSpec(SimpleColType::kLongDecimal, 4));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_LongDecimal_col16,
+    10K_LongDecimal_col16,
+    makeInputSpec(SimpleColType::kLongDecimal, 16));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_LongDecimal_col1,
+    makeInputSpec(SimpleColType::kLongDecimal, 1));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_LongDecimal_col4,
+    makeInputSpec(SimpleColType::kLongDecimal, 4));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_LongDecimal_col16,
+    makeInputSpec(SimpleColType::kLongDecimal, 16));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_LongDecimal_col1,
+    makeInputSpec(SimpleColType::kLongDecimal, 1));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_LongDecimal_col4,
+    makeInputSpec(SimpleColType::kLongDecimal, 4));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_LongDecimal_col16,
     makeInputSpec(SimpleColType::kLongDecimal, 16));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Double_col1,
+    10K_Double_col1,
     makeInputSpec(SimpleColType::kDouble, 1));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Double_col4,
+    10K_Double_col4,
     makeInputSpec(SimpleColType::kDouble, 4));
 EXCHANGE_BENCHMARK_CASE(
-    Simple10K_Double_col16,
+    10K_Double_col16,
+    makeInputSpec(SimpleColType::kDouble, 16));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Double_col1,
+    makeInputSpec(SimpleColType::kDouble, 1));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Double_col4,
+    makeInputSpec(SimpleColType::kDouble, 4));
+EXCHANGE_BENCHMARK_CONSTANT_CASE(
+    10K_Double_col16,
+    makeInputSpec(SimpleColType::kDouble, 16));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Double_col1,
+    makeInputSpec(SimpleColType::kDouble, 1));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Double_col4,
+    makeInputSpec(SimpleColType::kDouble, 4));
+EXCHANGE_BENCHMARK_DICTIONARY_CASE(
+    10K_Double_col16,
     makeInputSpec(SimpleColType::kDouble, 16));
 
 // The complex type benchmarks are temporarily disabled.
@@ -800,10 +1002,14 @@ EXCHANGE_BENCHMARK_CASE(
 // makeInputSpec(ExchangeInputKind::kStruct1K));
 
 #undef EXCHANGE_BENCHMARK_CASE
+#undef EXCHANGE_BENCHMARK_DICTIONARY_CASE
+#undef EXCHANGE_BENCHMARK_CONSTANT_CASE
 #undef EXCHANGE_BENCHMARK_DESTINATIONS
-#undef EXCHANGE_BENCHMARK_NULLS
 #undef EXCHANGE_BENCHMARK_MODES
+#undef EXCHANGE_BENCHMARK_RELATIVE_INPUT
 #undef EXCHANGE_BENCHMARK_INPUT
+#undef EXCHANGE_BENCHMARK_INPUT_IMPL
+#undef EXCHANGE_BENCHMARK_NAMED_PARAM_RELATIVE
 #undef EXCHANGE_BENCHMARK_NAMED_PARAM
 
 } // namespace
@@ -821,6 +1027,9 @@ int main(int argc, char** argv) {
 
   bm = std::make_unique<ExchangeBenchmark>();
   folly::runBenchmarks();
+  std::fflush(stdout);
+  std::fflush(stderr);
+  std::cout << std::endl << "Exchange detailed stats:" << std::endl;
   printAllExchangeStats();
   bm.reset();
 

--- a/velox/exec/benchmarks/OptimizedHashPartitionFunctionBenchmark.cpp
+++ b/velox/exec/benchmarks/OptimizedHashPartitionFunctionBenchmark.cpp
@@ -260,9 +260,7 @@ void runPartitionBenchmark(
   for (uint32_t iteration = 0; iteration < iterations; ++iteration) {
     std::optional<uint32_t> singlePartition =
         partitionFunction->partition(*input, partitions);
-    if (singlePartition.has_value()) {
-      std::fill(partitions.begin(), partitions.end(), singlePartition.value());
-    }
+
     folly::doNotOptimizeAway(partitions.data());
   }
 }

--- a/velox/exec/tests/OptimizedHashPartitionFunctionTest.cpp
+++ b/velox/exec/tests/OptimizedHashPartitionFunctionTest.cpp
@@ -102,6 +102,26 @@ TEST_F(OptimizedHashPartitionFunctionTest, onePartitionReturnsConstantResult) {
   EXPECT_EQ(partitions, std::vector<uint32_t>{123});
 }
 
+TEST_F(OptimizedHashPartitionFunctionTest, constantKeyReturnsConstantResult) {
+  const auto numRows = 10'000;
+  for (const auto& vector : {
+           makeConstant(true, numRows),
+           BaseVector::createNullConstant(BOOLEAN(), numRows, pool()),
+       }) {
+    auto input = makeRowVector({vector});
+    const auto rowType = asRowType(input->type());
+    OptimizedHashPartitionFunction optimized(
+        /*localExchange=*/true, 16, rowType, {0});
+
+    std::vector<uint32_t> optimizedPartitions{123};
+    const auto optimizedPartition =
+        optimized.partition(*input, optimizedPartitions);
+    ASSERT_TRUE(optimizedPartition.has_value());
+    EXPECT_LT(optimizedPartition.value(), 16);
+    EXPECT_EQ(optimizedPartitions, std::vector<uint32_t>{123});
+  }
+}
+
 TEST_F(OptimizedHashPartitionFunctionTest, emptyConstantKeyReturnsEmptyResult) {
   auto input = makeRowVector({makeConstant(true, 0)});
   const auto rowType = asRowType(input->type());
@@ -111,6 +131,34 @@ TEST_F(OptimizedHashPartitionFunctionTest, emptyConstantKeyReturnsEmptyResult) {
   std::vector<uint32_t> optimizedPartitions{123};
   EXPECT_EQ(optimized.partition(*input, optimizedPartitions), std::nullopt);
   EXPECT_TRUE(optimizedPartitions.empty());
+}
+
+TEST_F(OptimizedHashPartitionFunctionTest, constantKeyMatchesFlatKey) {
+  constexpr auto numRows = 10'000;
+  auto constantInput = makeRowVector({makeConstant<int64_t>(123, numRows)});
+  auto flatInput = makeRowVector(
+      {makeFlatVector<int64_t>(numRows, [](auto /*row*/) { return 123; })});
+  const auto rowType = asRowType(constantInput->type());
+
+  for (const bool localExchange : {false, true}) {
+    OptimizedHashPartitionFunction constantPartitionFunction(
+        localExchange, 16, rowType, {0});
+    OptimizedHashPartitionFunction flatPartitionFunction(
+        localExchange, 16, rowType, {0});
+
+    std::vector<uint32_t> constantPartitions{123};
+    const auto constantPartition =
+        constantPartitionFunction.partition(*constantInput, constantPartitions);
+    ASSERT_TRUE(constantPartition.has_value());
+    EXPECT_EQ(constantPartitions, std::vector<uint32_t>{123});
+
+    std::vector<uint32_t> flatPartitions;
+    EXPECT_EQ(
+        flatPartitionFunction.partition(*flatInput, flatPartitions),
+        std::nullopt);
+    EXPECT_EQ(
+        flatPartitions, std::vector<uint32_t>(numRows, *constantPartition));
+  }
 }
 
 TEST_F(OptimizedHashPartitionFunctionTest, specUsesConfiguredImplementation) {

--- a/velox/exec/tests/OptimizedVectorHasherTest.cpp
+++ b/velox/exec/tests/OptimizedVectorHasherTest.cpp
@@ -194,6 +194,51 @@ TEST_F(OptimizedVectorHasherTest, nullConstant) {
   compareHashes(INTEGER(), vector, allRows, true, 11);
 }
 
+TEST_F(OptimizedVectorHasherTest, scalarHashPrecomputed) {
+  auto vector = makeFlatVector<int64_t>({123});
+  auto hasher = OptimizedVectorHasher::create(BIGINT(), 0);
+  hasher->precompute(*vector);
+
+  raw_vector<uint64_t> expected(1, pool());
+  expected[0] = 0;
+  hasher->hashPrecomputed(false, expected);
+  EXPECT_EQ(hasher->hashPrecomputed(false, 19), expected[0]);
+
+  expected[0] = 19;
+  hasher->hashPrecomputed(true, expected);
+  EXPECT_EQ(hasher->hashPrecomputed(true, 19), expected[0]);
+}
+
+TEST_F(OptimizedVectorHasherTest, scalarHashConstant) {
+  auto vector = BaseVector::createConstant(INTEGER(), 123, 6, pool());
+  const SelectivityVector allRows(vector->size());
+  auto hasher = OptimizedVectorHasher::create(INTEGER(), 0);
+  hasher->decode(*vector, allRows);
+
+  raw_vector<uint64_t> expected(vector->size(), pool());
+  std::fill(expected.begin(), expected.end(), 0);
+  hasher->hash(false, expected);
+  auto actual = hasher->hashConstant(false, 19);
+  ASSERT_TRUE(actual.has_value());
+  EXPECT_EQ(actual.value(), expected[0]);
+
+  std::fill(expected.begin(), expected.end(), 19);
+  hasher->hash(true, expected);
+  actual = hasher->hashConstant(true, 19);
+  ASSERT_TRUE(actual.has_value());
+  EXPECT_EQ(actual.value(), expected[0]);
+}
+
+TEST_F(OptimizedVectorHasherTest, scalarHashConstantEmpty) {
+  auto vector = BaseVector::createConstant(INTEGER(), 123, 0, pool());
+  const SelectivityVector rows(vector->size());
+  auto hasher = OptimizedVectorHasher::create(INTEGER(), 0);
+  hasher->decode(*vector, rows);
+
+  EXPECT_EQ(hasher->hashConstant(false, 19), std::nullopt);
+  EXPECT_EQ(hasher->hashConstant(true, 19), std::nullopt);
+}
+
 TEST_F(OptimizedVectorHasherTest, unknown) {
   auto vector = makeAllNullFlatVector<UnknownValue>(100);
   const SelectivityVector allRows(vector->size());

--- a/velox/serializers/PrestoIterativePartitioningSerializer.cpp
+++ b/velox/serializers/PrestoIterativePartitioningSerializer.cpp
@@ -578,12 +578,11 @@ int64_t PrestoIterativePartitioningSerializer::estimateBytesAfterAppend(
 void PrestoIterativePartitioningSerializer::append(
     const RowVectorPtr& input,
     const std::vector<uint32_t>& partitions) {
-  VELOX_CHECK_NOT_NULL(input);
-  VELOX_CHECK_EQ(
+  VELOX_DCHECK_NOT_NULL(input);
+  VELOX_DCHECK_EQ(
       input->size(),
       partitions.size(),
       "partitions.size() must equal input->size()");
-
   validateOutputInputMapping(input);
 
   if (input->size() == 0) {
@@ -594,6 +593,29 @@ void PrestoIterativePartitioningSerializer::append(
   auto partitionedRowVector = PartitionedVector::create(
       std::static_pointer_cast<BaseVector>(input),
       partitions,
+      numPartitions_,
+      ctx,
+      pool_);
+
+  bufferState_->append(partitionedRowVector, outputToInputChannels_);
+  partitionedRowVectors_.push_back(std::move(partitionedRowVector));
+}
+
+void PrestoIterativePartitioningSerializer::append(
+    const RowVectorPtr& input,
+    uint32_t singlePartition) {
+  VELOX_DCHECK_NOT_NULL(input);
+  VELOX_DCHECK_LT(singlePartition, numPartitions_);
+  validateOutputInputMapping(input);
+
+  if (input->size() == 0) {
+    return;
+  }
+
+  PartitionBuildContext ctx;
+  auto partitionedRowVector = PartitionedVector::create(
+      std::static_pointer_cast<BaseVector>(input),
+      singlePartition,
       numPartitions_,
       ctx,
       pool_);

--- a/velox/serializers/PrestoIterativePartitioningSerializer.h
+++ b/velox/serializers/PrestoIterativePartitioningSerializer.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <folly/io/IOBuf.h>
@@ -101,6 +102,11 @@ class PrestoIterativePartitioningSerializer {
   void append(
       const RowVectorPtr& input,
       const std::vector<uint32_t>& partitions);
+
+  /// Routes all rows in `input` to `singlePartition`. Use this overload when
+  /// every row in `input` has the same destination — it skips the per-row
+  /// partition lookup.
+  void append(const RowVectorPtr& input, uint32_t singlePartition);
 
   /// Serializes all buffered data into one Presto page per non-empty partition
   /// and resets internal state. Returns an empty map if nothing has been

--- a/velox/serializers/tests/PrestoIterativePartitioningSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoIterativePartitioningSerializerTest.cpp
@@ -255,6 +255,24 @@ TEST_P(PrestoIterativePartitioningSerializerParamTest, allRowsToOnePartition) {
   EXPECT_EQ(deserialize(*ioBufs.at(2).first, type)->size(), 5);
 }
 
+// All rows routed to one non-zero partition without materialized assignments.
+TEST_P(
+    PrestoIterativePartitioningSerializerParamTest,
+    allRowsToOnePartitionFastPath) {
+  auto colType = GetParam();
+  auto type = ROW({"x"}, {colType});
+  auto col = BaseVector::create(colType, 5, pool_.get());
+  auto input = makeRowVector({"x"}, {col});
+
+  auto serializer = makeSerializer(type, 4);
+  serializer->append(input, /*singlePartition=*/2);
+  auto ioBufs = serializer->flush();
+
+  ASSERT_EQ(ioBufs.size(), 1);
+  ASSERT_TRUE(ioBufs.count(2));
+  EXPECT_EQ(deserialize(*ioBufs.at(2).first, type)->size(), 5);
+}
+
 // Single partition (numPartitions=1): all rows go to partition 0.
 TEST_P(PrestoIterativePartitioningSerializerParamTest, singlePartition) {
   auto colType = GetParam();
@@ -552,13 +570,14 @@ TEST_F(
   const auto singleRowPageBytes = simpleColumnPageBytes("LONG_ARRAY", 1, 0, 8);
 
   serializer->append(
-      makeRowVector({"v"}, {makeFlatVector<int64_t>({10})}), {0});
+      makeRowVector({"v"}, {makeFlatVector<int64_t>({10})}),
+      std::vector<uint32_t>{0});
   EXPECT_EQ(serializer->bytesBuffered(), singleRowPageBytes);
 
   auto input = makeRowVector({"v"}, {makeFlatVector<int64_t>({20})});
   EXPECT_EQ(serializer->bytesBuffered(), singleRowPageBytes);
 
-  serializer->append(input, {1});
+  serializer->append(input, std::vector<uint32_t>{1});
   const auto bytesBuffered = serializer->bytesBuffered();
   EXPECT_EQ(serializer->bytesBuffered(), 2 * singleRowPageBytes);
 
@@ -584,7 +603,7 @@ TEST_F(PrestoIterativePartitioningSerializerTest, bytesBufferedNullFlagGrowth) {
       serializer->bytesBuffered(),
       simpleColumnPageBytes("LONG_ARRAY", 8, 0, 8));
 
-  serializer->append(input, {0});
+  serializer->append(input, std::vector<uint32_t>{0});
   const auto bytesBuffered = serializer->bytesBuffered();
   EXPECT_EQ(bytesBuffered, simpleColumnPageBytes("LONG_ARRAY", 9, 1, 8));
 
@@ -670,7 +689,7 @@ TEST_F(
       makeRowVector({"v"}, {makeNullableFlatVector<int64_t>({std::nullopt})});
   const auto estimatedAfter = serializer->estimateBytesAfterAppend(input);
 
-  serializer->append(input, {0});
+  serializer->append(input, std::vector<uint32_t>{0});
   EXPECT_EQ(estimatedAfter, serializer->bytesBuffered());
 }
 

--- a/velox/vector/PartitionedVector.cpp
+++ b/velox/vector/PartitionedVector.cpp
@@ -49,12 +49,25 @@ inline void prefixSum(vector_size_t* offsets, uint32_t numPartitions) {
 
 inline void calculateOffsets(
     const std::vector<uint32_t>& partitions,
+    std::optional<uint32_t> singlePartition,
+    vector_size_t vectorSize,
     uint32_t numPartitions,
     vector_size_t* endPartitionOffsets) {
   VELOX_DCHECK_NOT_NULL(endPartitionOffsets);
 
+  std::fill_n(endPartitionOffsets, numPartitions, 0);
+
+  if (singlePartition.has_value()) {
+    VELOX_DCHECK_LT(singlePartition.value(), numPartitions);
+
+    std::fill_n(
+        endPartitionOffsets + singlePartition.value(),
+        numPartitions - singlePartition.value(),
+        vectorSize);
+    return;
+  }
+
   if (numPartitions > 1) {
-    std::fill_n(endPartitionOffsets, numPartitions, 0);
     countPartitionSizes(partitions, endPartitionOffsets);
     prefixSum(endPartitionOffsets, numPartitions);
   } else {
@@ -216,6 +229,7 @@ template <TypeKind typeKind>
 PartitionedVectorPtr createPartitionedFlatVector(
     VectorPtr vector,
     const std::vector<uint32_t>& partitions,
+    std::optional<uint32_t> singlePartition,
     uint32_t numPartitions,
     const BufferPtr& endPartitionOffsets,
     PartitionBuildContext& ctx,
@@ -229,7 +243,7 @@ PartitionedVectorPtr createPartitionedFlatVector(
 
   // Always call partition() so that numNullsPerPartition_ is populated,
   // even when numPartitions == 1 and no data movement is required.
-  partitionedFlatVector->partition(partitions, ctx);
+  partitionedFlatVector->partition(partitions, singlePartition, ctx);
 
   return partitionedFlatVector;
 }
@@ -237,6 +251,7 @@ PartitionedVectorPtr createPartitionedFlatVector(
 PartitionedVectorPtr createPartitionedRowVector(
     VectorPtr vector,
     const std::vector<uint32_t>& partitions,
+    std::optional<uint32_t> singlePartition,
     uint32_t numPartitions,
     const BufferPtr& endPartitionOffsets,
     PartitionBuildContext& ctx,
@@ -249,7 +264,7 @@ PartitionedVectorPtr createPartitionedRowVector(
 
   // Always call partition() to initialize partitionedChildren_, even when
   // numPartitions == 1, so that partitionAt() can reconstruct the RowVector.
-  partitionedRowVector->partition(partitions, ctx);
+  partitionedRowVector->partition(partitions, singlePartition, ctx);
 
   return partitionedRowVector;
 }
@@ -258,15 +273,41 @@ PartitionedVectorPtr createPartitionedRowVector(
 
 PartitionedVector::~PartitionedVector() = default;
 
+// public
 PartitionedVectorPtr PartitionedVector::create(
     const VectorPtr& vector,
     const std::vector<uint32_t>& partitions,
     uint32_t numPartitions,
     PartitionBuildContext& ctx,
     velox::memory::MemoryPool* pool) {
+  return create(vector, partitions, std::nullopt, numPartitions, ctx, pool);
+}
+
+// public
+PartitionedVectorPtr PartitionedVector::create(
+    const VectorPtr& vector,
+    uint32_t singlePartition,
+    uint32_t numPartitions,
+    PartitionBuildContext& ctx,
+    velox::memory::MemoryPool* pool) {
+  return create(vector, {}, singlePartition, numPartitions, ctx, pool);
+}
+
+// protected
+PartitionedVectorPtr PartitionedVector::create(
+    const VectorPtr& vector,
+    const std::vector<uint32_t>& partitions,
+    std::optional<uint32_t> singlePartition,
+    uint32_t numPartitions,
+    PartitionBuildContext& ctx,
+    velox::memory::MemoryPool* pool) {
   VELOX_CHECK_NOT_NULL(vector);
-  VELOX_CHECK_EQ(vector->size(), partitions.size());
   VELOX_CHECK_GT(numPartitions, 0);
+  if (singlePartition.has_value()) {
+    VELOX_CHECK_LT(singlePartition.value(), numPartitions);
+  } else {
+    VELOX_CHECK_EQ(vector->size(), partitions.size());
+  }
   VELOX_CHECK_NOT_NULL(pool);
 
   // Calculate the end offsets for each partition. For example, if there are 3
@@ -276,20 +317,29 @@ PartitionedVectorPtr PartitionedVector::create(
   ensureCapacity<vector_size_t>(endPartitionOffsets, numPartitions, pool);
   calculateOffsets(
       partitions,
+      singlePartition,
+      vector->size(),
       numPartitions,
       endPartitionOffsets->asMutable<vector_size_t>());
   endPartitionOffsets->setSize(numPartitions * sizeof(vector_size_t));
 
   auto raw = endPartitionOffsets->as<vector_size_t>();
-  VELOX_DCHECK_EQ(raw[numPartitions - 1], partitions.size());
+  VELOX_DCHECK_EQ(raw[numPartitions - 1], vector->size());
 
   return create(
-      vector, partitions, numPartitions, endPartitionOffsets, ctx, pool);
+      vector,
+      partitions,
+      singlePartition,
+      numPartitions,
+      endPartitionOffsets,
+      ctx,
+      pool);
 }
 
 PartitionedVectorPtr PartitionedVector::create(
     const VectorPtr& vector,
     const std::vector<uint32_t>& partitions,
+    std::optional<uint32_t> singlePartition,
     uint32_t numPartitions,
     const BufferPtr& endPartitionOffsets,
     PartitionBuildContext& ctx,
@@ -308,6 +358,7 @@ PartitionedVectorPtr PartitionedVector::create(
           typeKind,
           vector,
           partitions,
+          singlePartition,
           numPartitions,
           endPartitionOffsets,
           ctx,
@@ -317,14 +368,20 @@ PartitionedVectorPtr PartitionedVector::create(
 
     case VectorEncoding::Simple::ROW: {
       return createPartitionedRowVector(
-          vector, partitions, numPartitions, endPartitionOffsets, ctx, pool);
+          vector,
+          partitions,
+          singlePartition,
+          numPartitions,
+          endPartitionOffsets,
+          ctx,
+          pool);
     }
 
     case VectorEncoding::Simple::CONSTANT: {
       auto partitionedConstantVector =
           std::make_shared<PartitionedConstantVector>(
               vector, numPartitions, endPartitionOffsets, pool);
-      partitionedConstantVector->partition(partitions, ctx);
+      partitionedConstantVector->partition(partitions, singlePartition, ctx);
       return partitionedConstantVector;
     }
 
@@ -365,7 +422,17 @@ std::string PartitionedVector::toString() const {
 template <typename T>
 void PartitionedFlatVector<T>::partition(
     const std::vector<uint32_t>& partitions,
+    std::optional<uint32_t> singlePartition,
     PartitionBuildContext& ctx) {
+  if (singlePartition.has_value()) {
+    if (const auto* rawNulls = vector_->rawNulls()) {
+      numNullsPerPartition_[singlePartition.value()] =
+          static_cast<vector_size_t>(
+              bits::countNulls(rawNulls, 0, vector_->size()));
+    }
+    return;
+  }
+
   if (vector_->rawNulls()) {
     const auto numRows = static_cast<vector_size_t>(partitions.size());
     const auto numBytes = bits::nbytes(numRows);
@@ -424,6 +491,7 @@ VectorPtr PartitionedFlatVector<T>::partitionAt(uint32_t partition) const {
 
 void PartitionedRowVector::partition(
     const std::vector<uint32_t>& partitions,
+    std::optional<uint32_t> singlePartition,
     PartitionBuildContext& ctx) {
   auto* rowVector = vector_->as<RowVector>();
   partitionedChildren_.reserve(rowVector->childrenSize());
@@ -433,10 +501,20 @@ void PartitionedRowVector::partition(
         PartitionedVector::create(
             child,
             partitions,
+            singlePartition,
             numPartitions_,
             endPartitionOffsets_,
             ctx,
             pool_));
+  }
+
+  if (singlePartition.has_value()) {
+    if (const auto* rawNulls = vector_->rawNulls()) {
+      numNullsPerPartition_[singlePartition.value()] =
+          static_cast<vector_size_t>(
+              bits::countNulls(rawNulls, 0, vector_->size()));
+    }
+    return;
   }
 
   if (numPartitions_ > 1 && vector_->rawNulls()) {
@@ -504,8 +582,14 @@ VectorPtr PartitionedRowVector::partitionAt(uint32_t partition) const {
 
 void PartitionedConstantVector::partition(
     const std::vector<uint32_t>& /*partitions*/,
+    std::optional<uint32_t> singlePartition,
     PartitionBuildContext& /*ctx*/) {
   if (!vector_->isNullAt(0)) {
+    return;
+  }
+
+  if (singlePartition.has_value()) {
+    numNullsPerPartition_[singlePartition.value()] = vector_->size();
     return;
   }
 

--- a/velox/vector/PartitionedVector.h
+++ b/velox/vector/PartitionedVector.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include "velox/vector/BaseVector.h"
@@ -121,7 +122,8 @@ class PartitionedVector {
   ///   PartitionedVector.
   /// - partitions: a vector of partition IDs for each row in the base vector.
   ///   The length of this vector must be the same as the number of rows in the
-  ///   base vector. Each entry must be a value between 0 and numPartitions - 1.
+  ///   base vector unless singlePartition is set. Each entry must be a value
+  ///   between 0 and numPartitions - 1.
   /// - numPartitions: the total number of partitions. This must be greater than
   ///   0.
   /// - ctx: the context object for building the partitioned vector. This
@@ -135,6 +137,16 @@ class PartitionedVector {
   static PartitionedVectorPtr create(
       const VectorPtr& vector,
       const std::vector<uint32_t>& partitions,
+      uint32_t numPartitions,
+      PartitionBuildContext& ctx,
+      velox::memory::MemoryPool* pool);
+
+  /// Factory method for the case where every row of `vector` belongs to the
+  /// same partition. Skips the per-row partition lookup. `singlePartition`
+  /// must be less than `numPartitions`.
+  static PartitionedVectorPtr create(
+      const VectorPtr& vector,
+      uint32_t singlePartition,
       uint32_t numPartitions,
       PartitionBuildContext& ctx,
       velox::memory::MemoryPool* pool);
@@ -179,11 +191,24 @@ class PartitionedVector {
   virtual std::string toString() const;
 
  protected:
+  // Internal create method used by recursive descent into child columns. The
+  // `singlePartition` optional carries the parent's decision so child columns
+  // inherit the same partition without re-deriving it. When set, `partitions`
+  // is ignored.
+  static PartitionedVectorPtr create(
+      const VectorPtr& vector,
+      const std::vector<uint32_t>& partitions,
+      std::optional<uint32_t> singlePartition,
+      uint32_t numPartitions,
+      PartitionBuildContext& ctx,
+      velox::memory::MemoryPool* pool);
+
   // Internal create method that accepts pre-computed endPartitionOffsets
   // buffer.
   static PartitionedVectorPtr create(
       const VectorPtr& vector,
       const std::vector<uint32_t>& partitions,
+      std::optional<uint32_t> singlePartition,
       uint32_t numPartitions,
       const BufferPtr& partitionOffsetsBuffer,
       PartitionBuildContext& ctx,
@@ -211,6 +236,7 @@ class PartitionedVector {
 
   virtual void partition(
       const std::vector<uint32_t>& partitions,
+      std::optional<uint32_t> singlePartition,
       PartitionBuildContext& ctx) = 0;
 
   // The base vector that is being partitioned. This is modified during
@@ -252,6 +278,7 @@ class PartitionedFlatVector : public PartitionedVector {
 
   void partition(
       const std::vector<uint32_t>& partitions,
+      std::optional<uint32_t> singlePartition,
       PartitionBuildContext& ctx) override;
 
   VectorPtr partitionAt(uint32_t partition) const override;
@@ -275,6 +302,7 @@ class PartitionedRowVector : public PartitionedVector {
 
   void partition(
       const std::vector<uint32_t>& partitions,
+      std::optional<uint32_t> singlePartition,
       PartitionBuildContext& ctx) override;
 
   VectorPtr partitionAt(uint32_t partition) const override;
@@ -311,6 +339,7 @@ class PartitionedConstantVector : public PartitionedVector {
 
   void partition(
       const std::vector<uint32_t>& partitions,
+      std::optional<uint32_t> singlePartition,
       PartitionBuildContext& ctx) override;
 
   VectorPtr partitionAt(uint32_t partition) const override;

--- a/velox/vector/benchmarks/PartitionedVectorBenchmark.cpp
+++ b/velox/vector/benchmarks/PartitionedVectorBenchmark.cpp
@@ -219,8 +219,20 @@ void runBM(
   }
 }
 
+// Same as folly's BENCHMARK_NAMED_PARAM but stringizes only the param name,
+// so output lines read `<param_name>` instead of `runBM(<param_name>)`.
+#define BENCHMARK_PARAM_LABEL(name, param_name, ...)       \
+  BENCHMARK_IMPL(                                          \
+      FB_CONCATENATE(name, FB_CONCATENATE(_, param_name)), \
+      FOLLY_PP_STRINGIZE(param_name),                      \
+      iters,                                               \
+      unsigned,                                            \
+      iters) {                                             \
+    name(iters, ##__VA_ARGS__);                            \
+  }
+
 #define BENCHMARK_CONFIG(name, generator, numCols, nulls, numParts) \
-  BENCHMARK_NAMED_PARAM(                                            \
+  BENCHMARK_PARAM_LABEL(                                            \
       runBM,                                                        \
       name##_##numCols##Cols_##nulls##_P##numParts,                 \
       generator,                                                    \

--- a/velox/vector/tests/PartitionedVectorTest.cpp
+++ b/velox/vector/tests/PartitionedVectorTest.cpp
@@ -227,6 +227,51 @@ TEST_P(PartitioningVectorTest, testConstantVector) {
       numValues));
 }
 
+TEST_P(PartitioningVectorTest, singlePartitionWithoutAssignments) {
+  const int numValues = GetParam();
+  if (numValues == 0) {
+    return;
+  }
+
+  auto row = makeRowVector(
+      {makeFlatVector<int32_t>(numValues, [](auto row) { return row; }),
+       makeFlatVector<bool>(numValues, [](auto row) { return row % 2 == 0; })});
+  auto expected = BaseVector::copy(*row, pool_.get());
+
+  auto partitionedVector = PartitionedVector::create(
+      row,
+      /*singlePartition=*/2u,
+      4,
+      ctx_,
+      pool_.get());
+
+  EXPECT_EQ(partitionedVector->rawPartitionOffsets()[0], 0);
+  EXPECT_EQ(partitionedVector->rawPartitionOffsets()[1], 0);
+  EXPECT_EQ(partitionedVector->rawPartitionOffsets()[2], numValues);
+  EXPECT_EQ(partitionedVector->rawPartitionOffsets()[3], numValues);
+
+  EXPECT_EQ(partitionedVector->partitionAt(0)->size(), 0);
+  EXPECT_EQ(partitionedVector->partitionAt(1)->size(), 0);
+  test::assertEqualVectors(
+      expected, canonicalize(partitionedVector->partitionAt(2)));
+  EXPECT_EQ(partitionedVector->partitionAt(3)->size(), 0);
+
+  EXPECT_EQ(partitionedVector->numNullsAt(2), 0);
+
+  auto nullableFlat = makeFlatVector<int32_t>(
+      numValues, [](auto row) { return row; }, nullEvery(3));
+  auto partitionedNullableFlat = PartitionedVector::create(
+      nullableFlat,
+      /*singlePartition=*/2u,
+      4,
+      ctx_,
+      pool_.get());
+
+  EXPECT_EQ(
+      partitionedNullableFlat->numNullsAt(2),
+      BaseVector::countNulls(nullableFlat->nulls(), 0, numValues));
+}
+
 // Partitioning a null-free vector must not allocate a null buffer.
 TEST_P(PartitioningVectorTest, noNullBufferAllocatedForNullFreeFlat) {
   const int numValues = GetParam();


### PR DESCRIPTION
 Before
```
    ----------------------------------------------------------------------------
    partition_bool_remote_p16_constant_all_null                 7.15us   139.87K
    optimized_partition_bool_remote_p16_constant_al 349.51%     2.05us   488.84K
    ----------------------------------------------------------------------------
    partition_bool_remote_p100_constant_no_null                 7.14us   139.97K
    optimized_partition_bool_remote_p100_constant_n 190.04%     3.76us   265.99K
    ----------------------------------------------------------------------------
```
    After
```
    ----------------------------------------------------------------------------
    partition_bool_remote_p16_constant_all_null                 7.15us   139.82K
    optimized_partition_bool_remote_p16_constant_al 15456.%    46.28ns    21.61M
    ----------------------------------------------------------------------------
    partition_bool_remote_p100_constant_no_null                 7.14us   140.12K
    optimized_partition_bool_remote_p100_constant_n 14819.%    48.16ns    20.76M
    ----------------------------------------------------------------------------
```
    Other data types show the same pattern.

Depends on https://github.com/IBM/velox/pull/2016