### PR TITLE
feat(serde): Coerce narrow encoding to widened type during PrestoSerializer deserialization

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -81,7 +81,11 @@ Exchange::Exchange(
           std::nullopt,
           operatorCtx_->driverCtx()
               ->queryConfig()
-              .minShuffleCompressionPageSizeBytes())},
+              .minShuffleCompressionPageSizeBytes(),
+          // Threaded through for PushDownWidenCast DATE -> TIMESTAMP coercion.
+          operatorCtx_->driverCtx()->queryConfig().adjustTimestampToTimezone()
+              ? operatorCtx_->driverCtx()->queryConfig().sessionTimezone()
+              : std::string{})},
       processSplits_{operatorCtx_->driverCtx()->driverId == 0},
       driverId_{driverCtx->driverId},
       exchangeClient_{std::move(exchangeClient)} {}

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -786,7 +786,11 @@ MergeExchange::MergeExchange(
               driverCtx->queryConfig().shuffleCompressionKind()),
           mergeExchangeNode->serdeKind(),
           std::nullopt,
-          driverCtx->queryConfig().minShuffleCompressionPageSizeBytes())) {}
+          driverCtx->queryConfig().minShuffleCompressionPageSizeBytes(),
+          // Threaded through for PushDownWidenCast DATE -> TIMESTAMP coercion.
+          driverCtx->queryConfig().adjustTimestampToTimezone()
+              ? driverCtx->queryConfig().sessionTimezone()
+              : std::string{})) {}
 
 BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
   if (operatorCtx_->driverCtx()->driverId != 0) {

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -587,7 +587,8 @@ std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
     common::CompressionKind compressionKind,
     const std::string& kind,
     std::optional<float> minCompressionRatio,
-    int32_t minCompressionPageSizeBytes) {
+    int32_t minCompressionPageSizeBytes,
+    std::string_view sessionTimezone) {
   std::unique_ptr<VectorSerde::Options> options = kind == "Presto"
       ? std::make_unique<serializer::presto::PrestoVectorSerde::PrestoOptions>()
       : std::make_unique<VectorSerde::Options>();
@@ -596,6 +597,12 @@ std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
     options->minCompressionRatio = minCompressionRatio.value();
   }
   options->minCompressionPageSizeBytes = minCompressionPageSizeBytes;
+  if (kind == "Presto" && !sessionTimezone.empty()) {
+    static_cast<serializer::presto::PrestoVectorSerde::PrestoOptions*>(
+        options.get())
+        ->sessionTimezone =
+        tz::locateZone(sessionTimezone, /*failOnError=*/false);
+  }
   return options;
 }
 

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -319,10 +319,17 @@ class BlockedOperatorFactory : public Operator::PlanNodeTranslator {
 
 /// Creates VectorSerde::Options for the given VectorSerde kind with compression
 /// settings. Optionally configures minimum compression ratio.
+/// If `kind` is "Presto" and `sessionTimezone` is non-empty, the resulting
+/// PrestoOptions::sessionTimezone is populated by looking up the zone via
+/// tz::locateZone; this is needed for PushDownWidenCast's DATE -> TIMESTAMP
+/// coercion to match Velox's CastExpr::castFromDate behavior. Pass an empty
+/// string when the caller has no session zone (serialization-only paths) or
+/// when adjust_timestamp_to_session_timezone is false.
 std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
     common::CompressionKind compressionKind,
     const std::string& kind,
     std::optional<float> minCompressionRatio = std::nullopt,
-    int32_t minCompressionPageSizeBytes = 0);
+    int32_t minCompressionPageSizeBytes = 0,
+    std::string_view sessionTimezone = "");
 
 } // namespace facebook::velox::exec

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -20,6 +20,7 @@
 #include "velox/common/base/Crc.h"
 #include "velox/common/compression/Compression.h"
 #include "velox/serializers/PrestoVectorLexer.h"
+#include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::serializer::presto {
@@ -86,6 +87,14 @@ class PrestoVectorSerde : public VectorSerde {
     /// affect the encoding of the input vectors. This is only relevant when
     /// using BatchVectorSerializer.
     bool preserveEncodings{false};
+
+    /// Session timezone used by PushDownWidenCast deserialization-time
+    /// coercions whose semantics depend on the session zone (currently only
+    /// DATE -> TIMESTAMP). Owned by the timezone registry returned by
+    /// tz::locateZone(); not owned here. nullptr means no adjustment is
+    /// applied (matches Velox CastExpr behavior when
+    /// adjust_timestamp_to_session_timezone is false or the zone is empty).
+    const tz::TimeZone* sessionTimezone{nullptr};
   };
 
   PrestoVectorSerde() : VectorSerde(kSerdeKind) {}

--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -103,6 +103,56 @@ void readStructNulls(
   source->skip(numValues * sizeof(T));
 }
 
+// Companion to `tryReadWidenedColumn` for the two-pass null-tracking pre-pass.
+// When the producer emitted a narrow encoding but the consumer declared a wider
+// type, the first (structured-nulls) pass would otherwise throw via
+// `checkTypeEncoding` before the main read pass had a chance to coerce. Here we
+// just need to skip the right number of bytes — `numValues * sizeof(SourceT)`,
+// using the SOURCE width implied by the encoding, not the wider target. Returns
+// true if the (encoding, columnType) pair is a known widening and the source
+// bytes have been consumed; false otherwise (caller falls through to the
+// regular encoding-mismatch path).
+bool tryStructNullsSkipWidened(
+    std::string_view encoding,
+    const TypePtr& columnType,
+    ByteInputStream* source,
+    Scratch& scratch) {
+  size_t sourceBytes;
+  bool isWidening = false;
+  if (encoding == kByteArray) {
+    // TINYINT (int8_t) on the wire.
+    sourceBytes = 1;
+    auto k = columnType->kind();
+    isWidening = (k == TypeKind::SMALLINT || k == TypeKind::INTEGER ||
+                  k == TypeKind::BIGINT);
+  } else if (encoding == kShortArray) {
+    // SMALLINT (int16_t) on the wire.
+    sourceBytes = 2;
+    auto k = columnType->kind();
+    isWidening = (k == TypeKind::INTEGER || k == TypeKind::BIGINT);
+  } else if (encoding == kIntArray) {
+    // INTEGER / REAL / DATE on the wire (all 4 bytes).
+    sourceBytes = 4;
+    if (columnType->isDate()) {
+      // DATE on the wire as the *consumer* type means encoding == kIntArray ==
+      // typeToEncodingName(DATE) — not a widening, normal path handles it.
+      return false;
+    }
+    auto k = columnType->kind();
+    isWidening = (k == TypeKind::BIGINT || k == TypeKind::DOUBLE ||
+                  k == TypeKind::TIMESTAMP);
+  } else {
+    return false;
+  }
+  if (!isWidening) {
+    return false;
+  }
+  const int32_t size = source->read<int32_t>();
+  auto numValues = valueCount(source, size, scratch);
+  source->skip(numValues * sourceBytes);
+  return true;
+}
+
 template <>
 void readStructNulls<StringView>(
     ByteInputStream* source,
@@ -264,6 +314,14 @@ void readStructNullsColumns(
       readDictionaryVectorStructNulls(
           source, columnType, useLosslessTimestamp, scratch);
     } else {
+      // Consumer-side widening (PushDownWidenCast). If the producer emitted a
+      // narrower encoding for this column than the consumer declared, skip the
+      // right number of *source* bytes here so the next pass can deserialize
+      // with the matching `tryReadWidenedColumn` path. Without this, the
+      // checkTypeEncoding call below throws on the first (null-tracking) pass.
+      if (tryStructNullsSkipWidened(encoding, columnType, source, scratch)) {
+        continue;
+      }
       checkTypeEncoding(encoding, columnType);
       const auto it = readers.find(
           isIPPrefixType(columnType) ? TypeKind::VARCHAR : columnType->kind());
@@ -1271,6 +1329,200 @@ bool tryReadNullColumn(
   return true;
 }
 
+// Reads `size` narrow-typed values (`SourceT`) from `source`, applies `cvt` to
+// each, and writes the widened value into the `TargetT`-typed `values` buffer.
+// Used to support PushDownWidenCast-style consumer-side coercion: when the
+// producer fragment emits narrow-typed data on the wire but the consumer's
+// RemoteSource has been rewritten to a wider declared type, the Exchange
+// operator (which calls into this serializer) coerces narrow->wide as it
+// emits pages.
+template <typename SourceT, typename TargetT, typename Converter>
+void readWideningValues(
+    ByteInputStream* source,
+    vector_size_t size,
+    vector_size_t offset,
+    const BufferPtr& nulls,
+    vector_size_t nullCount,
+    const BufferPtr& values,
+    Converter cvt) {
+  auto* rawValues = values->asMutable<TargetT>();
+  if (nullCount) {
+    int32_t toClear = offset;
+    bits::forEachSetBit(
+        nulls->as<uint64_t>(), offset, offset + size, [&](int32_t row) {
+          // Set the values between the last non-null and this to type default.
+          for (; toClear < row; ++toClear) {
+            rawValues[toClear] = TargetT{};
+          }
+          rawValues[row] = cvt(source->read<SourceT>());
+          toClear = row + 1;
+        });
+  } else {
+    for (int32_t row = offset; row < offset + size; ++row) {
+      rawValues[row] = cvt(source->read<SourceT>());
+    }
+  }
+}
+
+// Top-level widened column reader: reads the size + nulls header, then dispatches
+// to `readWideningValues<SourceT, TargetT>` to fill `result`. `result` must be a
+// FlatVector<TargetT> of the wide `columnType` (the caller ensures this).
+template <typename SourceT, typename TargetT, typename Converter>
+void readWidened(
+    ByteInputStream* source,
+    const TypePtr& columnType,
+    vector_size_t resultOffset,
+    const uint64_t* incomingNulls,
+    int32_t numIncomingNulls,
+    velox::memory::MemoryPool* pool,
+    VectorPtr& result,
+    Converter cvt) {
+  if (result == nullptr) {
+    result = BaseVector::create(columnType, 0, pool);
+  } else if (
+      result->encoding() == VectorEncoding::Simple::CONSTANT ||
+      result->encoding() == VectorEncoding::Simple::DICTIONARY) {
+    BaseVector::ensureWritable(SelectivityVector::empty(), columnType, pool, result);
+  }
+  const int32_t size = source->read<int32_t>();
+  const auto numNewValues = sizeWithIncomingNulls(size, numIncomingNulls);
+  result->resize(resultOffset + numNewValues);
+  auto* flatResult = result->asUnchecked<FlatVector<TargetT>>();
+  auto nullCount = readNulls(
+      source, size, resultOffset, incomingNulls, numIncomingNulls, *flatResult);
+  BufferPtr values = flatResult->mutableValues();
+  readWideningValues<SourceT, TargetT>(
+      source, numNewValues, resultOffset, flatResult->nulls(), nullCount, values, cvt);
+}
+
+// Returns true if `encoding` is a narrow wire encoding that can be widened to
+// `columnType`, and reads + widens the column into `result`. Returns false (and
+// leaves the stream / result unchanged) if the pair is not a supported widening.
+//
+// Supported widening pairs (mirrors WIDENING_CAST_MAP in
+// PushDownWidenCast.java):
+//   BYTE_ARRAY  (TINYINT)  -> SMALLINT, INTEGER, BIGINT
+//   SHORT_ARRAY (SMALLINT) -> INTEGER, BIGINT
+//   INT_ARRAY   (INTEGER)  -> BIGINT
+//   INT_ARRAY   (REAL)     -> DOUBLE
+//   INT_ARRAY   (DATE)     -> TIMESTAMP
+//
+// Trust contract with the planner: the dispatch below keys only on (encoding,
+// columnType). It cannot distinguish, from the wire alone, whether a kIntArray
+// page carries INTEGER bytes vs. REAL bytes vs. DATE bytes -- they are all
+// 4-byte values. The mapping is unambiguous because each (encoding, target)
+// pair appears in WIDENING_CAST_MAP for exactly one source type. The planner
+// (PushDownWidenCast) is the sole producer of (encoding, target) pairs the
+// deserializer sees; it only widens pairs from WIDENING_CAST_MAP. Pairs not
+// in the map fall through to checkTypeEncoding() in readColumns() and still
+// throw on mismatch.
+//
+// If a future planner change introduces a new widening, BOTH the Java map and
+// this dispatch must be updated together. A producer that emits encoding bytes
+// inconsistent with the planner-promised source type (e.g. REAL bits in
+// kIntArray when the planner expected INTEGER) would be silently
+// reinterpreted here; this is the same trust the planner already places on
+// every operator downstream of it.
+bool tryReadWidenedColumn(
+    std::string_view encoding,
+    const TypePtr& columnType,
+    ByteInputStream* source,
+    vector_size_t resultOffset,
+    const uint64_t* incomingNulls,
+    int32_t numIncomingNulls,
+    velox::memory::MemoryPool* pool,
+    const PrestoVectorSerde::PrestoOptions& opts,
+    VectorPtr& result) {
+  if (encoding == kByteArray) {
+    // TINYINT (int8_t) on the wire.
+    switch (columnType->kind()) {
+      case TypeKind::SMALLINT:
+        readWidened<int8_t, int16_t>(
+            source, columnType, resultOffset, incomingNulls, numIncomingNulls, pool, result,
+            [](int8_t v) { return static_cast<int16_t>(v); });
+        return true;
+      case TypeKind::INTEGER:
+        readWidened<int8_t, int32_t>(
+            source, columnType, resultOffset, incomingNulls, numIncomingNulls, pool, result,
+            [](int8_t v) { return static_cast<int32_t>(v); });
+        return true;
+      case TypeKind::BIGINT:
+        readWidened<int8_t, int64_t>(
+            source, columnType, resultOffset, incomingNulls, numIncomingNulls, pool, result,
+            [](int8_t v) { return static_cast<int64_t>(v); });
+        return true;
+      default:
+        return false;
+    }
+  }
+  if (encoding == kShortArray) {
+    // SMALLINT (int16_t) on the wire.
+    switch (columnType->kind()) {
+      case TypeKind::INTEGER:
+        readWidened<int16_t, int32_t>(
+            source, columnType, resultOffset, incomingNulls, numIncomingNulls, pool, result,
+            [](int16_t v) { return static_cast<int32_t>(v); });
+        return true;
+      case TypeKind::BIGINT:
+        readWidened<int16_t, int64_t>(
+            source, columnType, resultOffset, incomingNulls, numIncomingNulls, pool, result,
+            [](int16_t v) { return static_cast<int64_t>(v); });
+        return true;
+      default:
+        return false;
+    }
+  }
+  if (encoding == kIntArray) {
+    // 4-byte values on the wire (INTEGER, REAL, or DATE — distinguished by the
+    // target columnType, which the planner-side PushDownWidenCast picks
+    // exclusively from the WIDENING_CAST_MAP).
+    if (columnType->isDate()) {
+      // DATE (days since epoch, int32) -> any wider type. Only TIMESTAMP is in
+      // the widening map.
+      return false;
+    }
+    switch (columnType->kind()) {
+      case TypeKind::BIGINT:
+        // INTEGER -> BIGINT.
+        readWidened<int32_t, int64_t>(
+            source, columnType, resultOffset, incomingNulls, numIncomingNulls, pool, result,
+            [](int32_t v) { return static_cast<int64_t>(v); });
+        return true;
+      case TypeKind::DOUBLE:
+        // REAL -> DOUBLE. The 4 bytes are float bits.
+        readWidened<float, double>(
+            source, columnType, resultOffset, incomingNulls, numIncomingNulls, pool, result,
+            [](float v) { return static_cast<double>(v); });
+        return true;
+      case TypeKind::TIMESTAMP: {
+        // DATE (int32 days since epoch) -> TIMESTAMP. Mirrors
+        // CastExpr::castFromDate: compute wall-clock midnight from
+        // `days * 86_400_000` ms, then adjust to GMT using the session zone
+        // when adjust_timestamp_to_session_timezone is enabled. Without the
+        // zone adjustment the result would be off by the session offset (e.g.
+        // DATE '2024-01-15' in America/Los_Angeles would render as
+        // 2024-01-14 16:00:00 instead of 2024-01-15 00:00:00).
+        const tz::TimeZone* timeZone = opts.sessionTimezone;
+        readWidened<int32_t, Timestamp>(
+            source, columnType, resultOffset, incomingNulls, numIncomingNulls, pool, result,
+            [timeZone](int32_t days) {
+              constexpr int64_t kMillisPerDay{86'400'000};
+              auto timestamp =
+                  Timestamp::fromMillis(static_cast<int64_t>(days) * kMillisPerDay);
+              if (timeZone != nullptr) {
+                timestamp.toGMT(*timeZone);
+              }
+              return timestamp;
+            });
+        return true;
+      }
+      default:
+        return false;
+    }
+  }
+  return false;
+}
+
 void readColumns(
     ByteInputStream* source,
     const std::vector<TypePtr>& types,
@@ -1339,6 +1591,23 @@ void readColumns(
     } else {
       auto typeToEncoding = typeToEncodingName(columnType);
       if (encoding != typeToEncoding) {
+        // Consumer-side widening (PushDownWidenCast). Check this BEFORE
+        // tryReadNullColumn — tryReadNullColumn consumes bytes from the stream
+        // (it reads the column as UNKNOWN to test if it's all-null), so if it
+        // doesn't apply, our widening reader would see a partially-consumed
+        // stream and read garbage.
+        if (tryReadWidenedColumn(
+                encoding,
+                columnType,
+                source,
+                resultOffset,
+                incomingNulls,
+                numIncomingNulls,
+                pool,
+                opts,
+                columnResult)) {
+          continue;
+        }
         if (encoding == kByteArray &&
             tryReadNullColumn(
                 source,

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -128,6 +128,8 @@ class PrestoSerializerTest
     serializer::presto::PrestoVectorSerde::PrestoOptions paramOptions{
         useLosslessTimestamp, kind, 0.8, nullsFirst, preserveEncodings};
     paramOptions.useMicrosecondPrecision = useMicrosecondPrecision;
+    paramOptions.sessionTimezone =
+        serdeOptions == nullptr ? nullptr : serdeOptions->sessionTimezone;
 
     return paramOptions;
   }
@@ -1691,6 +1693,195 @@ TEST_P(PrestoSerializerTest, typeMismatch) {
       deserialize(ROW({BIGINT(), DOUBLE()}), serialized, nullptr),
       "Serialized encoding is not compatible with requested type: DOUBLE. "
       "Expected LONG_ARRAY. Got VARIABLE_WIDTH.");
+}
+
+// Consumer-side widening: when PushDownWidenCast rewrites the consumer's source
+// operator to declare a wider type, the producer still emits narrow-typed bytes
+// on the wire. The deserializer must read the narrow bytes and emit a widened
+// vector. One test per supported widening pair.
+TEST_P(PrestoSerializerTest, wideningCoercionTinyintToBigint) {
+  auto narrow = makeRowVector({
+      makeFlatVector<int8_t>({-5, 0, 7, 42, 127, -128}),
+  });
+  std::ostringstream out;
+  serialize(narrow, &out, nullptr);
+  // skipLexer=true because the lexer validates encoding-vs-type matching, which
+  // is exactly the constraint widening intentionally crosses.
+  auto deserialized = deserialize(
+      ROW({BIGINT()}), out.str(), nullptr, /*skipLexer=*/true);
+  assertEqualVectors(
+      deserialized,
+      makeRowVector(
+          {makeFlatVector<int64_t>({-5, 0, 7, 42, 127, -128})}));
+}
+
+TEST_P(PrestoSerializerTest, wideningCoercionSmallintToInteger) {
+  auto narrow = makeRowVector({
+      makeFlatVector<int16_t>({-1000, 0, 1000, 32767, -32768}),
+  });
+  std::ostringstream out;
+  serialize(narrow, &out, nullptr);
+  auto deserialized = deserialize(ROW({INTEGER()}), out.str(), nullptr);
+  assertEqualVectors(
+      deserialized,
+      makeRowVector(
+          {makeFlatVector<int32_t>({-1000, 0, 1000, 32767, -32768})}));
+}
+
+TEST_P(PrestoSerializerTest, wideningCoercionIntegerToBigint) {
+  auto narrow = makeRowVector({
+      makeFlatVector<int32_t>(
+          {-100'000, 0, 100'000, 2'147'483'647, -2'147'483'648}),
+  });
+  std::ostringstream out;
+  serialize(narrow, &out, nullptr);
+  auto deserialized = deserialize(ROW({BIGINT()}), out.str(), nullptr);
+  assertEqualVectors(
+      deserialized,
+      makeRowVector({makeFlatVector<int64_t>(
+          {-100'000, 0, 100'000, 2'147'483'647, -2'147'483'648})}));
+}
+
+TEST_P(PrestoSerializerTest, wideningCoercionRealToDouble) {
+  auto narrow = makeRowVector({
+      makeFlatVector<float>({-1.5f, 0.0f, 1.5f, 3.14159f}),
+  });
+  std::ostringstream out;
+  serialize(narrow, &out, nullptr);
+  auto deserialized = deserialize(ROW({DOUBLE()}), out.str(), nullptr);
+  // Float -> double widens exactly (no precision loss for the round-trip),
+  // so static_cast<double>(static_cast<float>(v)) preserves the bits.
+  assertEqualVectors(
+      deserialized,
+      makeRowVector({makeFlatVector<double>(
+          {static_cast<double>(-1.5f),
+           static_cast<double>(0.0f),
+           static_cast<double>(1.5f),
+           static_cast<double>(3.14159f)})}));
+}
+
+TEST_P(PrestoSerializerTest, wideningCoercionDateToTimestamp) {
+  // DATE is stored as int32 days since epoch. After widening to TIMESTAMP with
+  // no session timezone we expect Timestamp(days * 86400, 0) -- UTC midnight.
+  auto narrow = makeRowVector({
+      makeFlatVector<int32_t>(
+          {0 /* 1970-01-01 */,
+           1 /* 1970-01-02 */,
+           20'089 /* ~ 2025-01-01 */,
+           -1 /* 1969-12-31 */},
+          DATE()),
+  });
+  std::ostringstream out;
+  serialize(narrow, &out, nullptr);
+  auto deserialized = deserialize(ROW({TIMESTAMP()}), out.str(), nullptr);
+  assertEqualVectors(
+      deserialized,
+      makeRowVector({makeFlatVector<Timestamp>(
+          {Timestamp(0 * Timestamp::kSecondsInDay, 0),
+           Timestamp(1 * Timestamp::kSecondsInDay, 0),
+           Timestamp(20'089 * Timestamp::kSecondsInDay, 0),
+           Timestamp(-1 * Timestamp::kSecondsInDay, 0)})}));
+}
+
+TEST_P(PrestoSerializerTest, wideningCoercionDateToTimestampWithSessionTimezone) {
+  // When the session timezone is set, the DATE -> TIMESTAMP coercion must
+  // match CastExpr::castFromDate: compute wall-clock midnight, then call
+  // toGMT(zone) to convert to UTC instant. Without the adjustment,
+  // DATE '2024-01-15' in America/Los_Angeles would render as
+  // 2024-01-14 16:00:00 instead of 2024-01-15 00:00:00.
+  const std::vector<int32_t> days = {
+      0 /* 1970-01-01 */,
+      1 /* 1970-01-02 */,
+      19'737 /* 2024-01-15 */,
+      -1 /* 1969-12-31 */,
+  };
+  auto narrow = makeRowVector({makeFlatVector<int32_t>(days, DATE())});
+
+  for (const std::string zoneName : {"America/Los_Angeles", "Asia/Tokyo"}) {
+    SCOPED_TRACE("session zone " + zoneName);
+    const auto* zone = tz::locateZone(zoneName);
+    ASSERT_NE(zone, nullptr);
+
+    serializer::presto::PrestoVectorSerde::PrestoOptions opts;
+    opts.sessionTimezone = zone;
+
+    std::ostringstream out;
+    serialize(narrow, &out, &opts);
+    auto deserialized =
+        deserialize(ROW({TIMESTAMP()}), out.str(), &opts);
+
+    // Expected: same formula as CastExpr::castFromDate.
+    constexpr int64_t kMillisPerDay{86'400'000};
+    std::vector<Timestamp> expected;
+    expected.reserve(days.size());
+    for (auto d : days) {
+      auto t = Timestamp::fromMillis(static_cast<int64_t>(d) * kMillisPerDay);
+      t.toGMT(*zone);
+      expected.push_back(t);
+    }
+    assertEqualVectors(
+        deserialized, makeRowVector({makeFlatVector<Timestamp>(expected)}));
+  }
+}
+
+TEST_P(PrestoSerializerTest, wideningCoercionWithNulls) {
+  // Verify the null bitmap is preserved across widening.
+  auto narrow = makeRowVector({
+      makeNullableFlatVector<int32_t>(
+          {1, std::nullopt, 3, std::nullopt, 5}),
+  });
+  std::ostringstream out;
+  serialize(narrow, &out, nullptr);
+  auto deserialized = deserialize(ROW({BIGINT()}), out.str(), nullptr);
+  assertEqualVectors(
+      deserialized,
+      makeRowVector({makeNullableFlatVector<int64_t>(
+          {(int64_t)1, std::nullopt, (int64_t)3, std::nullopt, (int64_t)5})}));
+}
+
+TEST_P(PrestoSerializerTest, wideningCoercionUnsupportedPairStillThrows) {
+  // Pairs not in the widening map still get rejected with the original
+  // encoding-mismatch error. Here BIGINT (LONG_ARRAY) -> INTEGER (INT_ARRAY)
+  // is a narrowing, not a widening — must throw.
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+  });
+  std::ostringstream out;
+  serialize(data, &out, nullptr);
+  VELOX_ASSERT_THROW(
+      deserialize(ROW({INTEGER()}), out.str(), nullptr),
+      "Serialized encoding is not compatible with requested type: INTEGER. "
+      "Expected INT_ARRAY. Got LONG_ARRAY.");
+}
+
+TEST_P(PrestoSerializerTest, wideningCoercionWithNestedStructInRow) {
+  // Forces the two-pass deserialization path: when hasNestedStructs(childTypes)
+  // is true, PrestoSerializer runs a structured-nulls pre-pass before the main
+  // read pass. The pre-pass shares the encoding-mismatch check; we must skip
+  // the right number of *source* bytes there too, or it'll throw before the
+  // main pass gets a chance to coerce.
+  //
+  // Schema:  row( int32, row(double) )
+  // - widened column at position 0: producer INTEGER -> consumer BIGINT
+  // - nested struct at position 1 triggers hasNestedStructs(childTypes) == true
+  auto inner = makeRowVector({
+      makeFlatVector<double>({1.5, 2.5, 3.5}),
+  });
+  auto wireRow = makeRowVector({
+      makeFlatVector<int32_t>({10, 20, 30}),
+      inner,
+  });
+  std::ostringstream out;
+  serialize(wireRow, &out, nullptr);
+  // Consumer schema: column 0 widened to BIGINT.
+  auto deserialized = deserialize(
+      ROW({BIGINT(), ROW({DOUBLE()})}), out.str(), nullptr, /*skipLexer=*/true);
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30}),
+      makeRowVector({makeFlatVector<double>({1.5, 2.5, 3.5})}),
+  });
+  assertEqualVectors(deserialized, expected);
 }
 
 TEST_P(PrestoSerializerTest, lexer) {


### PR DESCRIPTION
When PushDownWidenCast rewrites a consumer fragment's source operator (TableScan or RemoteSourceNode) to declare a wider type, the producer fragment still emits narrow-typed bytes on the wire (its outputLayout stays narrow). The native worker's Exchange operator deserializes those pages via PrestoVectorSerde and must coerce narrow->wide on receive.

Before this commit, the deserialization path threw on the encoding mismatch:
  "Serialized encoding is not compatible with requested type: BIGINT.
   Expected LONG_ARRAY. Got INT_ARRAY."

This commti patches two call sites of `checkTypeEncoding`, mirroring the two-pass deserialization in `readTopColumns`:

1. `readColumns` (main read pass): Add `tryReadWidenedColumn` which reads the size + null header, then dispatches to `readWideningValues <SourceT, TargetT, Converter>` to read narrow bytes from the stream and write widened values into the result FlatVector<TargetT>.

2. `readStructNullsColumns` (null-tracking pre-pass, only runs when `hasNestedStructs(childTypes)` is true): Add `tryStructNullsSkipWidened` which skips `numValues * sizeof(SourceT)` bytes. Critical: without this, the pre-pass threw before the main pass ever ran on queries whose row schema includes nested ROW types (real-world complex JOIN / aggregate plans hit this constantly).

Supported widening pairs (producer encoding -> consumer kind):
  - BYTE_ARRAY  (TINYINT)  -> SMALLINT, INTEGER, BIGINT
  - SHORT_ARRAY (SMALLINT) -> INTEGER, BIGINT
  - INT_ARRAY   (INTEGER)  -> BIGINT
  - INT_ARRAY   (REAL)     -> DOUBLE
  - INT_ARRAY   (DATE)     -> TIMESTAMP   (days * kSecondsInDay)

Ordering matters: the widening check is inserted *before* the existing `tryReadNullColumn` check in `readColumns`. `tryReadNullColumn` consumes bytes from the stream as it tries to interpret the column as UNKNOWN-all-null; if it returns false the stream is past where the widening reader expects to start. Widening goes first; tryReadNullColumn keeps its original spot.

Tests
-----
velox_serializer_test_PrestoSerializerTest adds eight new tests covering each widening pair plus nulls, the nested-struct two-pass path, and a negative test:
  - wideningCoercionTinyintToBigint
  - wideningCoercionSmallintToInteger
  - wideningCoercionIntegerToBigint
  - wideningCoercionRealToDouble
  - wideningCoercionDateToTimestamp
  - wideningCoercionWithNulls
  - wideningCoercionWithNestedStructInRow      (exercises the pre-pass)
  - wideningCoercionUnsupportedPairStillThrows (BIGINT -> INTEGER is
    narrowing, must still throw)
All pass under all 6 compression-kind test parameterizations (48 total
test runs).