### PR TITLE
feat: Implement se/dser method for HashTable

### DIFF
--- a/velox/common/serialization/CMakeLists.txt
+++ b/velox/common/serialization/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   DeserializationRegistry.cpp
   HEADERS
   DeserializationRegistry.h
+  NativeSerdeIO.h
   Registry.h
   Serializable.h
 )

--- a/velox/common/serialization/NativeSerdeIO.h
+++ b/velox/common/serialization/NativeSerdeIO.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <istream>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::common {
+
+class NativeStringWriter {
+ public:
+  explicit NativeStringWriter(std::string& data) : data_(data) {}
+
+  void write(const void* data, size_t size) {
+    data_.append(static_cast<const char*>(data), size);
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+ private:
+  std::string& data_;
+};
+
+class NativeStringReader {
+ public:
+  explicit NativeStringReader(std::string_view data) : data_(data) {}
+
+  void read(void* out, size_t size) {
+    VELOX_CHECK_LE(offset_ + size, data_.size(), "Corrupted binary data");
+    memcpy(out, data_.data() + offset_, size);
+    offset_ += size;
+  }
+
+  template <typename T>
+  T readValue() {
+    static_assert(std::is_trivially_copyable_v<T>);
+    T value;
+    read(&value, sizeof(value));
+    return value;
+  }
+
+  bool atEnd() const {
+    return offset_ == data_.size();
+  }
+
+ private:
+  std::string_view data_;
+  size_t offset_{0};
+};
+
+class NativeBufferedWriter {
+ public:
+  NativeBufferedWriter(std::ostream& out, size_t bufferSize)
+      : out_(out), buffer_(bufferSize), pos_(0) {}
+
+  ~NativeBufferedWriter() {
+    flush();
+  }
+
+  void write(const void* data, size_t size) {
+    const char* src = static_cast<const char*>(data);
+    while (size > 0) {
+      size_t available = buffer_.size() - pos_;
+      if (available == 0) {
+        flush();
+        available = buffer_.size();
+      }
+
+      const size_t toWrite = std::min(size, available);
+      std::memcpy(buffer_.data() + pos_, src, toWrite);
+      pos_ += toWrite;
+      src += toWrite;
+      size -= toWrite;
+    }
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+  void flush() {
+    if (pos_ > 0) {
+      out_.write(buffer_.data(), pos_);
+      pos_ = 0;
+    }
+  }
+
+ private:
+  std::ostream& out_;
+  std::vector<char> buffer_;
+  size_t pos_;
+};
+
+class NativeBufferedReader {
+ public:
+  NativeBufferedReader(std::istream& in, size_t bufferSize)
+      : in_(in), buffer_(bufferSize), pos_(0), size_(0) {}
+
+  void read(void* data, size_t size) {
+    char* dest = static_cast<char*>(data);
+    while (size > 0) {
+      if (pos_ >= size_) {
+        refill();
+      }
+
+      const size_t available = size_ - pos_;
+      const size_t toRead = std::min(size, available);
+      std::memcpy(dest, buffer_.data() + pos_, toRead);
+      pos_ += toRead;
+      dest += toRead;
+      size -= toRead;
+    }
+  }
+
+  template <typename T>
+  T readValue() {
+    static_assert(std::is_trivially_copyable_v<T>);
+    T value;
+    read(&value, sizeof(value));
+    return value;
+  }
+
+ private:
+  void refill() {
+    in_.read(buffer_.data(), buffer_.size());
+    size_ = in_.gcount();
+    pos_ = 0;
+    VELOX_CHECK_GT(size_, 0, "Unexpected end of stream");
+  }
+
+  std::istream& in_;
+  std::vector<char> buffer_;
+  size_t pos_;
+  size_t size_;
+};
+
+} // namespace facebook::velox::common

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -250,6 +250,7 @@ velox_link_libraries(
   velox_exec_window
   velox_expression
   velox_file
+  velox_presto_type_parser
   velox_presto_serializer
   velox_trace
   velox_time

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -21,9 +21,14 @@
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/process/ProcessBase.h"
 #include "velox/common/process/TraceContext.h"
+#include "velox/common/serialization/NativeSerdeIO.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/AdaptivePrefetch.h"
 #include "velox/exec/OperatorUtils.h"
+#include "velox/functions/prestosql/types/parser/TypeParser.h"
+#include "velox/vector/FlatVector.h"
+
+#include <algorithm>
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -2710,5 +2715,627 @@ void HashTable<ignoreNullKeys>::prepareForJoinProbe(
 
   populateLookupRows(rows, lookup.rows);
 }
+namespace {
+
+class CountingWriter {
+ public:
+  void write(const void*, size_t size) {
+    size_ += size;
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+  void flush() {}
+
+  size_t size() const {
+    return size_;
+  }
+
+ private:
+  size_t size_{0};
+};
+
+class MemoryWriter {
+ public:
+  MemoryWriter(void* data, size_t size)
+      : begin_(static_cast<char*>(data)),
+        current_(static_cast<char*>(data)),
+        end_(begin_ + size) {
+    VELOX_CHECK_NOT_NULL(
+        data, "Serialized hash table destination cannot be null");
+  }
+
+  void write(const void* data, size_t size) {
+    VELOX_CHECK_LE(
+        size,
+        remaining(),
+        "Insufficient space in serialized hash table buffer");
+    std::memcpy(current_, data, size);
+    current_ += size;
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+  void flush() {}
+
+  size_t writtenSize() const {
+    return static_cast<size_t>(current_ - begin_);
+  }
+
+ private:
+  size_t remaining() const {
+    return static_cast<size_t>(end_ - current_);
+  }
+
+  char* begin_;
+  char* current_;
+  char* end_;
+};
+
+} // namespace
+
+template <bool ignoreNullKeys>
+template <typename Writer>
+void HashTable<ignoreNullKeys>::serializeImpl(Writer& writer) const {
+  VELOX_CHECK(isJoinBuild_, "Only join-build hash tables are supported");
+  uint64_t totalRows = rows_ != nullptr ? rows_->numRows() : 0;
+  for (const auto& other : otherTables_) {
+    if (other->rows() != nullptr) {
+      totalRows += other->rows()->numRows();
+    }
+  }
+  VELOX_CHECK(
+      totalRows == 0 || table_ != nullptr,
+      "Serialization requires a prepared join table");
+
+  LOG(INFO) << "Serializing HashTable: "
+            << const_cast<HashTable<ignoreNullKeys>*>(this)->toString();
+
+  auto writeValue = [&](auto value) { writer.writeValue(value); };
+
+  // Serialize magic and version.
+  writeValue(static_cast<uint32_t>(0x48415348)); // "HASH"
+  writeValue(
+      static_cast<uint32_t>(8)); // Version 8: added constructor parameters for
+                                 // complete reconstruction
+
+  // Serialize base metadata, including all constructor parameters.
+  writeValue(static_cast<bool>(ignoreNullKeys));
+  writeValue(allowDuplicates_);
+  writeValue(isJoinBuild_);
+  writeValue(minTableSizeForParallelJoinBuild_);
+  writeValue(bloomFilterMaxSize_);
+  writeValue(hasDuplicates_.check());
+  writeValue(numDistinct_);
+  writeValue(static_cast<int32_t>(hashMode_));
+
+  // Serialize RowContainer flags.
+  const bool hasProbedFlag = rows_->probedFlagOffset() != 0;
+  const bool hasCountFlag = rows_->countOffset() != 0;
+  writeValue(hasProbedFlag);
+  writeValue(hasCountFlag);
+
+  // Serialize VectorHasher metadata.
+  writeValue(static_cast<uint32_t>(hashers_.size()));
+  for (const auto& hasher : hashers_) {
+    auto typeStr = hasher->type()->toString();
+    writeValue(static_cast<uint32_t>(typeStr.length()));
+    writer.write(typeStr.c_str(), typeStr.length());
+    writeValue(hasher->channel());
+  }
+
+  // Serialize dependentTypes metadata.
+  const auto& allColumnTypes = rows_->columnTypes();
+  const auto numKeyColumns = hashers_.size();
+  const auto numDependentColumns = allColumnTypes.size() > numKeyColumns
+      ? allColumnTypes.size() - numKeyColumns
+      : 0;
+
+  writeValue(static_cast<uint32_t>(numDependentColumns));
+  for (size_t i = numKeyColumns; i < allColumnTypes.size(); ++i) {
+    auto typeStr = allColumnTypes[i]->toString();
+    writeValue(static_cast<uint32_t>(typeStr.length()));
+    writer.write(typeStr.c_str(), typeStr.length());
+  }
+
+  // Serialize row data. For join build, RowContainer stores all build rows,
+  // which can exceed numDistinct_ when duplicate keys exist. Therefore we must
+  // use rows_->numRows() instead of numDistinct_, otherwise listRows() would
+  // not enumerate the full input and validation would fail. We also need to
+  // include rows from otherTables_ because parallel build may spread data
+  // across multiple tables.
+  writeValue(totalRows);
+
+  const bool serializeNormalizedKeys = hashMode_ == HashMode::kNormalizedKey;
+  raw_vector<normalized_key_t> normalizedKeys(0, pool_);
+  if (serializeNormalizedKeys) {
+    normalizedKeys.reserve(totalRows);
+  }
+
+  if (totalRows > 0) {
+    uint32_t numColumns = rows_->columnTypes().size();
+    writeValue(numColumns);
+
+    // Serialize column types.
+    for (int32_t col = 0; col < numColumns; ++col) {
+      auto typeStr = rows_->columnTypes()[col]->toString();
+      writeValue(static_cast<uint32_t>(typeStr.length()));
+      writer.write(typeStr.c_str(), typeStr.length());
+    }
+
+    // Serialize rows for all tables. Keep per-table serialized batches instead
+    // of copying into one large flatSerialized buffer while preserving the
+    // existing "all hashes -> all rows" wire layout.
+    std::vector<VectorPtr> serializedRowBatches;
+    serializedRowBatches.reserve(
+        (rows_ != nullptr ? 1 : 0) + otherTables_.size());
+    raw_vector<uint64_t> allHashes(0, pool_);
+    allHashes.reserve(totalRows);
+    vector_size_t serializedRowCount = 0;
+    auto* self = const_cast<HashTable<ignoreNullKeys>*>(this);
+
+    auto serializeRowsFrom = [&](RowContainer* sourceRows) {
+      if (sourceRows == nullptr || sourceRows->numRows() == 0) {
+        return;
+      }
+
+      const auto numSourceRows = sourceRows->numRows();
+      std::vector<char*> tableRows(numSourceRows);
+      RowContainerIterator iter;
+      const auto listed =
+          sourceRows->listRows(&iter, numSourceRows, tableRows.data());
+      VELOX_CHECK_EQ(listed, numSourceRows, "Failed to list serialized rows");
+
+      auto serializedBatch = BaseVector::create<FlatVector<StringView>>(
+          VARCHAR(), numSourceRows, sourceRows->pool());
+      sourceRows->extractSerializedRows(
+          folly::Range<char**>(tableRows.data(), tableRows.size()),
+          serializedBatch);
+      serializedRowBatches.push_back(serializedBatch);
+      serializedRowCount += numSourceRows;
+      if (serializeNormalizedKeys) {
+        for (auto* row : tableRows) {
+          normalizedKeys.push_back(RowContainer::normalizedKey(row));
+        }
+      }
+
+      raw_vector<uint64_t> tableHashes(numSourceRows, pool_);
+      bool hashSuccess = self->hashRows(
+          folly::Range<char**>(tableRows.data(), tableRows.size()),
+          false,
+          tableHashes);
+
+      // Fall back to full hashes when hashRows fails, e.g. kArray cannot
+      // produce value IDs for the current state.
+      if (!hashSuccess) {
+        for (vector_size_t i = 0; i < numSourceRows; ++i) {
+          sourceRows->hash(
+              0,
+              folly::Range<char**>(tableRows.data() + i, 1),
+              false,
+              &tableHashes[i]);
+          for (int32_t j = 1; j < self->hashers_.size(); ++j) {
+            sourceRows->hash(
+                j,
+                folly::Range<char**>(tableRows.data() + i, 1),
+                true,
+                &tableHashes[i]);
+          }
+        }
+      }
+
+      for (const auto hash : tableHashes) {
+        allHashes.push_back(hash);
+      }
+    };
+
+    serializeRowsFrom(rows_.get());
+    for (const auto& other : otherTables_) {
+      serializeRowsFrom(other->rows());
+    }
+
+    VELOX_CHECK_EQ(serializedRowCount, totalRows, "Total rows mismatch");
+    VELOX_CHECK_EQ(allHashes.size(), totalRows, "Total hashes mismatch");
+    if (serializeNormalizedKeys) {
+      VELOX_CHECK_EQ(
+          normalizedKeys.size(), totalRows, "Total normalized keys mismatch");
+    }
+
+    // Write all hashes.
+    for (uint64_t hash : allHashes) {
+      writeValue(hash);
+    }
+
+    // Write serialized row data batch by batch to avoid copying into one large
+    // intermediate buffer.
+    for (const auto& serializedBatch : serializedRowBatches) {
+      const auto* flatBatch =
+          serializedBatch->template asUnchecked<FlatVector<StringView>>();
+      for (vector_size_t i = 0; i < flatBatch->size(); ++i) {
+        const auto serialized = flatBatch->valueAt(i);
+        writeValue(static_cast<uint32_t>(serialized.size()));
+        if (serialized.size() > 0) {
+          writer.write(serialized.data(), serialized.size());
+        }
+      }
+    }
+  } else {
+    writeValue(static_cast<uint32_t>(0));
+  }
+
+  // Serialize columnHasNulls_.
+  writeValue(static_cast<uint32_t>(columnHasNulls_.size()));
+  for (bool hasNull : columnHasNulls_) {
+    writeValue(hasNull);
+  }
+
+  writeValue(capacity_);
+  writeValue(static_cast<uint32_t>(hashers_.size()));
+  for (const auto& hasher : hashers_) {
+    const auto stateSize = hasher->serializedStateSize();
+    writeValue(stateSize);
+    if (stateSize > 0) {
+      auto state = hasher->serializeState();
+      VELOX_CHECK_EQ(
+          state.size(),
+          stateSize,
+          "Serialized VectorHasher state size mismatch");
+      writer.write(state.data(), state.size());
+    }
+  }
+
+  writeValue(static_cast<bool>(serializeNormalizedKeys));
+  if (serializeNormalizedKeys && totalRows > 0) {
+    for (const auto normalizedKey : normalizedKeys) {
+      writeValue(normalizedKey);
+    }
+  }
+
+  // Flush explicitly so write failures surface at the serialization call site.
+  writer.flush();
+}
+
+template <bool ignoreNullKeys>
+size_t HashTable<ignoreNullKeys>::serializedSize() const {
+  CountingWriter writer;
+  serializeImpl(writer);
+  return writer.size();
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::serializeTo(void* data, size_t size) const {
+  MemoryWriter writer(data, size);
+  serializeImpl(writer);
+  VELOX_CHECK_EQ(
+      writer.writtenSize(), size, "Hash table serialized size mismatch");
+}
+
+template <bool ignoreNullKeys>
+template <typename Reader>
+std::unique_ptr<HashTable<ignoreNullKeys>> HashTable<
+    ignoreNullKeys>::deserializeImpl(Reader& reader, memory::MemoryPool* pool) {
+  auto readValue = [&]<typename T>() -> T {
+    return reader.template readValue<T>();
+  };
+
+  // Read and validate magic and version.
+  uint32_t magic = readValue.template operator()<uint32_t>();
+  uint32_t version = readValue.template operator()<uint32_t>();
+
+  VELOX_CHECK_EQ(magic, 0x48415348, "Invalid magic number");
+  VELOX_CHECK_EQ(
+      version,
+      8,
+      "Expected version 8, got {}. Version 7 is deprecated due to issues.",
+      version);
+
+  // Read metadata.
+  bool ignoreNulls = readValue.template operator()<bool>();
+  VELOX_CHECK_EQ(ignoreNulls, ignoreNullKeys, "ignoreNullKeys mismatch");
+
+  bool allowDuplicates = readValue.template operator()<bool>();
+  bool isJoinBuild = readValue.template operator()<bool>();
+  uint32_t minTableSizeForParallelJoinBuild =
+      readValue.template operator()<uint32_t>();
+  uint64_t bloomFilterMaxSize = readValue.template operator()<uint64_t>();
+  bool hasDuplicates = readValue.template operator()<bool>();
+
+  int64_t numDistinct = readValue.template operator()<int64_t>();
+  int32_t hashModeInt = readValue.template operator()<int32_t>();
+  VELOX_CHECK(
+      hashModeInt == static_cast<int32_t>(HashMode::kHash) ||
+          hashModeInt == static_cast<int32_t>(HashMode::kArray) ||
+          hashModeInt == static_cast<int32_t>(HashMode::kNormalizedKey),
+      "Invalid hash mode in serialized HashTable: {}",
+      hashModeInt);
+
+  // Read RowContainer flags.
+  bool hasProbedFlag = readValue.template operator()<bool>();
+  bool hasCountFlag = readValue.template operator()<bool>();
+
+  // Read VectorHasher metadata.
+  uint32_t numHashers = readValue.template operator()<uint32_t>();
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  std::vector<TypePtr> keyTypes;
+  hashers.reserve(numHashers);
+  keyTypes.reserve(numHashers);
+
+  auto parseType = [](const std::string& typeStr) -> TypePtr {
+    auto normalized = typeStr;
+    std::replace(normalized.begin(), normalized.end(), '<', '(');
+    std::replace(normalized.begin(), normalized.end(), '>', ')');
+    std::replace(normalized.begin(), normalized.end(), ':', ' ');
+    return functions::prestosql::parseType(normalized);
+  };
+
+  for (uint32_t i = 0; i < numHashers; ++i) {
+    uint32_t typeLen = readValue.template operator()<uint32_t>();
+    std::string typeStr(typeLen, '\0');
+    if (typeLen > 0) {
+      reader.read(typeStr.data(), typeLen);
+    }
+
+    column_index_t channel = readValue.template operator()<column_index_t>();
+
+    TypePtr type = parseType(typeStr);
+    keyTypes.push_back(type);
+    hashers.push_back(std::make_unique<VectorHasher>(type, channel));
+  }
+
+  // Read dependentTypes metadata.
+  uint32_t numDependentTypes = readValue.template operator()<uint32_t>();
+  std::vector<TypePtr> dependentTypes;
+  dependentTypes.reserve(numDependentTypes);
+  for (uint32_t i = 0; i < numDependentTypes; ++i) {
+    uint32_t typeLen = readValue.template operator()<uint32_t>();
+    std::string typeStr(typeLen, '\0');
+    if (typeLen > 0) {
+      reader.read(typeStr.data(), typeLen);
+    }
+    dependentTypes.push_back(parseType(typeStr));
+  }
+
+  // Read row data. The serialization format writes numColumns and column types
+  // only when numRows > 0, so deserialization must follow the same condition
+  // to keep the stream position aligned for empty tables.
+  uint64_t numRows = readValue.template operator()<uint64_t>();
+  uint32_t numColumns = 0;
+
+  std::vector<TypePtr> columnTypes;
+  if (numRows > 0) {
+    numColumns = readValue.template operator()<uint32_t>();
+    if (numColumns > 0) {
+      columnTypes.reserve(numColumns);
+      for (uint32_t col = 0; col < numColumns; ++col) {
+        uint32_t typeLen = readValue.template operator()<uint32_t>();
+        std::string typeStr(typeLen, '\0');
+        if (typeLen > 0) {
+          reader.read(typeStr.data(), typeLen);
+        }
+        columnTypes.push_back(parseType(typeStr));
+      }
+    }
+  } else {
+    // When numRows == 0, serialization writes an extra 0 for numColumns.
+    // Consume it here to keep the stream aligned.
+    readValue.template operator()<uint32_t>();
+  }
+
+  // Create the HashTable using all serialized constructor parameters.
+  auto table = std::make_unique<HashTable<ignoreNullKeys>>(
+      std::move(hashers),
+      std::vector<Accumulator>{},
+      dependentTypes,
+      allowDuplicates,
+      isJoinBuild,
+      hasProbedFlag,
+      hasCountFlag,
+      minTableSizeForParallelJoinBuild,
+      pool,
+      bloomFilterMaxSize);
+
+  if (numRows > 0) {
+    const auto expectedNumColumns = keyTypes.size() + dependentTypes.size();
+    VELOX_CHECK_EQ(
+        columnTypes.size(),
+        expectedNumColumns,
+        "Serialized row schema has {} columns, but HashTable expects {}",
+        columnTypes.size(),
+        expectedNumColumns);
+    for (size_t i = 0; i < columnTypes.size(); ++i) {
+      const auto& expectedType = i < keyTypes.size()
+          ? keyTypes[i]
+          : dependentTypes[i - keyTypes.size()];
+      VELOX_CHECK(
+          columnTypes[i]->equivalent(*expectedType),
+          "Serialized row schema mismatch at column {}: got {}, expected {}",
+          i,
+          columnTypes[i]->toString(),
+          expectedType->toString());
+    }
+  }
+
+  // Restore the hasDuplicates flag.
+  if (hasDuplicates) {
+    table->hasDuplicates_.set();
+  }
+
+  std::vector<uint64_t> precomputedHashes;
+  if (numRows > 0) {
+    precomputedHashes.reserve(numRows);
+    for (uint64_t i = 0; i < numRows; ++i) {
+      precomputedHashes.push_back(readValue.template operator()<uint64_t>());
+    }
+  }
+
+  // Restore row data.
+  std::vector<char*> allRows;
+  allRows.reserve(numRows);
+
+  if (numRows > 0) {
+    std::string serializedRowBuffer;
+    for (uint64_t i = 0; i < numRows; ++i) {
+      char* newRow = table->rows_->newRow();
+
+      // Initialize nextRow pointer to nullptr to avoid garbage values
+      // that could cause crashes or incorrect results in listJoinResults.
+      // This must be done before storeSerializedRow because the serialized
+      // data does not include the nextRow pointer (it's an internal hash
+      // table structure), and uninitialized memory may contain random values.
+      if (table->nextOffset_) {
+        *reinterpret_cast<char**>(newRow + table->nextOffset_) = nullptr;
+      }
+
+      uint32_t rowSize = readValue.template operator()<uint32_t>();
+      if (rowSize > 0) {
+        serializedRowBuffer.resize(rowSize);
+        reader.read(serializedRowBuffer.data(), rowSize);
+        table->rows_->storeSerializedRow(
+            std::string_view(serializedRowBuffer.data(), rowSize), newRow);
+      } else {
+        table->rows_->storeSerializedRow(std::string_view{}, newRow);
+      }
+
+      // Initialize probed flag to false (0) if applicable
+      if (hasProbedFlag && table->rows_->probedFlagOffset() != 0) {
+        bits::clearBit(newRow, table->rows_->probedFlagOffset());
+      }
+
+      // Initialize count to 1 for counting joins. Each deserialized row
+      // represents one occurrence of the key. This matches the behavior of
+      // RowContainer::initializeRow() which also sets count to 1.
+      if (hasCountFlag && table->rows_->countOffset() != 0) {
+        *reinterpret_cast<int32_t*>(newRow + table->rows_->countOffset()) = 1;
+      }
+
+      allRows.push_back(newRow);
+    }
+  }
+
+  // Read columnHasNulls_.
+  uint32_t numColumnFlags = readValue.template operator()<uint32_t>();
+  table->columnHasNulls_.resize(numColumnFlags);
+  for (uint32_t i = 0; i < numColumnFlags; ++i) {
+    table->columnHasNulls_[i] = readValue.template operator()<bool>();
+  }
+
+  table->numDistinct_ = numDistinct;
+  const auto serializedCapacity = readValue.template operator()<uint64_t>();
+  const auto serializedHasherCount = readValue.template operator()<uint32_t>();
+  VELOX_CHECK_EQ(
+      serializedHasherCount,
+      table->hashers_.size(),
+      "Serialized VectorHasher count mismatch");
+
+  for (uint32_t i = 0; i < serializedHasherCount; ++i) {
+    const auto stateSize = readValue.template operator()<uint32_t>();
+    std::string state(stateSize, '\0');
+    if (stateSize > 0) {
+      reader.read(state.data(), stateSize);
+    }
+    table->hashers_[i]->deserializeState(state);
+  }
+
+  const bool hasNormalizedKeys = readValue.template operator()<bool>();
+  if (hasNormalizedKeys) {
+    VELOX_CHECK_EQ(
+        hashModeInt,
+        static_cast<int32_t>(HashMode::kNormalizedKey),
+        "Serialized normalized keys require normalized hash mode");
+    for (auto* row : allRows) {
+      RowContainer::normalizedKey(row) =
+          readValue.template operator()<normalized_key_t>();
+    }
+  }
+
+  table->hashMode_ = static_cast<HashMode>(hashModeInt);
+  if (table->hashMode_ == HashMode::kHash) {
+    table->rows_->disableNormalizedKeys();
+  }
+
+  if (!allRows.empty()) {
+    if (table->hashMode_ == HashMode::kArray) {
+      table->capacity_ = serializedCapacity;
+      const auto bytes = table->capacity_ * tableSlotSize();
+      const auto numPages = memory::AllocationTraits::numPages(bytes);
+      table->rows_->pool()->allocateContiguous(
+          numPages, table->tableAllocation_);
+      table->table_ = table->tableAllocation_.template data<char*>();
+      memset(table->table_, 0, bytes);
+    } else {
+      table->allocateTables(serializedCapacity, kNoSpillInputStartPartitionBit);
+    }
+
+    VELOX_CHECK_EQ(
+        precomputedHashes.size(),
+        allRows.size(),
+        "Serialized join-table format requires stored hashes");
+
+    // Recompute value IDs for kArray to match the deserialized VectorHasher
+    // state. This is required because serialized hashes may be full hashes
+    // when hashRows fell back, or value IDs produced from a different
+    // VectorHasher state.
+    if (table->hashMode_ == HashMode::kArray) {
+      raw_vector<uint64_t> valueIds(allRows.size(), pool);
+      bool success = table->hashRows(
+          folly::Range<char**>(allRows.data(), allRows.size()),
+          false,
+          valueIds);
+      VELOX_CHECK(
+          success,
+          "Failed to compute value IDs in kArray mode during deserialization. "
+          "This indicates the data type does not support value IDs.");
+
+      table->insertForJoin(
+          allRows.data(), valueIds.data(), allRows.size(), nullptr);
+    } else {
+      // For kHash and kNormalizedKey, reuse the stored hashes directly.
+      table->insertForJoin(
+          allRows.data(), precomputedHashes.data(), allRows.size(), nullptr);
+    }
+  }
+  table->numDistinct_ = numDistinct;
+  LOG(INFO) << "Deserialized HashTable: " << table->toString();
+
+  return table;
+}
+
+template <bool ignoreNullKeys>
+std::unique_ptr<HashTable<ignoreNullKeys>>
+HashTable<ignoreNullKeys>::deserializeFrom(
+    const void* data,
+    size_t size,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(data, "Serialized hash table data cannot be null");
+  common::NativeStringReader reader(
+      std::string_view(static_cast<const char*>(data), size));
+  auto table = deserializeImpl(reader, pool);
+  VELOX_CHECK(
+      reader.atEnd(), "Trailing bytes after hash table deserialization");
+  return table;
+}
+
+template size_t HashTable<true>::serializedSize() const;
+template size_t HashTable<false>::serializedSize() const;
+
+template void HashTable<true>::serializeTo(void* data, size_t size) const;
+template void HashTable<false>::serializeTo(void* data, size_t size) const;
+
+template std::unique_ptr<HashTable<true>> HashTable<true>::deserializeFrom(
+    const void* data,
+    size_t size,
+    memory::MemoryPool* pool);
+template std::unique_ptr<HashTable<false>> HashTable<false>::deserializeFrom(
+    const void* data,
+    size_t size,
+    memory::MemoryPool* pool);
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -848,6 +848,23 @@ class HashTable : public BaseHashTable {
   /// are left till the end of the table.
   std::string toString(int64_t startBucket, int64_t numBuckets = 1) const;
 
+  /// Returns the exact serialized size in bytes for the current hash table.
+  size_t serializedSize() const;
+
+  /// Serializes the hash table directly to a caller-provided memory buffer.
+  /// @param data Destination buffer
+  /// @param size Size of destination buffer in bytes. Must equal
+  /// serializedSize().
+  void serializeTo(void* data, size_t size) const;
+
+  /// Deserializes the hash table directly from a contiguous memory buffer.
+  /// @param data Serialized hash table bytes
+  /// @param size Serialized hash table size in bytes
+  /// @param pool Memory pool for allocating deserialized data
+  /// @return A new HashTable instance with deserialized data
+  static std::unique_ptr<HashTable<ignoreNullKeys>>
+  deserializeFrom(const void* data, size_t size, memory::MemoryPool* pool);
+
   /// Invoked to check the consistency of the internal state. The function scans
   /// all the table slots to check if the relevant slot counting are correct
   /// such as the number of used slots ('numDistinct_') and the number of
@@ -882,6 +899,14 @@ class HashTable : public BaseHashTable {
   }
 
  private:
+  template <typename Writer>
+  void serializeImpl(Writer& writer) const;
+
+  template <typename Reader>
+  static std::unique_ptr<HashTable<ignoreNullKeys>> deserializeImpl(
+      Reader& reader,
+      memory::MemoryPool* pool);
+
   // Enables debug stats for collisions for debug build.
 #ifdef NDEBUG
   static constexpr bool kTrackLoads = false;

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -765,6 +765,11 @@ void RowContainer::storeSerializedRow(
     char* row) {
   VELOX_CHECK(!vector.isNullAt(index));
   const auto serialized = vector.valueAt(index);
+  storeSerializedRow(
+      std::string_view(serialized.data(), serialized.size()), row);
+}
+
+void RowContainer::storeSerializedRow(std::string_view serialized, char* row) {
   size_t offset = 0;
 
   ::memcpy(row + flagsByteOffset_, serialized.data(), flagBytes_);
@@ -783,6 +788,10 @@ void RowContainer::storeSerializedRow(
     }
     updateColumnStats(row, i);
   }
+  VELOX_CHECK_EQ(
+      offset,
+      serialized.size(),
+      "Serialized row size mismatch while storing RowContainer row");
 }
 
 void RowContainer::extractString(

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -23,6 +23,8 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
 
+#include <string_view>
+
 namespace facebook::velox::exec {
 namespace test {
 class RowContainerTestHelper;
@@ -428,6 +430,10 @@ class RowContainer {
       const FlatVector<StringView>& vector,
       vector_size_t index,
       char* row);
+
+  /// Copies serialized row bytes produced by 'extractSerializedRows' into the
+  /// container.
+  void storeSerializedRow(std::string_view serialized, char* row);
 
   /// Copies the values at 'col' into 'result' (starting at 'resultOffset')
   /// for the 'numRows' rows pointed to by 'rows'. If a 'row' is null, sets

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -19,9 +19,17 @@
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/memory/HashStringAllocator.h"
+#include "velox/common/serialization/NativeSerdeIO.h"
 #include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox::exec {
+
+namespace {
+
+constexpr uint32_t kVectorHasherStateMagic = 0x56485331; // VHS1
+constexpr uint32_t kVectorHasherStateVersion = 3;
+
+} // namespace
 
 #define VALUE_ID_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)                \
   [&]() {                                                                   \
@@ -1006,6 +1014,243 @@ void VectorHasher::merge(const VectorHasher& other, size_t maxNumDistinct) {
       break;
     }
   }
+}
+
+std::string VectorHasher::serializeState() const {
+  const common::BigintValuesUsingBloomFilter* bloomFilter = nullptr;
+  std::string bloomFilterData;
+  if (bloomFilter_) {
+    VELOX_CHECK(
+        supportsBloomFilter(),
+        "Unexpected bloom filter for VectorHasher type {}",
+        type_->toString());
+    bloomFilter = dynamic_cast<const common::BigintValuesUsingBloomFilter*>(
+        bloomFilter_.get());
+    VELOX_CHECK_NOT_NULL(
+        bloomFilter, "Unexpected bloom filter implementation in VectorHasher");
+    bloomFilterData.reserve(16 + bloomFilter->blocksByteSize());
+    bloomFilter->serializeBinary(bloomFilterData);
+  }
+
+  std::vector<const UniqueValue*> valuesById;
+  if (!distinctOverflow_) {
+    valuesById.resize(uniqueValues_.size(), nullptr);
+    for (const auto& value : uniqueValues_) {
+      VELOX_CHECK_GE(value.id(), 1);
+      VELOX_CHECK_LE(value.id(), valuesById.size());
+      valuesById[value.id() - 1] = &value;
+    }
+  }
+
+  std::string data;
+  data.reserve(serializedStateSize());
+  common::NativeStringWriter writer(data);
+
+  writer.writeValue<uint32_t>(kVectorHasherStateMagic);
+  writer.writeValue<uint32_t>(kVectorHasherStateVersion);
+  writer.writeValue<uint32_t>(static_cast<uint32_t>(typeKind_));
+  writer.writeValue<bool>(typeProvidesCustomComparison_);
+  writer.writeValue<uint64_t>(rangeSize_);
+  writer.writeValue<uint64_t>(multiplier_);
+  writer.writeValue<bool>(isRange_);
+  writer.writeValue<bool>(hasRange_);
+  writer.writeValue<bool>(rangeOverflow_);
+  writer.writeValue<bool>(distinctOverflow_);
+  writer.writeValue<int64_t>(min_);
+  writer.writeValue<int64_t>(max_);
+
+  writer.writeValue<bool>(bloomFilter != nullptr);
+  if (bloomFilter != nullptr) {
+    writer.writeValue<uint32_t>(bloomFilterData.size());
+    if (!bloomFilterData.empty()) {
+      writer.write(bloomFilterData.data(), bloomFilterData.size());
+    }
+  }
+
+  if (distinctOverflow_) {
+    writer.writeValue<uint32_t>(0);
+    return data;
+  }
+
+  writer.writeValue<uint32_t>(valuesById.size());
+  for (const auto* value : valuesById) {
+    VELOX_CHECK_NOT_NULL(value, "Missing unique value for serialized id range");
+    const auto bytes = value->bytesView();
+    writer.writeValue<uint32_t>(bytes.size());
+    if (!bytes.empty()) {
+      writer.write(bytes.data(), bytes.size());
+    }
+  }
+
+  return data;
+}
+
+uint32_t VectorHasher::serializedStateSize() const {
+  uint32_t size = sizeof(kVectorHasherStateMagic) +
+      sizeof(kVectorHasherStateVersion) + sizeof(uint32_t) + sizeof(bool) +
+      sizeof(rangeSize_) + sizeof(multiplier_) + sizeof(isRange_) +
+      sizeof(hasRange_) + sizeof(rangeOverflow_) + sizeof(distinctOverflow_) +
+      sizeof(min_) + sizeof(max_) + sizeof(bool) + sizeof(uint32_t);
+
+  if (bloomFilter_) {
+    VELOX_CHECK(
+        supportsBloomFilter(),
+        "Unexpected bloom filter for VectorHasher type {}",
+        type_->toString());
+    auto* bloomFilter =
+        dynamic_cast<const common::BigintValuesUsingBloomFilter*>(
+            bloomFilter_.get());
+    VELOX_CHECK_NOT_NULL(
+        bloomFilter, "Unexpected bloom filter implementation in VectorHasher");
+    size += sizeof(bool) + 3 * sizeof(uint32_t) + bloomFilter->blocksByteSize();
+  }
+
+  if (!distinctOverflow_) {
+    for (const auto& value : uniqueValues_) {
+      size += sizeof(uint32_t) + value.size();
+    }
+  }
+
+  return size;
+}
+
+void VectorHasher::serializeState(common::NativeBufferedWriter& writer) const {
+  const common::BigintValuesUsingBloomFilter* bloomFilter = nullptr;
+  std::string bloomFilterData;
+  if (bloomFilter_) {
+    VELOX_CHECK(
+        supportsBloomFilter(),
+        "Unexpected bloom filter for VectorHasher type {}",
+        type_->toString());
+    bloomFilter = dynamic_cast<const common::BigintValuesUsingBloomFilter*>(
+        bloomFilter_.get());
+    VELOX_CHECK_NOT_NULL(
+        bloomFilter, "Unexpected bloom filter implementation in VectorHasher");
+    bloomFilterData.reserve(16 + bloomFilter->blocksByteSize());
+    bloomFilter->serializeBinary(bloomFilterData);
+  }
+
+  std::vector<const UniqueValue*> valuesById;
+  if (!distinctOverflow_) {
+    valuesById.resize(uniqueValues_.size(), nullptr);
+    for (const auto& value : uniqueValues_) {
+      VELOX_CHECK_GE(value.id(), 1);
+      VELOX_CHECK_LE(value.id(), valuesById.size());
+      valuesById[value.id() - 1] = &value;
+    }
+  }
+
+  writer.writeValue<uint32_t>(kVectorHasherStateMagic);
+  writer.writeValue<uint32_t>(kVectorHasherStateVersion);
+  writer.writeValue<uint32_t>(static_cast<uint32_t>(typeKind_));
+  writer.writeValue<bool>(typeProvidesCustomComparison_);
+  writer.writeValue<uint64_t>(rangeSize_);
+  writer.writeValue<uint64_t>(multiplier_);
+  writer.writeValue<bool>(isRange_);
+  writer.writeValue<bool>(hasRange_);
+  writer.writeValue<bool>(rangeOverflow_);
+  writer.writeValue<bool>(distinctOverflow_);
+  writer.writeValue<int64_t>(min_);
+  writer.writeValue<int64_t>(max_);
+
+  writer.writeValue<bool>(bloomFilter != nullptr);
+  if (bloomFilter != nullptr) {
+    writer.writeValue<uint32_t>(bloomFilterData.size());
+    if (!bloomFilterData.empty()) {
+      writer.write(bloomFilterData.data(), bloomFilterData.size());
+    }
+  }
+
+  if (distinctOverflow_) {
+    writer.writeValue<uint32_t>(0);
+    return;
+  }
+
+  writer.writeValue<uint32_t>(valuesById.size());
+  for (const auto* value : valuesById) {
+    VELOX_CHECK_NOT_NULL(value, "Missing unique value for serialized id range");
+    const auto bytes = value->bytesView();
+    writer.writeValue<uint32_t>(bytes.size());
+    if (!bytes.empty()) {
+      writer.write(bytes.data(), bytes.size());
+    }
+  }
+}
+
+void VectorHasher::deserializeState(std::string_view data) {
+  common::NativeStringReader reader(data);
+  const auto magic = reader.readValue<uint32_t>();
+  const auto version = reader.readValue<uint32_t>();
+  VELOX_CHECK_EQ(magic, kVectorHasherStateMagic, "Invalid VectorHasher state");
+  VELOX_CHECK_EQ(
+      version,
+      kVectorHasherStateVersion,
+      "Unsupported VectorHasher state version: {}",
+      version);
+
+  const auto typeKind = static_cast<TypeKind>(reader.readValue<uint32_t>());
+  const auto hasCustomComparison = reader.readValue<bool>();
+  VELOX_CHECK_EQ(typeKind, typeKind_, "VectorHasher type kind mismatch");
+  VELOX_CHECK_EQ(
+      hasCustomComparison,
+      typeProvidesCustomComparison_,
+      "VectorHasher comparison mode mismatch");
+
+  rangeSize_ = reader.readValue<uint64_t>();
+  multiplier_ = reader.readValue<uint64_t>();
+  isRange_ = reader.readValue<bool>();
+  hasRange_ = reader.readValue<bool>();
+  rangeOverflow_ = reader.readValue<bool>();
+  distinctOverflow_ = reader.readValue<bool>();
+  min_ = reader.readValue<int64_t>();
+  max_ = reader.readValue<int64_t>();
+
+  bloomFilter_.reset();
+  const bool hasBloomFilter = reader.readValue<bool>();
+  if (hasBloomFilter) {
+    VELOX_CHECK(
+        supportsBloomFilter(),
+        "Unexpected bloom filter for VectorHasher type {}",
+        type_->toString());
+    const auto bloomFilterSize = reader.readValue<uint32_t>();
+    std::string bloomFilterData(bloomFilterSize, '\0');
+    if (bloomFilterSize > 0) {
+      reader.read(bloomFilterData.data(), bloomFilterSize);
+    }
+    bloomFilter_ = common::BigintValuesUsingBloomFilter::deserializeBinary(
+        bloomFilterData);
+  }
+
+  uniqueValues_.clear();
+  uniqueValuesStorage_.clear();
+  distinctStringsBytes_ = 0;
+
+  const auto numUniqueValues = reader.readValue<uint32_t>();
+  if (!distinctOverflow_) {
+    for (uint32_t id = 1; id <= numUniqueValues; ++id) {
+      const auto size = reader.readValue<uint32_t>();
+      std::string value(size, '\0');
+      if (size > 0) {
+        reader.read(value.data(), size);
+      }
+
+      UniqueValue unique(value.data(), size);
+      unique.setId(id);
+      auto [iter, inserted] = uniqueValues_.insert(unique);
+      VELOX_CHECK(inserted, "Duplicate value in VectorHasher state");
+      copyStringToLocal(&*iter);
+    }
+  } else {
+    for (uint32_t i = 0; i < numUniqueValues; ++i) {
+      const auto size = reader.readValue<uint32_t>();
+      if (size > 0) {
+        std::string skip(size, '\0');
+        reader.read(skip.data(), size);
+      }
+    }
+  }
+
+  VELOX_CHECK(reader.atEnd(), "Trailing bytes in VectorHasher state");
 }
 
 std::string VectorHasher::toString() const {

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -18,6 +18,8 @@
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 
+#include <string_view>
+
 #include <type_traits>
 
 #include <velox/type/Filter.h>
@@ -25,6 +27,10 @@
 #include "velox/exec/Operator.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
+
+namespace facebook::velox::common {
+class NativeBufferedWriter;
+}
 
 namespace facebook::velox::exec {
 
@@ -71,6 +77,15 @@ class UniqueValue {
     }
     // String is stored as a pointer in data_.
     return std::string{reinterpret_cast<const char*>(data_), size_};
+  }
+
+  std::string_view bytesView() const {
+    if (size_ <= sizeof(int64_t)) {
+      return std::string_view{
+          reinterpret_cast<const char*>(&data_), static_cast<size_t>(size_)};
+    }
+    return std::string_view{
+        reinterpret_cast<const char*>(data_), static_cast<size_t>(size_)};
   }
 
   void setData(int64_t data) {
@@ -368,6 +383,17 @@ class VectorHasher {
   }
 
   std::string toString() const;
+
+  // Serializes the value-id / range state needed to preserve non-kHash join
+  // probe behavior across process boundaries.
+  std::string serializeState() const;
+
+  uint32_t serializedStateSize() const;
+
+  void serializeState(common::NativeBufferedWriter& writer) const;
+
+  // Restores state produced by serializeState().
+  void deserializeState(std::string_view data);
 
   size_t numUniqueValues() const {
     return numDistinct();

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ set(
   UnnestTest.cpp
   PlanNodeSerdeTest.cpp
   HashJoinBridgeTest.cpp
+  HashTableSerializationTest.cpp
   SortBufferTest.cpp
   VectorHasherTest.cpp
   # group7 (~449s): IndexLookupJoinTestExtra 188

--- a/velox/exec/tests/HashTableSerializationTest.cpp
+++ b/velox/exec/tests/HashTableSerializationTest.cpp
@@ -1,0 +1,627 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/HashTable.h"
+#include "velox/exec/VectorHasher.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <gtest/gtest.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::exec::test {
+
+namespace {
+std::string readFile(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in.good()) {
+    return "";
+  }
+  in.seekg(0, std::ios::end);
+  const auto end = in.tellg();
+  if (end <= 0) {
+    return "";
+  }
+  const auto size = static_cast<size_t>(end);
+  in.seekg(0, std::ios::beg);
+  std::string data;
+  data.resize(size);
+  in.read(data.data(), data.size());
+  return data;
+}
+
+void writeFile(const std::string& path, const std::string& data) {
+  std::ofstream out(path, std::ios::binary);
+  out.write(data.data(), data.size());
+}
+} // namespace
+
+class HashTableSerializationTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  std::string serialize(const HashTable<true>& table) const {
+    std::string data;
+    data.resize(table.serializedSize());
+    table.serializeTo(data.data(), data.size());
+    return data;
+  }
+
+  std::unique_ptr<HashTable<true>> deserialize(
+      const std::string& data,
+      memory::MemoryPool* pool) const {
+    return HashTable<true>::deserializeFrom(data.data(), data.size(), pool);
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool();
+    tempDir_ = exec::test::TempDirectoryPath::create();
+  }
+
+  void TearDown() override {
+    pool_.reset();
+  }
+
+  std::unique_ptr<HashTable<true>> createTestHashTable(
+      const std::vector<TypePtr>& keyTypes,
+      const std::vector<TypePtr>& dependentTypes,
+      bool allowDuplicates = false) {
+    std::vector<std::unique_ptr<VectorHasher>> hashers;
+    for (int i = 0; i < keyTypes.size(); ++i) {
+      hashers.push_back(std::make_unique<VectorHasher>(keyTypes[i], i));
+    }
+
+    return std::make_unique<HashTable<true>>(
+        std::move(hashers),
+        std::vector<Accumulator>{},
+        dependentTypes,
+        allowDuplicates,
+        true, // isJoinBuild
+        false, // hasProbedFlag
+        false, // hasCountFlag
+        0, // minTableSizeForParallelJoinBuild
+        pool_.get());
+  }
+
+  void insertData(
+      HashTable<true>* table,
+      const RowVectorPtr& data,
+      const std::vector<column_index_t>& /*keyChannels*/) {
+    SelectivityVector allRows(data->size());
+
+    std::vector<char*> inserted(data->size());
+    const auto nextOffset = table->rows()->nextOffset();
+    for (int i = 0; i < data->size(); ++i) {
+      inserted[i] = table->rows()->newRow();
+      if (nextOffset > 0) {
+        *reinterpret_cast<char**>(inserted[i] + nextOffset) = nullptr;
+      }
+    }
+
+    for (int col = 0; col < data->childrenSize(); ++col) {
+      DecodedVector decoded(*data->childAt(col), allRows);
+      for (int row = 0; row < data->size(); ++row) {
+        table->rows()->store(decoded, row, inserted[row], col);
+      }
+    }
+  }
+
+  void verifyHashTablesEqual(
+      HashTable<true>* original,
+      HashTable<true>* restored) {
+    EXPECT_EQ(original->numDistinct(), restored->numDistinct());
+    EXPECT_EQ(original->hashMode(), restored->hashMode());
+
+    auto* origRows = original->rows();
+    auto* restRows = restored->rows();
+
+    ASSERT_EQ(origRows->numRows(), restRows->numRows());
+    ASSERT_EQ(origRows->columnTypes().size(), restRows->columnTypes().size());
+
+    std::vector<char*> origRowPtrs;
+    std::vector<char*> restRowPtrs;
+
+    RowContainerIterator origIter;
+    RowContainerIterator restIter;
+
+    std::vector<char*> buffer(1000);
+
+    while (true) {
+      auto numRows = origRows->listRows(
+          &origIter, buffer.size(), RowContainer::kUnlimited, buffer.data());
+      if (numRows == 0)
+        break;
+      origRowPtrs.insert(
+          origRowPtrs.end(), buffer.begin(), buffer.begin() + numRows);
+    }
+
+    while (true) {
+      auto numRows = restRows->listRows(
+          &restIter, buffer.size(), RowContainer::kUnlimited, buffer.data());
+      if (numRows == 0)
+        break;
+      restRowPtrs.insert(
+          restRowPtrs.end(), buffer.begin(), buffer.begin() + numRows);
+    }
+
+    ASSERT_EQ(origRowPtrs.size(), restRowPtrs.size());
+
+    auto encodeRows = [](RowContainer* rows,
+                         const std::vector<char*>& rowPtrs) {
+      std::vector<std::string> encodedRows;
+      encodedRows.reserve(rowPtrs.size());
+      for (auto* rowPtr : rowPtrs) {
+        std::string encoded;
+        for (int col = 0; col < rows->columnTypes().size(); ++col) {
+          const auto column = rows->columnAt(col);
+          const bool isNull = RowContainer::isNullAt(rowPtr, column);
+          encoded += isNull ? "NULL:" : "VAL:";
+          if (!isNull) {
+            const auto& type = rows->columnTypes()[col];
+            switch (type->kind()) {
+              case TypeKind::BIGINT:
+                encoded += std::to_string(*reinterpret_cast<const int64_t*>(
+                    rowPtr + column.offset()));
+                break;
+              case TypeKind::INTEGER:
+                encoded += std::to_string(*reinterpret_cast<const int32_t*>(
+                    rowPtr + column.offset()));
+                break;
+              case TypeKind::DOUBLE:
+                encoded += std::to_string(
+                    *reinterpret_cast<const double*>(rowPtr + column.offset()));
+                break;
+              case TypeKind::BOOLEAN:
+                encoded +=
+                    *reinterpret_cast<const bool*>(rowPtr + column.offset())
+                    ? "true"
+                    : "false";
+                break;
+              case TypeKind::VARCHAR: {
+                const auto* str = reinterpret_cast<const StringView*>(
+                    rowPtr + column.offset());
+                encoded.append(str->data(), str->size());
+                break;
+              }
+              default:
+                VELOX_FAIL(
+                    "Unsupported type in HashTableSerializationTest comparison: {}",
+                    type->toString());
+            }
+          }
+          encoded += "|";
+        }
+        encodedRows.push_back(std::move(encoded));
+      }
+      std::sort(encodedRows.begin(), encodedRows.end());
+      return encodedRows;
+    };
+
+    EXPECT_EQ(
+        encodeRows(origRows, origRowPtrs), encodeRows(restRows, restRowPtrs));
+  }
+
+  void verifyJoinProbe(
+      HashTable<true>* table,
+      const RowVectorPtr& probe,
+      int32_t expectedHits) {
+    HashLookup lookup(table->hashers(), pool_.get());
+    SelectivityVector rows(probe->size());
+    rows.setAll();
+
+    table->prepareForJoinProbe(lookup, probe, rows, true);
+    table->joinProbe(lookup);
+
+    int32_t hitCount = 0;
+    for (int32_t row = 0; row < probe->size(); ++row) {
+      if (lookup.hits[row] != nullptr) {
+        ++hitCount;
+      }
+    }
+    EXPECT_EQ(hitCount, expectedHits);
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<TempDirectoryPath> tempDir_;
+};
+
+TEST_F(HashTableSerializationTest, BasicSerializationDefault) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<std::string>({"a", "b", "c", "d", "e"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, BasicSerializationJoinProbe) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<std::string>({"a", "b", "c", "d", "e"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+  verifyJoinProbe(restored.get(), data, data->size());
+}
+
+TEST_F(HashTableSerializationTest, MultipleDataTypes) {
+  auto table = createTestHashTable(
+      {BIGINT(), INTEGER(), VARCHAR()}, {DOUBLE(), BOOLEAN()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int32_t>({10, 20, 30}),
+       makeFlatVector<std::string>({"key1", "key2", "key3"}),
+       makeFlatVector<double>({1.1, 2.2, 3.3}),
+       makeFlatVector<bool>({true, false, true})});
+
+  insertData(table.get(), data, {0, 1, 2});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, NullValues) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, std::nullopt, 3, std::nullopt, 5}),
+       makeNullableFlatVector<std::string>(
+           {"a", std::nullopt, "c", "d", std::nullopt})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, LargeDataSet) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  std::vector<int64_t> keys;
+  std::vector<std::string> values;
+  for (int i = 0; i < 10000; ++i) {
+    keys.push_back(i);
+    values.push_back("value_" + std::to_string(i));
+  }
+
+  auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, LongStrings) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  std::vector<std::string> values = {
+      "short",
+      "this is a very long string that exceeds 12 bytes",
+      "medium",
+      std::string(1000, 'x'),
+      ""};
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}), makeFlatVector(values)});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, AllowDuplicates) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, true);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 1, 2, 2, 3}),
+       makeFlatVector<std::string>({"a1", "a2", "b1", "b2", "c"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, CrossProcessSerialization) {
+  std::string tempFile = tempDir_->getPath() + "/hashtable_cross_process.bin";
+
+  pid_t pid = fork();
+
+  if (pid == 0) {
+    auto childPool = memory::memoryManager()->addLeafPool();
+    pool_ = childPool;
+    auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+    auto data = makeRowVector(
+        {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+         makeFlatVector<std::string>(
+             {"child1", "child2", "child3", "child4", "child5"})});
+
+    insertData(table.get(), data, {0});
+    table->prepareJoinTable(
+        {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+    const auto serialized = serialize(*table);
+    writeFile(tempFile, serialized);
+
+    exit(0);
+  } else {
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_EQ(WEXITSTATUS(status), 0) << "Child process failed";
+
+    const auto serialized = readFile(tempFile);
+    ASSERT_GT(serialized.size(), 0) << "Failed to read serialized file";
+    auto restored = deserialize(serialized, pool_.get());
+
+    EXPECT_EQ(restored->numDistinct(), 5);
+    EXPECT_EQ(restored->rows()->numRows(), 5);
+
+    std::remove(tempFile.c_str());
+  }
+}
+
+TEST_F(HashTableSerializationTest, MultiProcessConcurrentSerialization) {
+  const int numProcesses = 4;
+  std::vector<std::string> tempFiles;
+
+  for (int i = 0; i < numProcesses; ++i) {
+    std::string tempFile = tempDir_->getPath() + "/hashtable_process_" +
+        std::to_string(i) + ".bin";
+    tempFiles.push_back(tempFile);
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+      auto childPool = memory::memoryManager()->addLeafPool();
+      pool_ = childPool;
+      auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+      int start = i * 1000;
+      int end = start + 1000;
+
+      std::vector<int64_t> keys;
+      std::vector<std::string> values;
+      for (int j = start; j < end; ++j) {
+        keys.push_back(j);
+        values.push_back(
+            "process_" + std::to_string(i) + "_value_" + std::to_string(j));
+      }
+
+      auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+      insertData(table.get(), data, {0});
+      table->prepareJoinTable(
+          {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+      const auto serialized = serialize(*table);
+      writeFile(tempFile, serialized);
+
+      exit(0);
+    }
+  }
+
+  for (int i = 0; i < numProcesses; ++i) {
+    int status;
+    wait(&status);
+    ASSERT_EQ(WEXITSTATUS(status), 0) << "Child process " << i << " failed";
+  }
+
+  for (int i = 0; i < numProcesses; ++i) {
+    const auto serialized = readFile(tempFiles[i]);
+    ASSERT_GT(serialized.size(), 0) << "Failed to read file from process " << i;
+    auto restored = deserialize(serialized, pool_.get());
+
+    EXPECT_EQ(restored->numDistinct(), 1000)
+        << "Process " << i << " data mismatch";
+
+    std::remove(tempFiles[i].c_str());
+  }
+}
+
+TEST_F(HashTableSerializationTest, CrossProcessDataMerge) {
+  const int numPartitions = 3;
+  std::vector<std::string> partitionFiles;
+
+  for (int i = 0; i < numPartitions; ++i) {
+    std::string tempFile =
+        tempDir_->getPath() + "/partition_" + std::to_string(i) + ".bin";
+    partitionFiles.push_back(tempFile);
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+      auto childPool = memory::memoryManager()->addLeafPool();
+      pool_ = childPool;
+      auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+      std::vector<int64_t> keys;
+      std::vector<std::string> values;
+
+      for (int64_t key = 0; key < 1000; ++key) {
+        if (key % numPartitions == i) {
+          keys.push_back(key);
+          values.push_back(
+              "partition_" + std::to_string(i) + "_key_" + std::to_string(key));
+        }
+      }
+
+      auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+      insertData(table.get(), data, {0});
+      table->prepareJoinTable(
+          {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+      const auto serialized = serialize(*table);
+      writeFile(tempFile, serialized);
+
+      exit(0);
+    }
+  }
+
+  for (int i = 0; i < numPartitions; ++i) {
+    int status;
+    wait(&status);
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+  }
+
+  int totalRows = 0;
+  for (int i = 0; i < numPartitions; ++i) {
+    const auto serialized = readFile(partitionFiles[i]);
+    ASSERT_GT(serialized.size(), 0) << "Failed to read partition file " << i;
+    auto partition = deserialize(serialized, pool_.get());
+
+    totalRows += partition->numDistinct();
+
+    std::remove(partitionFiles[i].c_str());
+  }
+
+  EXPECT_EQ(totalRows, 1000) << "Merged data count mismatch";
+}
+
+TEST_F(HashTableSerializationTest, PerformanceBenchmark) {
+  const int numRows = 100000;
+
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  std::vector<int64_t> keys;
+  std::vector<std::string> values;
+  for (int i = 0; i < numRows; ++i) {
+    keys.push_back(i);
+    values.push_back("benchmark_value_" + std::to_string(i));
+  }
+
+  auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  {
+    auto start = std::chrono::high_resolution_clock::now();
+
+    const auto serialized = serialize(*table);
+
+    auto serEnd = std::chrono::high_resolution_clock::now();
+
+    auto restored = deserialize(serialized, pool_.get());
+
+    auto deserEnd = std::chrono::high_resolution_clock::now();
+
+    auto serTime =
+        std::chrono::duration_cast<std::chrono::milliseconds>(serEnd - start)
+            .count();
+    auto deserTime =
+        std::chrono::duration_cast<std::chrono::milliseconds>(deserEnd - serEnd)
+            .count();
+
+    LOG(INFO) << "Default Serialization Performance (" << numRows << " rows):";
+    LOG(INFO) << "  Serialization: " << serTime << " ms";
+    LOG(INFO) << "  Deserialization: " << deserTime << " ms";
+    LOG(INFO) << "  Total: " << (serTime + deserTime) << " ms";
+  }
+}
+
+TEST_F(HashTableSerializationTest, InvalidMagicNumber) {
+  uint32_t invalidMagic = 0x12345678;
+  std::string data(sizeof(invalidMagic), '\0');
+  std::memcpy(data.data(), &invalidMagic, sizeof(invalidMagic));
+  EXPECT_THROW(deserialize(data, pool_.get()), VeloxException);
+}
+
+TEST_F(HashTableSerializationTest, UnsupportedVersion) {
+  uint32_t magic = 0x48415348;
+  uint32_t version = 999;
+  std::string data(sizeof(magic) + sizeof(version), '\0');
+  std::memcpy(data.data(), &magic, sizeof(magic));
+  std::memcpy(data.data() + sizeof(magic), &version, sizeof(version));
+  EXPECT_THROW(deserialize(data, pool_.get()), VeloxException);
+}
+
+TEST_F(HashTableSerializationTest, CorruptedData) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<std::string>({"a", "b", "c"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  auto serialized = serialize(*table);
+  ASSERT_GT(serialized.size(), 8);
+  serialized.resize(serialized.size() - 8);
+  EXPECT_THROW(deserialize(serialized, pool_.get()), VeloxException);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -1683,6 +1683,76 @@ TEST_F(VectorHasherTest, stringFilterDistinctOverflow) {
   ASSERT_TRUE(filter == nullptr);
 }
 
+TEST_F(VectorHasherTest, serializeStateRoundTripStringDistinctValues) {
+  std::vector<std::string> strings = {
+      "short",
+      "this is a long string value",
+      "medium",
+      "another long string value",
+      "short"};
+
+  auto vector = makeFlatVector<StringView>(
+      strings.size(),
+      [&strings](vector_size_t row) { return StringView(strings[row]); });
+
+  auto hasher = exec::VectorHasher::create(VARCHAR(), 0);
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> hashes(vector->size());
+  hasher->decode(*vector, rows);
+  hasher->computeValueIds(rows, hashes);
+  hasher->enableValueIds(1, 0);
+
+  auto serialized = hasher->serializeState();
+
+  auto restored = exec::VectorHasher::create(VARCHAR(), 0);
+  restored->deserializeState(serialized);
+
+  EXPECT_EQ(restored->numUniqueValues(), 4);
+
+  auto filter = restored->getFilter(false);
+  ASSERT_NE(filter, nullptr);
+  auto bytesValues = dynamic_cast<common::BytesValues*>(filter.get());
+  ASSERT_NE(bytesValues, nullptr);
+  EXPECT_TRUE(bytesValues->testBytes(strings[0].data(), strings[0].size()));
+  EXPECT_TRUE(bytesValues->testBytes(strings[1].data(), strings[1].size()));
+  EXPECT_TRUE(bytesValues->testBytes(strings[2].data(), strings[2].size()));
+  EXPECT_TRUE(bytesValues->testBytes(strings[3].data(), strings[3].size()));
+  EXPECT_FALSE(bytesValues->testBytes("missing", 7));
+}
+
+TEST_F(VectorHasherTest, serializeStateRoundTripBloomFilter) {
+  auto hasher = exec::VectorHasher::create(BIGINT(), 0);
+
+  constexpr uint32_t numRows = 10'000;
+  constexpr int numBatches = 15;
+  SelectivityVector rows(numRows);
+  raw_vector<uint64_t> hashes(numRows);
+  for (int batch = 0; batch < numBatches; ++batch) {
+    auto vector = makeFlatVector<int64_t>(
+        numRows, [batch](vector_size_t row) { return batch * numRows + row; });
+    hasher->decode(*vector, rows);
+    hasher->computeValueIds(rows, hashes);
+  }
+
+  ASSERT_TRUE(hasher->supportsBloomFilter());
+
+  auto filter = std::make_shared<common::BigintValuesUsingBloomFilter>(
+      numRows * numBatches, false);
+  for (int64_t value : {1, 17, 1024, 65536}) {
+    filter->insert(value);
+  }
+  hasher->setBloomFilter(filter);
+
+  auto serialized = hasher->serializeState();
+
+  auto restored = exec::VectorHasher::create(BIGINT(), 0);
+  restored->deserializeState(serialized);
+
+  auto restoredFilter = restored->getBloomFilter();
+  ASSERT_NE(restoredFilter, nullptr);
+  EXPECT_TRUE(restoredFilter->testingEquals(*filter));
+}
+
 DEBUG_ONLY_TEST_F(VectorHasherTest, customComparisonNoValueIds) {
   // Test that custom comparison types cannot use value IDs for optimization.
   auto data = makeRowVector({makeNullableFlatVector<int64_t>(

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -23,6 +24,7 @@
 #include "velox/type/Filter.h"
 
 #include "velox/common/EnumDefine.h"
+#include "velox/common/serialization/NativeSerdeIO.h"
 
 namespace facebook::velox::common {
 
@@ -415,6 +417,41 @@ std::unique_ptr<Filter> BigintValuesUsingBloomFilter::create(
       i = 0;
     }
   }
+  return std::unique_ptr<BigintValuesUsingBloomFilter>(
+      new BigintValuesUsingBloomFilter(nullAllowed, std::move(blocks)));
+}
+
+void BigintValuesUsingBloomFilter::serializeBinary(std::string& out) const {
+  common::NativeStringWriter writer(out);
+  writer.writeValue<bool>(nullAllowed());
+  writer.writeValue<uint32_t>(xsimd::batch<uint32_t>::size);
+  writer.writeValue<uint32_t>(blocks_.size());
+  for (const auto& block : blocks_) {
+    for (auto word : block.data) {
+      writer.writeValue<uint32_t>(word);
+    }
+  }
+}
+
+std::unique_ptr<Filter> BigintValuesUsingBloomFilter::deserializeBinary(
+    std::string_view data) {
+  common::NativeStringReader reader(data);
+  const auto nullAllowed = reader.readValue<bool>();
+  const auto simdWidth = reader.readValue<uint32_t>();
+  VELOX_USER_CHECK_EQ(
+      simdWidth,
+      xsimd::batch<uint32_t>::size,
+      "Cannot deserialize BigintValuesUsingBloomFilter serialized on hardware with different SIMD length");
+  const auto numBlocks = reader.readValue<uint32_t>();
+  std::vector<SplitBlockBloomFilter::Block> blocks(numBlocks);
+  for (auto& block : blocks) {
+    for (auto& word : block.data) {
+      word = reader.readValue<uint32_t>();
+    }
+  }
+  VELOX_USER_CHECK(
+      reader.atEnd(),
+      "Trailing bytes in BigintValuesUsingBloomFilter binary data");
   return std::unique_ptr<BigintValuesUsingBloomFilter>(
       new BigintValuesUsingBloomFilter(nullAllowed, std::move(blocks)));
 }

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include <folly/Range.h>
 #include <folly/container/F14Set.h>
 #include <xsimd/xsimd.hpp>
@@ -1337,6 +1339,10 @@ class BigintValuesUsingBloomFilter final : public Filter {
   folly::dynamic serialize() const override;
 
   static std::unique_ptr<Filter> create(const folly::dynamic& obj);
+
+  void serializeBinary(std::string& out) const;
+
+  static std::unique_ptr<Filter> deserializeBinary(std::string_view data);
 
   bool testingEquals(const Filter& other) const override;
 


### PR DESCRIPTION
## Problem

`HashTable` currently does not support native serialization/deserialization.  
To enable driver-side broadcast hash join in Gluten (similar to Spark), we need to serialize the pre-built hash table on the driver and deserialize it on executors.

## Context

A `HashTable` cannot be restored correctly by serializing only the bucket contents. Its runtime behavior also depends on:
- `RowContainer` row layout and stored row payloads,
- `VectorHasher` state used by non-`kHash` probe paths,
- optional bloom filter state,
- hash-mode-specific rebuild behavior (`kHash`, `kArray`, `kNormalizedKey`).

## Changes

- Added native binary serde helpers in `velox/common/serialization/NativeSerdeIO.h`.
- Added `HashTable::serializedSize()`, `HashTable::serializeTo(...)`, and `HashTable::deserializeFrom(...)`.
- Serialized and restored:
  - hash table metadata and versioning,
  - key/dependent type information,
  - row data and stored hashes,
  - `columnHasNulls_`,
  - `VectorHasher` state,
  - normalized keys when present.
- Added `RowContainer::storeSerializedRow(std::string_view, char*)` to restore rows directly from serialized row bytes.
- Added `VectorHasher` state serialization/deserialization to preserve value-id/range state across processes.
- Added binary serialization/deserialization for `BigintValuesUsingBloomFilter`.
- Rebuilt the table during deserialization based on hash mode:
  - reused serialized hashes for `kHash` / `kNormalizedKey`,
  - recomputed value IDs for `kArray` to match restored `VectorHasher` state.
- Added unit tests covering:
  - round-trip serialization/deserialization,
  - join probe after restore,
  - multiple data types, nulls, long strings, duplicates, and large inputs,
  - corrupted/invalid payload handling,
  - cross-process serialization scenarios,
  - `VectorHasher` state round-trip cases.

## Testing

- Added `HashTableSerializationTest`
- Added `VectorHasher` serialization round-trip tests