### PR TITLE
Add fileNameGenerator to the constructor of IcebergInsertTableHandle

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -85,20 +85,7 @@ folly::dynamic extractPartitionValue<TypeKind::TIMESTAMP>(
   return timestamp.toMicros();
 }
 
-class IcebergFileNameGenerator : public FileNameGenerator {
- public:
-  IcebergFileNameGenerator() {}
-
-  std::pair<std::string, std::string> gen(
-      std::optional<uint32_t> bucketId,
-      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-      const ConnectorQueryCtx& connectorQueryCtx,
-      bool commitRequired) const override;
-
-  folly::dynamic serialize() const override;
-
-  std::string toString() const override;
-};
+} // namespace
 
 std::pair<std::string, std::string> IcebergFileNameGenerator::gen(
     std::optional<uint32_t> bucketId,
@@ -123,8 +110,6 @@ std::string IcebergFileNameGenerator::toString() const {
   return "IcebergFileNameGenerator";
 }
 
-} // namespace
-
 IcebergInsertTableHandle::IcebergInsertTableHandle(
     std::vector<IcebergColumnHandlePtr> inputColumns,
     LocationHandlePtr locationHandle,
@@ -134,6 +119,7 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
     const std::vector<IcebergSortingColumn>& sortedBy,
     std::optional<common::CompressionKind> compressionKind,
     const std::unordered_map<std::string, std::string>& serdeParameters,
+    std::shared_ptr<const FileNameGenerator> fileNameGenerator,
     WriteKind writeKind)
     : HiveInsertTableHandle(
           std::vector<std::shared_ptr<const HiveColumnHandle>>(
@@ -146,7 +132,7 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
           serdeParameters,
           nullptr,
           false,
-          std::make_shared<const IcebergFileNameGenerator>()),
+          std::move(fileNameGenerator)),
       partitionSpec_(std::move(partitionSpec)),
       columnTransforms_(
           partitionSpec_

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -45,6 +45,21 @@ class IcebergSortingColumn : public ISerializable {
   const core::SortOrder sortOrder_;
 };
 
+class IcebergFileNameGenerator : public FileNameGenerator {
+ public:
+  IcebergFileNameGenerator() {}
+
+  std::pair<std::string, std::string> gen(
+      std::optional<uint32_t> bucketId,
+      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx& connectorQueryCtx,
+      bool commitRequired) const override;
+
+  folly::dynamic serialize() const override;
+
+  std::string toString() const override;
+};
+
 // Represents a request for Iceberg write.
 class IcebergInsertTableHandle final : public HiveInsertTableHandle {
  public:
@@ -69,6 +84,8 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
   /// @param compressionKind Optional compression to apply to data files.
   /// @param serdeParameters Additional serialization/deserialization parameters
   /// for the file format.
+  /// @param fileNameGenerator File name generator for generating unique file
+  /// names for data files. If nullptr, will use IcebergFileNameGenerator.
   /// @param writeKind Selects between data-file emission (default) and V3
   /// deletion-vector emission. The default preserves existing INSERT
   /// semantics.
@@ -82,6 +99,8 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
       const std::vector<IcebergSortingColumn>& sortedBy = {},
       std::optional<common::CompressionKind> compressionKind = {},
       const std::unordered_map<std::string, std::string>& serdeParameters = {},
+      std::shared_ptr<const FileNameGenerator> fileNameGenerator =
+          std::make_shared<const IcebergFileNameGenerator>(),
       WriteKind writeKind = WriteKind::kData);
 
   std::shared_ptr<const IcebergPartitionSpec> partitionSpec() const {


### PR DESCRIPTION
Cherry-pick of #1571 (author: @Zouxxyy) onto `staging/staging-rebase`.

The original commit conflicted with the staging branch's `WriteKind` addition to the
`IcebergInsertTableHandle` constructor: both changes append a trailing constructor
parameter. Resolved by keeping both, with `fileNameGenerator` placed immediately
after `serdeParameters` — the same position it has upstream — and the staging-only
`writeKind` kept as the last parameter. This way future upstream additions to the
constructor will cherry-pick cleanly without touching `writeKind`. No callers pass
arguments positionally past `compressionKind`, so the new parameter is
backward-compatible.