### PR TITLE
perf: Introduce OptimizedHashPartitionFunction

### DIFF
--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -81,7 +81,8 @@ function github_checkout {
 # The values that CPU_ARCH can take are as follows:
 #   arm64  : Target Apple silicon.
 #   aarch64: Target general 64 bit arm cpus.
-#   avx:     Target Intel CPUs with AVX.
+#   avx512:  Target Intel CPUs with AVX-512F.
+#   avx:     Target Intel CPUs with AVX2.
 #   sse:     Target Intel CPUs with sse.
 # Echo's the appropriate compiler flags which can be captured as so
 # CXX_FLAGS=$(get_cxx_flags) or
@@ -102,7 +103,9 @@ function get_cxx_flags {
       else # x86_64
         local CPU_CAPABILITIES
         CPU_CAPABILITIES=$(sysctl -a | grep machdep.cpu.features | awk '{print tolower($0)}')
-        if [[ $CPU_CAPABILITIES =~ "avx" ]]; then
+        if [[ $CPU_CAPABILITIES =~ "avx512f" ]]; then
+          CPU_ARCH="avx512"
+        elif [[ $CPU_CAPABILITIES =~ "avx" ]]; then
           CPU_ARCH="avx"
         else
           CPU_ARCH="sse"
@@ -114,7 +117,9 @@ function get_cxx_flags {
       else # x86_64
         local CPU_CAPABILITIES
         CPU_CAPABILITIES=$(cat /proc/cpuinfo | grep flags | head -n 1 | awk '{print tolower($0)}')
-        if [[ $CPU_CAPABILITIES =~ "avx" ]]; then
+        if [[ $CPU_CAPABILITIES =~ "avx512f" ]]; then
+          CPU_ARCH="avx512"
+        elif [[ $CPU_CAPABILITIES =~ "avx" ]]; then
           CPU_ARCH="avx"
         elif [[ $CPU_CAPABILITIES =~ "sse" ]]; then
           CPU_ARCH="sse"
@@ -131,8 +136,12 @@ function get_cxx_flags {
     echo -n "-mcpu=apple-m1+crc"
     ;;
 
+  "avx512")
+    echo -n "-mavx512f -mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2"
+    ;;
+
   "avx")
-    echo -n "-mavx2 -mfma -mavx -mf16c -mlzcnt  -mbmi2"
+    echo -n "-mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2"
     ;;
 
   "sse")

--- a/velox/common/process/ProcessBase.cpp
+++ b/velox/common/process/ProcessBase.cpp
@@ -32,6 +32,8 @@ DECLARE_bool(avx2); // Enables use of AVX2 when available NOLINT
 
 DECLARE_bool(bmi2); // Enables use of BMI2 when available NOLINT
 
+DECLARE_bool(avx512f);
+
 namespace facebook {
 namespace velox {
 namespace process {
@@ -106,6 +108,7 @@ uint64_t threadCpuNanos() {
 namespace {
 bool bmi2CpuFlag = folly::CpuId().bmi2();
 bool avx2CpuFlag = folly::CpuId().avx2();
+bool avx512fCpuFlag = folly::CpuId().avx512f();
 } // namespace
 
 bool hasAvx2() {
@@ -119,6 +122,14 @@ bool hasAvx2() {
 bool hasBmi2() {
 #ifdef __BMI2__
   return bmi2CpuFlag && FLAGS_bmi2;
+#else
+  return false;
+#endif
+}
+
+bool hasAvx512f() {
+#ifdef __AVX512F__
+  return avx512fCpuFlag && FLAGS_avx512f;
 #else
   return false;
 #endif

--- a/velox/common/process/ProcessBase.h
+++ b/velox/common/process/ProcessBase.h
@@ -46,6 +46,10 @@ uint64_t threadCpuNanos();
 /// by flag.
 bool hasAvx2();
 
+/// True if the machine has Intel AVX512F instructions and these are not
+/// disabled by flag.
+bool hasAvx512f();
+
 /// True if the machine has Intel BMI2 instructions and these are not disabled
 /// by flag.
 bool hasBmi2();

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -132,7 +132,8 @@ void HiveConnector::registerSerDe() {
 
 std::unique_ptr<core::PartitionFunction> HivePartitionFunctionSpec::create(
     int numPartitions,
-    bool localExchange) const {
+    bool localExchange,
+    bool /*useOptimizedPartitionFunction*/) const {
   std::vector<int> bucketToPartitions;
   if (bucketToPartition_.empty()) {
     // NOTE: if hive partition function spec doesn't specify bucket to partition

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -141,7 +141,8 @@ class HivePartitionFunctionSpec : public core::PartitionFunctionSpec {
 
   std::unique_ptr<core::PartitionFunction> create(
       int numPartitions,
-      bool localExchange) const override;
+      bool localExchange,
+      bool useOptimizedPartitionFunction = false) const override;
 
   std::string toString() const override;
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2500,9 +2500,13 @@ class PartitionFunctionSpec : public ISerializable {
  public:
   /// If 'localExchange' is true, the partition function is used for local
   /// exchange within a velox task.
+  /// TODO: useOptimizedPartitionFunction = true is only supported in
+  /// HashPartitionFunction now. Will extend the optimization to other
+  /// PartitionFunctions soon.
   virtual std::unique_ptr<PartitionFunction> create(
       int numPartitions,
-      bool localExchange = false) const = 0;
+      bool localExchange = false,
+      bool useOptimizedPartitionFunction = false) const = 0;
 
   virtual ~PartitionFunctionSpec() = default;
 
@@ -2515,7 +2519,8 @@ class GatherPartitionFunctionSpec : public PartitionFunctionSpec {
  public:
   std::unique_ptr<PartitionFunction> create(
       int /*numPartitions*/,
-      bool /*localExchange*/) const override {
+      bool /*localExchange*/,
+      bool /*useOptimizedPartitionFunction*/ = false) const override {
     VELOX_UNREACHABLE();
   }
 

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -90,6 +90,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
 
     // Partitioned output.
     VELOX_REGISTER_QUERY_CONFIG(kPartitionedOutputEagerFlush);
+    VELOX_REGISTER_QUERY_CONFIG(kOptimizedHashPartitionFunctionEnabled);
     VELOX_REGISTER_QUERY_CONFIG(kMaxPartitionedOutputBufferSize);
     VELOX_REGISTER_QUERY_CONFIG(kMaxOutputBufferSize);
 

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -454,6 +454,16 @@ class QueryConfig {
       false,
       "Flush PartitionedOutput rows eagerly without buffering.")
 
+  /// If true, use OptimizedHashPartitionFunction in place of
+  /// HashPartitionFunction.
+  VELOX_QUERY_CONFIG(
+      kOptimizedHashPartitionFunctionEnabled,
+      optimizedHashPartitionFunctionEnabled,
+      "optimized_hash_partition_function_enabled",
+      bool,
+      false,
+      "Use OptimizedHashPartitionFunction instead of HashPartitionFunction.")
+
   /// The maximum number of bytes to buffer in PartitionedOutput operator to
   /// avoid creating tiny SerializedPages.
   VELOX_QUERY_CONFIG(

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -71,6 +71,7 @@ velox_add_library(
   OperatorTraceScan.cpp
   OperatorTraceWriter.cpp
   OperatorUtils.cpp
+  OptimizedHashPartitionFunction.cpp
   OptimizedPartitionedOutput.cpp
   OptimizedVectorHasher.cpp
   OrderBy.cpp

--- a/velox/exec/HashPartitionFunction.cpp
+++ b/velox/exec/HashPartitionFunction.cpp
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <velox/exec/HashPartitionFunction.h>
-#include <velox/exec/VectorHasher.h>
+#include "velox/exec/HashPartitionFunction.h"
+
+#include "velox/exec/OptimizedHashPartitionFunction.h"
+#include "velox/exec/VectorHasher.h"
 
 #define XXH_INLINE_ALL
 #include <xxhash.h> // @manual=third-party//xxHash:xxhash
@@ -123,9 +125,15 @@ std::optional<uint32_t> HashPartitionFunction::partition(
 
 std::unique_ptr<core::PartitionFunction> HashPartitionFunctionSpec::create(
     int numPartitions,
-    bool localExchange) const {
-  return std::make_unique<exec::HashPartitionFunction>(
-      localExchange, numPartitions, inputType_, keyChannels_, constValues_);
+    bool localExchange,
+    bool useOptimizedPartitionFunction) const {
+  return createHashPartitionFunction(
+      localExchange,
+      numPartitions,
+      inputType_,
+      keyChannels_,
+      constValues_,
+      useOptimizedPartitionFunction);
 }
 
 std::string HashPartitionFunctionSpec::toString() const {
@@ -179,5 +187,34 @@ core::PartitionFunctionSpecPtr HashPartitionFunctionSpec::deserialize(
   }
   return std::make_shared<HashPartitionFunctionSpec>(
       ISerializable::deserialize<RowType>(obj["inputType"]), keys, constValues);
+}
+
+std::unique_ptr<HashPartitionFunctionBase> createHashPartitionFunction(
+    bool localExchange,
+    int numPartitions,
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    const std::vector<VectorPtr>& constValues,
+    bool useOptimizedPartitionFunction) {
+  if (useOptimizedPartitionFunction) {
+    return std::make_unique<OptimizedHashPartitionFunction>(
+        localExchange, numPartitions, inputType, keyChannels, constValues);
+  }
+  return std::make_unique<HashPartitionFunction>(
+      localExchange, numPartitions, inputType, keyChannels, constValues);
+}
+
+std::unique_ptr<HashPartitionFunctionBase> createHashPartitionFunction(
+    const HashBitRange& hashBitRange,
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    const std::vector<VectorPtr>& constValues,
+    bool useOptimizedPartitionFunction) {
+  if (useOptimizedPartitionFunction) {
+    return std::make_unique<OptimizedHashPartitionFunction>(
+        hashBitRange, inputType, keyChannels, constValues);
+  }
+  return std::make_unique<HashPartitionFunction>(
+      hashBitRange, inputType, keyChannels, constValues);
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/HashPartitionFunction.h
+++ b/velox/exec/HashPartitionFunction.h
@@ -15,11 +15,18 @@
  */
 #pragma once
 
-#include <velox/exec/HashBitRange.h>
-#include <velox/exec/VectorHasher.h>
 #include "velox/core/PlanNode.h"
+#include "velox/exec/HashBitRange.h"
+#include "velox/exec/VectorHasher.h"
 
 namespace facebook::velox::exec {
+
+class HashPartitionFunctionBase : public core::PartitionFunction {
+ public:
+  ~HashPartitionFunctionBase() override = default;
+
+  virtual int numPartitions() const = 0;
+};
 
 /// Calculates partition number for each row of the specified vector using a
 /// hash function. The constructor with hashBitRange parameter requires both
@@ -27,7 +34,9 @@ namespace facebook::velox::exec {
 /// numPartitions allows the keyChannels argument to be empty. If keyChannels is
 /// empty, then the resulting partition number of partition() will always be
 /// zero.
-class HashPartitionFunction : public core::PartitionFunction {
+/// Extends PartitionFunction with access to the configured number of
+/// partitions.
+class HashPartitionFunction : public HashPartitionFunctionBase {
  public:
   HashPartitionFunction(
       bool localExchange,
@@ -48,7 +57,7 @@ class HashPartitionFunction : public core::PartitionFunction {
       const RowVector& input,
       std::vector<uint32_t>& partitions) override;
 
-  int numPartitions() const {
+  int numPartitions() const override {
     return numPartitions_;
   }
 
@@ -85,7 +94,8 @@ class HashPartitionFunctionSpec : public core::PartitionFunctionSpec {
 
   std::unique_ptr<core::PartitionFunction> create(
       int numPartitions,
-      bool localExchange) const override;
+      bool localExchange,
+      bool useOptimizedPartitionFunction = false) const override;
 
   std::string toString() const override;
 
@@ -100,4 +110,22 @@ class HashPartitionFunctionSpec : public core::PartitionFunctionSpec {
   const std::vector<column_index_t> keyChannels_;
   const std::vector<VectorPtr> constValues_;
 };
+
+/// Creates either HashPartitionFunction or OptimizedHashPartitionFunction
+/// based on 'useOptimizedPartitionFunction'.
+std::unique_ptr<HashPartitionFunctionBase> createHashPartitionFunction(
+    bool localExchange,
+    int numPartitions,
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    const std::vector<VectorPtr>& constValues = {},
+    bool useOptimizedPartitionFunction = false);
+
+std::unique_ptr<HashPartitionFunctionBase> createHashPartitionFunction(
+    const HashBitRange& hashBitRange,
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    const std::vector<VectorPtr>& constValues = {},
+    bool useOptimizedPartitionFunction = false);
+
 } // namespace facebook::velox::exec

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -339,10 +339,13 @@ LocalPartition::LocalPartition(
           ctx->task->getLocalExchangeQueues(ctx->splitGroupId, planNode->id())},
       numPartitions_{queues_.size()},
       partitionFunction_(
-          numPartitions_ == 1 ? nullptr
-                              : planNode->partitionFunctionSpec().create(
-                                    numPartitions_,
-                                    /*localExchange=*/true)),
+          numPartitions_ == 1
+              ? nullptr
+              : planNode->partitionFunctionSpec().create(
+                    numPartitions_,
+                    /*localExchange=*/true,
+                    ctx->queryConfig()
+                        .optimizedHashPartitionFunctionEnabled())),
       singlePartitionBufferSize_{
           (numPartitions_ <
                ctx->queryConfig()

--- a/velox/exec/MarkDistinct.cpp
+++ b/velox/exec/MarkDistinct.cpp
@@ -356,8 +356,14 @@ void MarkDistinct::setupInputSpiller(
       &spillConfig_.value(),
       spillStats_.get());
 
-  spillHashFunction_ = std::make_unique<HashPartitionFunction>(
-      inputSpiller_->hashBits(), inputType_, distinctKeyChannels_);
+  spillHashFunction_ = createHashPartitionFunction(
+      inputSpiller_->hashBits(),
+      inputType_,
+      distinctKeyChannels_,
+      {},
+      operatorCtx_->driverCtx()
+          ->queryConfig()
+          .optimizedHashPartitionFunctionEnabled());
 }
 
 void MarkDistinct::spill() {

--- a/velox/exec/MarkDistinct.h
+++ b/velox/exec/MarkDistinct.h
@@ -106,7 +106,7 @@ class MarkDistinct : public Operator {
 
   SpillPartitionSet spillInputPartitionSet_;
 
-  std::unique_ptr<HashPartitionFunction> spillHashFunction_;
+  std::unique_ptr<HashPartitionFunctionBase> spillHashFunction_;
 
   SpillPartitionSet spillHashTablePartitionSet_;
 

--- a/velox/exec/OptimizedHashPartitionFunction.cpp
+++ b/velox/exec/OptimizedHashPartitionFunction.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) International Business Machines Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/OptimizedHashPartitionFunction.h"
+
+#include <algorithm>
+
+#include <folly/Portability.h>
+
+#include "velox/common/process/ProcessBase.h"
+
+#if defined(__AVX2__) || defined(__AVX512F__)
+#include <immintrin.h>
+#endif
+
+#define XXH_INLINE_ALL
+#include <xxhash.h> // @manual=third-party//xxHash:xxhash
+
+namespace facebook::velox::exec {
+namespace {
+// Gets the hash value for local exchange with given 'rawHash'. 'rawHash'
+// is the value computed by this hash function which is used for remote
+// shuffle across stages like for Prestissimo.
+static inline uint32_t localExchangeHash(uint32_t rawHash) {
+  // Mix the bits so we don't use the same hash used to distribute between
+  // stages.
+  bits::reverseBits(reinterpret_cast<uint8_t*>(&rawHash), sizeof(rawHash));
+  return XXH32(&rawHash, sizeof(rawHash), 0);
+}
+
+FOLLY_ALWAYS_INLINE uint32_t mixedHash(uint64_t hash) {
+  return static_cast<uint32_t>(hash) ^ static_cast<uint32_t>(hash >> 32);
+}
+
+FOLLY_ALWAYS_INLINE uint32_t
+reduceRange(uint64_t hash, uint32_t numPartitions) {
+  return (static_cast<uint64_t>(mixedHash(hash)) * numPartitions) >> 32;
+}
+
+void rangeReductionPowerOfTwo(
+    const uint64_t* hashes,
+    uint32_t* partitions,
+    vector_size_t size,
+    uint32_t numPartitions) {
+  VELOX_DCHECK(bits::isPowerOfTwo(numPartitions));
+
+  if (numPartitions == 1) {
+    std::fill(partitions, partitions + size, 0);
+    return;
+  }
+
+  const auto shift = 32 - __builtin_ctz(numPartitions);
+  for (vector_size_t index = 0; index < size; ++index) {
+    partitions[index] = mixedHash(hashes[index]) >> shift;
+  }
+}
+
+#if defined(__AVX512F__)
+void rangeReductionAvx512(
+    const uint64_t* hashes,
+    uint32_t* partitions,
+    vector_size_t size,
+    uint32_t numPartitions) {
+  const __m512i numPartitionsVec = _mm512_set1_epi64(numPartitions);
+
+  vector_size_t index = 0;
+  for (; index + 8 <= size; index += 8) {
+    const auto hashesVec =
+        _mm512_loadu_si512(reinterpret_cast<const __m512i*>(hashes + index));
+
+    const auto mixedHashesVec =
+        _mm512_xor_si512(hashesVec, _mm512_srli_epi64(hashesVec, 32));
+    const auto productVec = _mm512_mul_epu32(mixedHashesVec, numPartitionsVec);
+    const auto shiftedVec = _mm512_srli_epi64(productVec, 32);
+    const auto packedResults = _mm512_cvtepi64_epi32(shiftedVec);
+    _mm256_storeu_si256(
+        reinterpret_cast<__m256i*>(partitions + index), packedResults);
+  }
+
+  for (; index < size; ++index) {
+    partitions[index] = reduceRange(hashes[index], numPartitions);
+  }
+}
+#endif
+
+#if defined(__AVX2__)
+void rangeReductionAvx2(
+    const uint64_t* hashes,
+    uint32_t* partitions,
+    vector_size_t size,
+    uint32_t numPartitions) {
+  const auto packIndexes = _mm256_setr_epi32(0, 2, 4, 6, 0, 0, 0, 0);
+  const auto numPartitionsVec = _mm256_set1_epi64x(numPartitions);
+
+  vector_size_t index = 0;
+  for (; index + 4 <= size; index += 4) {
+    const auto hashesVec =
+        _mm256_loadu_si256(reinterpret_cast<const __m256i*>(hashes + index));
+    const auto mixedHashesVec =
+        _mm256_xor_si256(hashesVec, _mm256_srli_epi64(hashesVec, 32));
+    const auto productVec = _mm256_mul_epu32(mixedHashesVec, numPartitionsVec);
+    const auto shiftedVec = _mm256_srli_epi64(productVec, 32);
+    const auto packedResults =
+        _mm256_permutevar8x32_epi32(shiftedVec, packIndexes);
+    _mm_storeu_si128(
+        reinterpret_cast<__m128i*>(partitions + index),
+        _mm256_castsi256_si128(packedResults));
+  }
+
+  for (; index < size; ++index) {
+    partitions[index] = reduceRange(hashes[index], numPartitions);
+  }
+}
+#endif
+
+void rangeReductionImpl(
+    const uint64_t* hashes,
+    uint32_t* partitions,
+    vector_size_t size,
+    uint32_t numPartitions) {
+  if (bits::isPowerOfTwo(numPartitions)) {
+    rangeReductionPowerOfTwo(hashes, partitions, size, numPartitions);
+    return;
+  }
+
+#if defined(__AVX512F__)
+  if (process::hasAvx512f()) {
+    rangeReductionAvx512(hashes, partitions, size, numPartitions);
+    return;
+  }
+#endif
+
+#if defined(__AVX2__)
+  if (process::hasAvx2()) {
+    rangeReductionAvx2(hashes, partitions, size, numPartitions);
+    return;
+  }
+#endif
+
+  for (vector_size_t index = 0; index < size; ++index) {
+    partitions[index] = reduceRange(hashes[index], numPartitions);
+  }
+}
+
+void applyLocalExchangeHash(raw_vector<uint64_t>& hashes) {
+  for (auto& hash : hashes) {
+    hash = localExchangeHash(hash);
+  }
+}
+
+void applyHashBitRange(
+    const HashBitRange& hashBitRange,
+    const raw_vector<uint64_t>& hashes,
+    std::vector<uint32_t>& partitions) {
+  partitions.resize(hashes.size());
+  for (auto index = 0; index < hashes.size(); ++index) {
+    partitions[index] = hashBitRange.partition(hashes[index]);
+  }
+}
+
+} // namespace
+
+void rangeReduction(
+    const uint64_t* hashes,
+    uint32_t* partitions,
+    vector_size_t size,
+    uint32_t numPartitions) {
+  rangeReductionImpl(hashes, partitions, size, numPartitions);
+}
+
+OptimizedHashPartitionFunction::OptimizedHashPartitionFunction(
+    bool localExchange,
+    int numPartitions,
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    const std::vector<VectorPtr>& constValues)
+    : localExchange_{localExchange}, numPartitions_{numPartitions} {
+  init(inputType, keyChannels, constValues);
+}
+
+OptimizedHashPartitionFunction::OptimizedHashPartitionFunction(
+    const HashBitRange& hashBitRange,
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    const std::vector<VectorPtr>& constValues)
+    : localExchange_{false},
+      numPartitions_{hashBitRange.numPartitions()},
+      hashBitRange_(hashBitRange) {
+  VELOX_CHECK_GT(hashBitRange.numPartitions(), 0);
+  VELOX_CHECK(!keyChannels.empty());
+  init(inputType, keyChannels, constValues);
+}
+
+std::optional<uint32_t> OptimizedHashPartitionFunction::partition(
+    const RowVector& input,
+    std::vector<uint32_t>& partitions) {
+  if (hashers_.empty()) {
+    return 0u;
+  }
+
+  const auto size = input.size();
+  if (size == 0) {
+    partitions.clear();
+    return std::nullopt;
+  }
+
+  if (!hashBitRange_.has_value() && numPartitions_ == 1) {
+    return 0u;
+  }
+
+  rows_.resize(size);
+  rows_.setAll();
+
+  hashes_.resize(size);
+  for (auto i = 0; i < hashers_.size(); ++i) {
+    auto& hasher = hashers_[i];
+    if (hasher->channel() != kConstantChannel) {
+      hashers_[i]->decode(*input.childAt(hasher->channel()), rows_);
+      hashers_[i]->hash(rows_, i > 0, hashes_);
+    } else {
+      hashers_[i]->hashPrecomputed(i > 0, hashes_);
+    }
+  }
+
+  if (localExchange_) {
+    applyLocalExchangeHash(hashes_);
+  }
+
+  if (hashBitRange_.has_value()) {
+    applyHashBitRange(*hashBitRange_, hashes_, partitions);
+  } else {
+    partitions.resize(size);
+    rangeReduction(hashes_.data(), partitions.data(), size, numPartitions_);
+  }
+
+  return std::nullopt;
+}
+
+void OptimizedHashPartitionFunction::init(
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& keyChannels,
+    const std::vector<VectorPtr>& constValues) {
+  hashers_.reserve(keyChannels.size());
+  size_t constChannel{0};
+  for (const auto channel : keyChannels) {
+    if (channel != kConstantChannel) {
+      hashers_.emplace_back(
+          OptimizedVectorHasher::create(inputType->childAt(channel), channel));
+    } else {
+      const auto& constValue = constValues[constChannel++];
+      hashers_.emplace_back(
+          OptimizedVectorHasher::create(constValue->type(), channel));
+      hashers_.back()->precompute(*constValue);
+    }
+  }
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/OptimizedHashPartitionFunction.h
+++ b/velox/exec/OptimizedHashPartitionFunction.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) International Business Machines Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/HashPartitionFunction.h"
+#include "velox/exec/OptimizedVectorHasher.h"
+
+namespace facebook::velox::exec {
+
+/// Maps hashes to partitions using range reduction. Visible for testing.
+void rangeReduction(
+    const uint64_t* hashes,
+    uint32_t* partitions,
+    vector_size_t size,
+    uint32_t numPartitions);
+
+/// Calculates partition numbers using OptimizedVectorHasher.
+class OptimizedHashPartitionFunction : public HashPartitionFunctionBase {
+ public:
+  OptimizedHashPartitionFunction(
+      bool localExchange,
+      int numPartitions,
+      const RowTypePtr& inputType,
+      const std::vector<column_index_t>& keyChannels,
+      const std::vector<VectorPtr>& constValues = {});
+
+  OptimizedHashPartitionFunction(
+      const HashBitRange& hashBitRange,
+      const RowTypePtr& inputType,
+      const std::vector<column_index_t>& keyChannels,
+      const std::vector<VectorPtr>& constValues = {});
+
+  ~OptimizedHashPartitionFunction() override = default;
+
+  std::optional<uint32_t> partition(
+      const RowVector& input,
+      std::vector<uint32_t>& partitions) override;
+
+  int numPartitions() const override {
+    return numPartitions_;
+  }
+
+ private:
+  void init(
+      const RowTypePtr& inputType,
+      const std::vector<column_index_t>& keyChannels,
+      const std::vector<VectorPtr>& constValues);
+
+  const bool localExchange_;
+  const int numPartitions_;
+  const std::optional<HashBitRange> hashBitRange_ = std::nullopt;
+  std::vector<std::unique_ptr<OptimizedVectorHasher>> hashers_;
+
+  // Reusable memory.
+  SelectivityVector rows_;
+  raw_vector<uint64_t> hashes_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/OptimizedPartitionedOutput.cpp
+++ b/velox/exec/OptimizedPartitionedOutput.cpp
@@ -52,9 +52,11 @@ OptimizedPartitionedOutput::OptimizedPartitionedOutput(
                                 .maxPartitionedOutputBufferSize()),
       pool_(pool()),
       partitionFunction_(
-          numDestinations_ == 1
-              ? nullptr
-              : planNode->partitionFunctionSpec().create(numDestinations_)) {
+          numDestinations_ == 1 ? nullptr
+                                : planNode->partitionFunctionSpec().create(
+                                      numDestinations_,
+                                      /*localExchange=*/false,
+                                      true)) {
   if (!planNode->isPartitioned()) {
     VELOX_USER_CHECK_EQ(numDestinations_, 1);
   }

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -207,10 +207,13 @@ PartitionedOutput::PartitionedOutput(
       numDestinations_(planNode->numPartitions()),
       replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),
       partitionFunction_(
-          numDestinations_ == 1 ? nullptr
-                                : planNode->partitionFunctionSpec().create(
-                                      numDestinations_,
-                                      /*localExchange=*/false)),
+          numDestinations_ == 1
+              ? nullptr
+              : planNode->partitionFunctionSpec().create(
+                    numDestinations_,
+                    /*localExchange=*/false,
+                    ctx->queryConfig()
+                        .optimizedHashPartitionFunctionEnabled())),
       outputChannels_(calculateOutputChannels(
           planNode->inputType(),
           planNode->outputType(),

--- a/velox/exec/RoundRobinPartitionFunction.h
+++ b/velox/exec/RoundRobinPartitionFunction.h
@@ -43,7 +43,8 @@ class RoundRobinPartitionFunctionSpec : public core::PartitionFunctionSpec {
  public:
   std::unique_ptr<core::PartitionFunction> create(
       int numPartitions,
-      bool /*localExchange*/) const override {
+      bool /*localExchange*/,
+      bool /*useOptimizedPartitionFunction*/ = false) const override {
     return std::make_unique<velox::exec::RoundRobinPartitionFunction>(
         numPartitions);
   }

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -449,8 +449,14 @@ void RowNumber::setupInputSpiller(
     keyChannels.push_back(hasher->channel());
   }
 
-  spillHashFunction_ = std::make_unique<HashPartitionFunction>(
-      inputSpiller_->hashBits(), inputType_, keyChannels);
+  spillHashFunction_ = createHashPartitionFunction(
+      inputSpiller_->hashBits(),
+      inputType_,
+      keyChannels,
+      {},
+      operatorCtx_->driverCtx()
+          ->queryConfig()
+          .optimizedHashPartitionFunctionEnabled());
 }
 
 void RowNumber::spill() {

--- a/velox/exec/RowNumber.h
+++ b/velox/exec/RowNumber.h
@@ -142,7 +142,7 @@ class RowNumber : public Operator {
   SpillPartitionSet spillInputPartitionSet_;
 
   // Used to calculate the spill partition numbers of the inputs.
-  std::unique_ptr<HashPartitionFunction> spillHashFunction_;
+  std::unique_ptr<HashPartitionFunctionBase> spillHashFunction_;
 
   // The cpu may be voluntarily yield after running too long when processing
   // input from spilled file.

--- a/velox/exec/ScaleWriterLocalPartition.cpp
+++ b/velox/exec/ScaleWriterLocalPartition.cpp
@@ -57,7 +57,10 @@ ScaleWriterPartitioningLocalPartition::ScaleWriterPartitioningLocalPartition(
       ? nullptr
       : planNode->partitionFunctionSpec().create(
             numTablePartitions_,
-            /*localExchange=*/true);
+            /*localExchange=*/true,
+            operatorCtx_->driverCtx()
+                ->queryConfig()
+                .optimizedHashPartitionFunctionEnabled());
 }
 
 void ScaleWriterPartitioningLocalPartition::initialize() {

--- a/velox/exec/SubPartitionedSortWindowBuild.cpp
+++ b/velox/exec/SubPartitionedSortWindowBuild.cpp
@@ -22,6 +22,7 @@ namespace facebook::velox::exec {
 SubPartitionedSortWindowBuild::SubPartitionedSortWindowBuild(
     const std::shared_ptr<const core::WindowNode>& node,
     int32_t numSubPartitions,
+    const core::QueryConfig& queryConfig,
     velox::memory::MemoryPool* pool,
     common::PrefixSortConfig&& prefixSortConfig,
     const common::SpillConfig* spillConfig,
@@ -40,8 +41,13 @@ SubPartitionedSortWindowBuild::SubPartitionedSortWindowBuild(
   for (int i = 0; i < numPartitionKeys_; i++) {
     keyChannels[i] = inputChannels_[i];
   }
-  subPartitioningFunction_ = std::make_unique<HashPartitionFunction>(
-      false, numSubPartitions_, node->inputType(), keyChannels);
+  subPartitioningFunction_ = createHashPartitionFunction(
+      /*localExchange=*/false,
+      numSubPartitions_,
+      node->inputType(),
+      keyChannels,
+      {},
+      queryConfig.optimizedHashPartitionFunctionEnabled());
   subWindowBuilds_.resize(numSubPartitions_);
   for (int i = 0; i < numSubPartitions_; i++) {
     subWindowBuilds_[i] = std::make_unique<SortWindowBuild>(
@@ -59,7 +65,12 @@ void SubPartitionedSortWindowBuild::addInput(RowVectorPtr input) {
   VELOX_CHECK_LT(currentSubPartition_, 0);
 
   subPartitionIdsBuffer_.resize(input->size());
-  subPartitioningFunction_->partition(*input, subPartitionIdsBuffer_);
+  std::optional<uint32_t> singlePartition =
+      subPartitioningFunction_->partition(*input, subPartitionIdsBuffer_);
+  if (singlePartition.has_value()) {
+    simd::simdFill<uint32_t>(
+        subPartitionIdsBuffer_.data(), singlePartition.value(), input->size());
+  }
 
   for (auto i = 0; i < inputChannels_.size(); ++i) {
     decodedInputVectors_[i].decode(*input->childAt(inputChannels_[i]));

--- a/velox/exec/SubPartitionedSortWindowBuild.h
+++ b/velox/exec/SubPartitionedSortWindowBuild.h
@@ -33,6 +33,7 @@ class SubPartitionedSortWindowBuild : public WindowBuild {
   SubPartitionedSortWindowBuild(
       const std::shared_ptr<const core::WindowNode>& node,
       int32_t numSubPartitions,
+      const core::QueryConfig& queryConfig,
       velox::memory::MemoryPool* pool,
       common::PrefixSortConfig&& prefixSortConfig,
       const common::SpillConfig* spillConfig,
@@ -80,7 +81,7 @@ class SubPartitionedSortWindowBuild : public WindowBuild {
   exec::SpillStats* const spillStats_;
 
   // Divide input rows to the corresponding sub partitions.
-  std::unique_ptr<HashPartitionFunction> subPartitioningFunction_;
+  std::unique_ptr<HashPartitionFunctionBase> subPartitioningFunction_;
 
   // WindowBuilds for each sub partition.
   std::vector<std::unique_ptr<SortWindowBuild>> subWindowBuilds_;

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -75,6 +75,7 @@ Window::Window(
       windowBuild_ = std::make_unique<SubPartitionedSortWindowBuild>(
           windowNode,
           numSubPartitions,
+          driverCtx->queryConfig(),
           pool(),
           makePrefixSortConfig(driverCtx->queryConfig()),
           spillConfig,

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -29,6 +29,18 @@ target_link_libraries(
   Folly::follybenchmark
 )
 
+add_executable(
+  velox_exec_optimized_hash_partition_function_benchmark
+  OptimizedHashPartitionFunctionBenchmark.cpp
+)
+
+target_link_libraries(
+  velox_exec_optimized_hash_partition_function_benchmark
+  velox_exec
+  velox_vector_test_lib
+  Folly::follybenchmark
+)
+
 add_executable(velox_filter_project_benchmark FilterProjectBenchmark.cpp)
 
 target_link_libraries(

--- a/velox/exec/benchmarks/OptimizedHashPartitionFunctionBenchmark.cpp
+++ b/velox/exec/benchmarks/OptimizedHashPartitionFunctionBenchmark.cpp
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) International Business Machines Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <array>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/exec/OptimizedHashPartitionFunction.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+// Add the following definitions to allow Clion runs.
+DEFINE_bool(gtest_color, false, "");
+DEFINE_string(gtest_filter, "*", "");
+
+using namespace facebook;
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+namespace {
+
+constexpr vector_size_t kSize = 10'000;
+constexpr vector_size_t kDictionarySize = kSize / 5;
+
+enum class FunctionKind {
+  kNormal,
+  kOptimized,
+};
+
+enum class EncodingMode {
+  kFlat,
+  kDictionary,
+  kConstant,
+};
+
+enum class NullMode {
+  kNoNulls,
+  kHalfNulls,
+  kAllNulls,
+};
+
+enum class PartitionMode {
+  kRemote,
+  kLocalExchange,
+  kHashBitRangeFirst8,
+  kHashBitRangeLast8,
+};
+
+template <typename T>
+T makeValue(vector_size_t row) {
+  return static_cast<T>((row * 8191) ^ (row >> 3));
+}
+
+template <>
+bool makeValue<bool>(vector_size_t row) {
+  return (row & 1) == 0;
+}
+
+template <>
+StringView makeValue<StringView>(vector_size_t row) {
+  thread_local std::array<char, 20> buffer;
+  const auto length = 5 + row % 16;
+  for (vector_size_t index = 0; index < length; ++index) {
+    buffer[index] = 'a' + (row + index * 7) % 26;
+  }
+  return StringView(buffer.data(), length);
+}
+
+std::function<bool(vector_size_t)> makeNulls(NullMode nullMode) {
+  switch (nullMode) {
+    case NullMode::kNoNulls:
+      return nullptr;
+    case NullMode::kHalfNulls:
+      return [](vector_size_t row) { return (row & 1) == 0; };
+    case NullMode::kAllNulls:
+      return [](vector_size_t /*row*/) { return true; };
+  }
+
+  VELOX_UNREACHABLE();
+}
+
+VectorPtr wrapInDictionary(
+    const VectorPtr& base,
+    vector_size_t size,
+    memory::MemoryPool* pool,
+    NullMode nullMode = NullMode::kNoNulls) {
+  auto indices = AlignedBuffer::allocate<vector_size_t>(size, pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  const auto baseSize = base->size();
+  for (vector_size_t row = 0; row < size; ++row) {
+    rawIndices[row] = (size - row - 1) % baseSize;
+  }
+
+  BufferPtr nulls;
+  if (nullMode == NullMode::kHalfNulls) {
+    nulls = AlignedBuffer::allocate<bool>(size, pool);
+    auto* rawNulls = nulls->asMutable<uint64_t>();
+    bits::fillBits(rawNulls, 0, size, bits::kNotNull);
+    for (vector_size_t row = 0; row < size; row += 2) {
+      bits::setNull(rawNulls, row);
+    }
+  } else if (nullMode == NullMode::kAllNulls) {
+    nulls = AlignedBuffer::allocate<bool>(size, pool);
+    auto* rawNulls = nulls->asMutable<uint64_t>();
+    bits::fillBits(rawNulls, 0, size, bits::kNull);
+  }
+
+  return BaseVector::wrapInDictionary(nulls, indices, size, base);
+}
+
+template <typename T>
+VectorPtr makeValuesVector(
+    VectorMaker& vectorMaker,
+    memory::MemoryPool* pool,
+    EncodingMode encodingMode,
+    NullMode nullMode,
+    vector_size_t size) {
+  const auto flatSize =
+      encodingMode == EncodingMode::kDictionary ? kDictionarySize : size;
+  auto flat = vectorMaker.flatVector<T>(
+      flatSize,
+      [](vector_size_t row) { return makeValue<T>(row); },
+      makeNulls(nullMode));
+
+  switch (encodingMode) {
+    case EncodingMode::kFlat:
+      return flat;
+    case EncodingMode::kDictionary:
+      return wrapInDictionary(flat, size, pool);
+    case EncodingMode::kConstant:
+      if (nullMode == NullMode::kAllNulls) {
+        return BaseVector::createNullConstant(
+            CppToType<T>::create(), size, pool);
+      }
+      if (nullMode == NullMode::kHalfNulls) {
+        auto constant = BaseVector::wrapInConstant(size, 1, flat);
+        // ConstantVector has one nullness for all logical rows. Use a
+        // dictionary wrapper to express alternating nulls while keeping the
+        // repeated-value payload constant.
+        return wrapInDictionary(constant, size, pool, nullMode);
+      }
+      return BaseVector::wrapInConstant(size, 0, flat);
+  }
+
+  VELOX_UNREACHABLE();
+}
+
+template <FunctionKind Kind>
+std::unique_ptr<HashPartitionFunctionBase> makePartitionFunction(
+    PartitionMode partitionMode,
+    const RowTypePtr& inputType,
+    int numPartitions) {
+  switch (partitionMode) {
+    case PartitionMode::kRemote:
+      if constexpr (Kind == FunctionKind::kNormal) {
+        return std::make_unique<HashPartitionFunction>(
+            false, numPartitions, inputType, std::vector<column_index_t>{0});
+      } else {
+        return std::make_unique<OptimizedHashPartitionFunction>(
+            false, numPartitions, inputType, std::vector<column_index_t>{0});
+      }
+    case PartitionMode::kLocalExchange:
+      if constexpr (Kind == FunctionKind::kNormal) {
+        return std::make_unique<HashPartitionFunction>(
+            true, numPartitions, inputType, std::vector<column_index_t>{0});
+      } else {
+        return std::make_unique<OptimizedHashPartitionFunction>(
+            true, numPartitions, inputType, std::vector<column_index_t>{0});
+      }
+    case PartitionMode::kHashBitRangeFirst8:
+      if constexpr (Kind == FunctionKind::kNormal) {
+        return std::make_unique<HashPartitionFunction>(
+            HashBitRange{0, 8}, inputType, std::vector<column_index_t>{0});
+      } else {
+        return std::make_unique<OptimizedHashPartitionFunction>(
+            HashBitRange{0, 8}, inputType, std::vector<column_index_t>{0});
+      }
+    case PartitionMode::kHashBitRangeLast8:
+      if constexpr (Kind == FunctionKind::kNormal) {
+        return std::make_unique<HashPartitionFunction>(
+            HashBitRange{56, 64}, inputType, std::vector<column_index_t>{0});
+      } else {
+        return std::make_unique<OptimizedHashPartitionFunction>(
+            HashBitRange{56, 64}, inputType, std::vector<column_index_t>{0});
+      }
+  }
+
+  VELOX_UNREACHABLE();
+}
+
+void normalRangeReduction(
+    const uint64_t* hashes,
+    uint32_t* partitions,
+    int size,
+    uint32_t numPartitions) {
+  for (int index = 0; index < size; ++index) {
+    partitions[index] = hashes[index] % numPartitions;
+  }
+}
+
+template <FunctionKind Kind>
+void runRangeReductionBenchmark(uint32_t iterations, uint32_t numPartitions) {
+  folly::BenchmarkSuspender suspender;
+
+  std::vector<uint64_t> hashes(kSize);
+  std::vector<uint32_t> partitions(kSize);
+  for (vector_size_t row = 0; row < kSize; ++row) {
+    hashes[row] = (static_cast<uint64_t>(row * 8191) << 32) ^
+        static_cast<uint64_t>(row * 1315423911ULL + 17);
+  }
+
+  suspender.dismiss();
+
+  for (uint32_t iteration = 0; iteration < iterations; ++iteration) {
+    if constexpr (Kind == FunctionKind::kNormal) {
+      normalRangeReduction(
+          hashes.data(), partitions.data(), kSize, numPartitions);
+    } else {
+      rangeReduction(hashes.data(), partitions.data(), kSize, numPartitions);
+    }
+    folly::doNotOptimizeAway(partitions.data());
+  }
+}
+
+template <typename T, FunctionKind Kind>
+void runPartitionBenchmark(
+    uint32_t iterations,
+    PartitionMode partitionMode,
+    EncodingMode encodingMode,
+    NullMode nullMode,
+    int numPartitions) {
+  folly::BenchmarkSuspender suspender;
+
+  auto pool = memory::memoryManager()->addLeafPool();
+  VectorMaker vectorMaker(pool.get());
+  auto values = makeValuesVector<T>(
+      vectorMaker, pool.get(), encodingMode, nullMode, kSize);
+  auto input = vectorMaker.rowVector({values});
+  auto partitionFunction = makePartitionFunction<Kind>(
+      partitionMode, asRowType(input->type()), numPartitions);
+  std::vector<uint32_t> partitions;
+
+  suspender.dismiss();
+
+  for (uint32_t iteration = 0; iteration < iterations; ++iteration) {
+    std::optional<uint32_t> singlePartition =
+        partitionFunction->partition(*input, partitions);
+    if (singlePartition.has_value()) {
+      std::fill(partitions.begin(), partitions.end(), singlePartition.value());
+    }
+    folly::doNotOptimizeAway(partitions.data());
+  }
+}
+
+template <typename T>
+void benchmarkNormalHashPartitionFunction(
+    uint32_t iterations,
+    PartitionMode partitionMode,
+    EncodingMode encodingMode,
+    NullMode nullMode,
+    int numPartitions) {
+  runPartitionBenchmark<T, FunctionKind::kNormal>(
+      iterations, partitionMode, encodingMode, nullMode, numPartitions);
+}
+
+template <typename T>
+void benchmarkOptimizedHashPartitionFunction(
+    uint32_t iterations,
+    PartitionMode partitionMode,
+    EncodingMode encodingMode,
+    NullMode nullMode,
+    int numPartitions) {
+  runPartitionBenchmark<T, FunctionKind::kOptimized>(
+      iterations, partitionMode, encodingMode, nullMode, numPartitions);
+}
+
+#define REGISTER_PARTITION_PAIR(                                                                                  \
+    T,                                                                                                            \
+    TYPE_NAME,                                                                                                    \
+    PARTITION_MODE,                                                                                               \
+    PARTITION_NAME,                                                                                               \
+    NUM_PARTITIONS,                                                                                               \
+    NUM_PARTITIONS_NAME,                                                                                          \
+    ENCODING_MODE,                                                                                                \
+    ENCODING_NAME,                                                                                                \
+    NULL_MODE,                                                                                                    \
+    NULL_NAME)                                                                                                    \
+  BENCHMARK(                                                                                                      \
+      partition_##TYPE_NAME##_##PARTITION_NAME##_##NUM_PARTITIONS_NAME##_##ENCODING_NAME##_##NULL_NAME,           \
+      iterations) {                                                                                               \
+    benchmarkNormalHashPartitionFunction<T>(                                                                      \
+        iterations, PARTITION_MODE, ENCODING_MODE, NULL_MODE, NUM_PARTITIONS);                                    \
+  }                                                                                                               \
+  BENCHMARK_RELATIVE(                                                                                             \
+      optimized_partition_##TYPE_NAME##_##PARTITION_NAME##_##NUM_PARTITIONS_NAME##_##ENCODING_NAME##_##NULL_NAME, \
+      iterations) {                                                                                               \
+    benchmarkOptimizedHashPartitionFunction<T>(                                                                   \
+        iterations, PARTITION_MODE, ENCODING_MODE, NULL_MODE, NUM_PARTITIONS);                                    \
+  }                                                                                                               \
+  BENCHMARK_DRAW_LINE();
+
+#define REGISTER_PARTITION_NULL_MODES( \
+    T,                                 \
+    TYPE_NAME,                         \
+    PARTITION_MODE,                    \
+    PARTITION_NAME,                    \
+    NUM_PARTITIONS,                    \
+    NUM_PARTITIONS_NAME,               \
+    ENCODING_MODE,                     \
+    ENCODING_NAME)                     \
+  REGISTER_PARTITION_PAIR(             \
+      T,                               \
+      TYPE_NAME,                       \
+      PARTITION_MODE,                  \
+      PARTITION_NAME,                  \
+      NUM_PARTITIONS,                  \
+      NUM_PARTITIONS_NAME,             \
+      ENCODING_MODE,                   \
+      ENCODING_NAME,                   \
+      NullMode::kNoNulls,              \
+      no_null)                         \
+  REGISTER_PARTITION_PAIR(             \
+      T,                               \
+      TYPE_NAME,                       \
+      PARTITION_MODE,                  \
+      PARTITION_NAME,                  \
+      NUM_PARTITIONS,                  \
+      NUM_PARTITIONS_NAME,             \
+      ENCODING_MODE,                   \
+      ENCODING_NAME,                   \
+      NullMode::kHalfNulls,            \
+      half_null)                       \
+  REGISTER_PARTITION_PAIR(             \
+      T,                               \
+      TYPE_NAME,                       \
+      PARTITION_MODE,                  \
+      PARTITION_NAME,                  \
+      NUM_PARTITIONS,                  \
+      NUM_PARTITIONS_NAME,             \
+      ENCODING_MODE,                   \
+      ENCODING_NAME,                   \
+      NullMode::kAllNulls,             \
+      all_null)
+
+#define REGISTER_PARTITION_ENCODINGS( \
+    T,                                \
+    TYPE_NAME,                        \
+    PARTITION_MODE,                   \
+    PARTITION_NAME,                   \
+    NUM_PARTITIONS,                   \
+    NUM_PARTITIONS_NAME)              \
+  REGISTER_PARTITION_NULL_MODES(      \
+      T,                              \
+      TYPE_NAME,                      \
+      PARTITION_MODE,                 \
+      PARTITION_NAME,                 \
+      NUM_PARTITIONS,                 \
+      NUM_PARTITIONS_NAME,            \
+      EncodingMode::kFlat,            \
+      flat)                           \
+  REGISTER_PARTITION_NULL_MODES(      \
+      T,                              \
+      TYPE_NAME,                      \
+      PARTITION_MODE,                 \
+      PARTITION_NAME,                 \
+      NUM_PARTITIONS,                 \
+      NUM_PARTITIONS_NAME,            \
+      EncodingMode::kDictionary,      \
+      dictionary)                     \
+  REGISTER_PARTITION_NULL_MODES(      \
+      T,                              \
+      TYPE_NAME,                      \
+      PARTITION_MODE,                 \
+      PARTITION_NAME,                 \
+      NUM_PARTITIONS,                 \
+      NUM_PARTITIONS_NAME,            \
+      EncodingMode::kConstant,        \
+      constant)
+
+#define REGISTER_PARTITION_COUNTS(                                \
+    T, TYPE_NAME, PARTITION_MODE, PARTITION_NAME)                 \
+  REGISTER_PARTITION_ENCODINGS(                                   \
+      T, TYPE_NAME, PARTITION_MODE, PARTITION_NAME, 1, p1)        \
+  REGISTER_PARTITION_ENCODINGS(                                   \
+      T, TYPE_NAME, PARTITION_MODE, PARTITION_NAME, 4, p4)        \
+  REGISTER_PARTITION_ENCODINGS(                                   \
+      T, TYPE_NAME, PARTITION_MODE, PARTITION_NAME, 16, p16)      \
+  REGISTER_PARTITION_ENCODINGS(                                   \
+      T, TYPE_NAME, PARTITION_MODE, PARTITION_NAME, 100, p100)    \
+  REGISTER_PARTITION_ENCODINGS(                                   \
+      T, TYPE_NAME, PARTITION_MODE, PARTITION_NAME, 1'000, p1000) \
+  REGISTER_PARTITION_ENCODINGS(                                   \
+      T, TYPE_NAME, PARTITION_MODE, PARTITION_NAME, 1'024, p1024)
+
+#define REGISTER_PARTITION_MODES(T, TYPE_NAME)                            \
+  REGISTER_PARTITION_COUNTS(T, TYPE_NAME, PartitionMode::kRemote, remote) \
+  REGISTER_PARTITION_COUNTS(                                              \
+      T, TYPE_NAME, PartitionMode::kLocalExchange, local_exchange)        \
+  REGISTER_PARTITION_ENCODINGS(                                           \
+      T,                                                                  \
+      TYPE_NAME,                                                          \
+      PartitionMode::kHashBitRangeFirst8,                                 \
+      hashbits_0_8,                                                       \
+      0,                                                                  \
+      hashbits)                                                           \
+  REGISTER_PARTITION_ENCODINGS(                                           \
+      T,                                                                  \
+      TYPE_NAME,                                                          \
+      PartitionMode::kHashBitRangeLast8,                                  \
+      hashbits_last_8,                                                    \
+      0,                                                                  \
+      hashbits)
+
+REGISTER_PARTITION_MODES(bool, bool)
+REGISTER_PARTITION_MODES(int8_t, tinyint)
+REGISTER_PARTITION_MODES(int16_t, smallint)
+REGISTER_PARTITION_MODES(int32_t, integer)
+REGISTER_PARTITION_MODES(int64_t, bigint)
+REGISTER_PARTITION_MODES(StringView, varchar)
+
+#define REGISTER_RANGE_REDUCTION_PAIR(NUM_PARTITIONS, NUM_PARTITIONS_NAME) \
+  BENCHMARK(normal_range_reduction_##NUM_PARTITIONS_NAME, iterations) {    \
+    runRangeReductionBenchmark<FunctionKind::kNormal>(                     \
+        iterations, NUM_PARTITIONS);                                       \
+  }                                                                        \
+  BENCHMARK_RELATIVE(                                                      \
+      optimized_range_reduction_##NUM_PARTITIONS_NAME, iterations) {       \
+    runRangeReductionBenchmark<FunctionKind::kOptimized>(                  \
+        iterations, NUM_PARTITIONS);                                       \
+  }                                                                        \
+  BENCHMARK_DRAW_LINE();
+
+REGISTER_RANGE_REDUCTION_PAIR(1, p1)
+REGISTER_RANGE_REDUCTION_PAIR(4, p4)
+REGISTER_RANGE_REDUCTION_PAIR(16, p16)
+REGISTER_RANGE_REDUCTION_PAIR(100, p100)
+REGISTER_RANGE_REDUCTION_PAIR(1'000, p1000)
+REGISTER_RANGE_REDUCTION_PAIR(1'024, p1024)
+
+#undef REGISTER_PARTITION_MODES
+#undef REGISTER_PARTITION_COUNTS
+#undef REGISTER_PARTITION_ENCODINGS
+#undef REGISTER_PARTITION_NULL_MODES
+#undef REGISTER_PARTITION_PAIR
+#undef REGISTER_RANGE_REDUCTION_PAIR
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ set(
   EnforceDistinctTest.cpp
   TraceUtilTest.cpp
   HashPartitionFunctionTest.cpp
+  OptimizedHashPartitionFunctionTest.cpp
   SpatialIndexTest.cpp
   ValuesTest.cpp
   ParallelProjectTest.cpp

--- a/velox/exec/tests/OptimizedHashPartitionFunctionTest.cpp
+++ b/velox/exec/tests/OptimizedHashPartitionFunctionTest.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) International Business Machines Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/OptimizedHashPartitionFunction.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook;
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+class OptimizedHashPartitionFunctionTest : public velox::test::VectorTestBase,
+                                           public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+};
+
+TEST_F(
+    OptimizedHashPartitionFunctionTest,
+    powerOfTwoRangeReductionMatchesMultiplyHigh) {
+  const std::vector<uint64_t> hashes = {
+      0,
+      1,
+      0x0000'0001'0000'0000ULL,
+      0x1234'5678'9abc'def0ULL,
+      0xffff'ffff'ffff'ffffULL,
+  };
+
+  for (const auto numPartitions : {1, 2, 4, 1'024}) {
+    std::vector<uint32_t> partitions(hashes.size());
+    rangeReduction(
+        hashes.data(),
+        partitions.data(),
+        static_cast<vector_size_t>(hashes.size()),
+        numPartitions);
+
+    std::vector<uint32_t> expected;
+    expected.reserve(hashes.size());
+    for (const auto hash : hashes) {
+      const auto mixedHash =
+          static_cast<uint32_t>(hash) ^ static_cast<uint32_t>(hash >> 32);
+      expected.push_back(
+          (static_cast<uint64_t>(mixedHash) * numPartitions) >> 32);
+    }
+
+    EXPECT_EQ(partitions, expected);
+  }
+}
+
+TEST_F(
+    OptimizedHashPartitionFunctionTest,
+    optimizedHashBitRangeMatchesRegular) {
+  const auto numRows = 10'000;
+  auto input = makeRowVector(
+      {makeNullableFlatVector<int64_t>([&] {
+         std::vector<std::optional<int64_t>> values;
+         values.reserve(numRows);
+         for (auto row = 0; row < numRows; ++row) {
+           values.emplace_back(
+               row % 17 == 0 ? std::nullopt : std::optional<int64_t>(row * 13));
+         }
+         return values;
+       }()),
+       makeFlatVector<StringView>(numRows, [](auto row) {
+         return StringView::makeInline(fmt::format("value_{}", row % 97));
+       })});
+  const auto rowType = asRowType(input->type());
+
+  HashPartitionFunction regular(HashBitRange{0, 5}, rowType, {0, 1});
+  OptimizedHashPartitionFunction optimized(HashBitRange{0, 5}, rowType, {0, 1});
+
+  std::vector<uint32_t> regularPartitions;
+  std::vector<uint32_t> optimizedPartitions;
+  EXPECT_EQ(
+      regular.partition(*input, regularPartitions),
+      optimized.partition(*input, optimizedPartitions));
+  EXPECT_EQ(regularPartitions, optimizedPartitions);
+}
+
+TEST_F(OptimizedHashPartitionFunctionTest, onePartitionReturnsConstantResult) {
+  auto input = makeRowVector({makeConstant(true, 10'000)});
+  const auto rowType = asRowType(input->type());
+  OptimizedHashPartitionFunction partitionFunction(
+      /*localExchange=*/true, 1, rowType, {0});
+
+  std::vector<uint32_t> partitions{123};
+  EXPECT_EQ(partitionFunction.partition(*input, partitions), 0u);
+  EXPECT_EQ(partitions, std::vector<uint32_t>{123});
+}
+
+TEST_F(OptimizedHashPartitionFunctionTest, emptyConstantKeyReturnsEmptyResult) {
+  auto input = makeRowVector({makeConstant(true, 0)});
+  const auto rowType = asRowType(input->type());
+  OptimizedHashPartitionFunction optimized(
+      /*localExchange=*/true, 16, rowType, {0});
+
+  std::vector<uint32_t> optimizedPartitions{123};
+  EXPECT_EQ(optimized.partition(*input, optimizedPartitions), std::nullopt);
+  EXPECT_TRUE(optimizedPartitions.empty());
+}
+
+TEST_F(OptimizedHashPartitionFunctionTest, specUsesConfiguredImplementation) {
+  auto input = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3, 4}),
+       makeFlatVector<StringView>({"a", "b", "c", "d"})});
+  const auto rowType = asRowType(input->type());
+  HashPartitionFunctionSpec spec(rowType, std::vector<column_index_t>{0, 1});
+  auto optimizedFunction = spec.create(8, /*localExchange=*/false, true);
+  ASSERT_NE(
+      dynamic_cast<OptimizedHashPartitionFunction*>(optimizedFunction.get()),
+      nullptr);
+
+  auto regularFunction = spec.create(8, /*localExchange=*/false);
+  ASSERT_NE(
+      dynamic_cast<HashPartitionFunction*>(regularFunction.get()), nullptr);
+
+  std::vector<uint32_t> optimizedPartitions;
+  ASSERT_EQ(
+      optimizedFunction->partition(*input, optimizedPartitions), std::nullopt);
+  ASSERT_EQ(optimizedPartitions.size(), input->size());
+  for (const auto partition : optimizedPartitions) {
+    EXPECT_LT(partition, 8);
+  }
+}

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1689,7 +1689,8 @@ class RoundRobinRowPartitionFunctionSpec : public core::PartitionFunctionSpec {
  public:
   std::unique_ptr<core::PartitionFunction> create(
       int numPartitions,
-      bool /*localExchange*/) const override {
+      bool /*localExchange*/,
+      bool /*useOptimizedPartitionFunction*/ = false) const override {
     return std::make_unique<RoundRobinRowPartitionFunction>(numPartitions);
   }
 

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -55,6 +55,8 @@ DEFINE_int32(
 
 DEFINE_bool(avx2, true, "Enables use of AVX2 when available");
 
+DEFINE_bool(avx512f, true, "Enables use of AVX512F when available");
+
 DEFINE_bool(bmi2, true, "Enables use of BMI2 when available");
 
 // Used in exec/Expr.cpp

--- a/velox/vector/tests/utils/PartitionedVectorTestBase.cpp
+++ b/velox/vector/tests/utils/PartitionedVectorTestBase.cpp
@@ -98,8 +98,12 @@ std::vector<VectorPtr> PartitionedVectorTestBase::partitionRowVectors(
   std::vector<uint32_t> partitions(totalNumRows, 0);
   if (numPartitions > 1) {
     auto rowType = asRowType(mergedRowVector->type());
-    //    auto partitionFunction = createPartitionFunction(rowType, {0});
-    partitionFunction->partition(*mergedRowVector->as<RowVector>(), partitions);
+    std::optional<uint32_t> singlePartition = partitionFunction->partition(
+        *mergedRowVector->as<RowVector>(), partitions);
+    if (singlePartition.has_value()) {
+      // All rows go to the same partition
+      std::fill(partitions.begin(), partitions.end(), singlePartition.value());
+    }
   }
 
   std::vector<VectorPtr> partitionedVectors =


### PR DESCRIPTION
This PR contains 2 commits:
1. perf: Add AVX512 support
2. Introduce OptimizedHashPartitionFunction
    Introduce OptimizedHashPartitionFunction as a faster drop-in replacement
    for HashPartitionFunction, gated behind a new query config flag
    optimized_hash_partition_function_enabled (default false). partition()
    is improved from 50% to over 200x.

    Add HashPartitionFunctionBase as a common base exposing numPartitions(),
    and createHashPartitionFunction() factories that select the
    implementation based on the flag. Thread QueryConfig* through
    PartitionFunctionSpec::create() and update callsites (LocalPartition,
    PartitionedOutput, MarkDistinct, RowNumber, Window,
    SubPartitionedSortWindowBuild, HiveConnector) to construct partition
    functions via the factory.

    Register CMake targets for the new test and benchmark binaries.