### PR TITLE
fix: Pass Velox CMake build type to Folly

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -48,7 +48,12 @@ function install_fmt {
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/"${FB_OS_VERSION}".tar.gz folly
-  local FOLLY_FLAGS=(-DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON)
+  local FOLLY_FLAGS=(
+    -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED"
+    -DBUILD_TESTS=OFF
+    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
+    -DFOLLY_HAVE_INT128_T=ON
+  )
   # When folly is static, use static gflags to avoid dual gflags flag
   # registration when .so plugins are dlopen'd (both the binary and plugin
   # would register the same flags in a shared gflags registry).


### PR DESCRIPTION
Currently Velox never passes CMAKE_BUILD_TYPE into Folly's own configure step, while cmake_install only forwards arbitrary caller flags, so Folly was not built in release mode when Velox is built in release mode. This commit adds -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" to FOLLY_FLAGS, so a release Velox dependency setup now builds release Folly on macOS and Linux.

The TPCH 1TB shows 
- 8% wall time improvement for the whole run (1 cold 1 warm)
- 12.7% wall time improvement for warm run
- PartitionedOutput shows 19% improvement in CPU time

The improvements is presumably from the Folly hash function speed up in release build.

Detailed comparisons can be found [here](https://grafana.ibm.prestodb.dev/d/b9d764a6-5753-4205-93bb-c983501a3b85/run-comparison-detailed?orgId=1&var-base_run=c1w1_native_oss_sf1k_tpch_catalog_260511-235423&var-target_run=c1w1_native_oss_sf1k_tpch_catalog_260511-232801&var-selected_run=-1&var-query_idx=0&var-stage_id=&from=now-30d&to=now)

```
Whole run 1cold 1 warm elapsed
713,081 vs. 659,360.  8% improvement

Warm only
285,687 vs. 253,468. 12.7% improvement

PartitionedOutput  CPU
6,978,244 vs. 5,852,930  19% improvement
```
