### PR TITLE
feat(dwio): Add DATE to TIMESTAMP widening coercion in DWIO readers

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -303,6 +303,25 @@ void SelectiveColumnReader::getIntValues(
           VELOX_FAIL("Unsupported value size: {}", valueSize_);
       }
       break;
+    case TypeKind::TIMESTAMP:
+      // DateType inherits from IntegerType (kind() == INTEGER), and DWRF
+      // erases DATE to plain INT during write -- so the genuine-DATE case
+      // and the post-DWRF-roundtrip case both present as kind() == INTEGER
+      // here.  Conversion (days * 86400) is the same in both.
+      VELOX_CHECK_EQ(
+          fileType_->type()->kind(),
+          TypeKind::INTEGER,
+          "TIMESTAMP output requires an INTEGER-kind file type (DATE or INTEGER), got: {}",
+          fileType_->type()->toString());
+      if (valueSize_ == sizeof(Timestamp)) {
+        // A prior convertDateToTimestampValues call already bulk-transmuted
+        // the int32 days buffer to Timestamps; further extractions are plain
+        // Timestamp compactions.
+        getFlatValues<Timestamp, Timestamp>(rows, result, TIMESTAMP());
+      } else {
+        convertDateToTimestampValues(rows, result);
+      }
+      break;
     default:
       VELOX_FAIL(
           "Not a valid type for integer reader: {}", requestedType->toString());
@@ -450,6 +469,120 @@ void SelectiveColumnReader::compactScalarValues<bool, bool>(
   numValues_ = rows.size();
   outputRows_.resize(numValues_);
   values_->setSize(bits::nbytes(numValues_));
+}
+
+void SelectiveColumnReader::convertDateToTimestampValues(
+    const RowSet& rows,
+    VectorPtr* result,
+    bool isFinal) {
+  VELOX_CHECK_EQ(valueSize_, sizeof(int32_t));
+  VELOX_CHECK(mayGetValues_);
+
+  if (allNull_) {
+    *result = std::make_shared<ConstantVector<Timestamp>>(
+        pool_, rows.size(), true, TIMESTAMP(), Timestamp());
+    if (isFinal) {
+      mayGetValues_ = false;
+    }
+    return;
+  }
+  VELOX_CHECK_NOT_NULL(values_);
+
+  static constexpr int64_t kSecondsPerDay{86'400};
+
+  // Bulk path: this single call asks for at least half of the read values.
+  // Transmute all numValues_ days to Timestamps in place (amortizing the
+  // conversion), transition to State B, then emit the requested slice via
+  // standard Timestamp extraction. Iterates backwards so the wider
+  // Timestamp writes don't clobber int32 source bytes we haven't read yet.
+  //
+  // Reentrancy note: after this path, subsequent calls go through
+  // getFlatValues<Timestamp, Timestamp> (dispatched via valueSize_ ==
+  // sizeof(Timestamp) in getIntValues). getFlatValues -> compactScalarValues
+  // shrinks values_ to rows.size() and updates numValues_ / valueRows_ in
+  // place, discarding un-extracted rows. Any follow-up call must therefore
+  // ask for rows that advance forward through what remains; disjoint or
+  // earlier subsets read stale/undefined bytes. The small-subset path below
+  // does not have this constraint.
+  if (rows.size() >= numValues_ / 2) {
+    ensureValuesCapacity<Timestamp>(numValues_, true);
+    const auto* rawDays = reinterpret_cast<const int32_t*>(rawValues_);
+    auto* timestamps = reinterpret_cast<Timestamp*>(rawValues_);
+    for (auto i = numValues_; i-- > 0;) {
+      timestamps[i] =
+          Timestamp(kSecondsPerDay * static_cast<int64_t>(rawDays[i]), 0);
+    }
+    valueSize_ = sizeof(Timestamp);
+    values_->setSize(numValues_ * sizeof(Timestamp));
+    getFlatValues<Timestamp, Timestamp>(rows, result, TIMESTAMP(), isFinal);
+    return;
+  }
+
+  // Small-subset path: leave the int32 days buffer intact and emit a
+  // freshly-allocated Timestamp vector for just rows.size(). values_,
+  // valueSize_, numValues_, and valueRows_ are all untouched, so this path
+  // supports arbitrary follow-up subsets of the same read -- including
+  // disjoint or earlier ones -- until a call happens to hit the bulk path
+  // above and switches valueSize_ to sizeof(Timestamp).
+  const auto sourceRows = valueRows_.empty()
+      ? (outputRows_.empty() ? RowSet(inputRows_) : RowSet(outputRows_))
+      : RowSet(valueRows_);
+  const auto* rawDays = reinterpret_cast<const int32_t*>(rawValues_);
+
+  auto timestampValues = AlignedBuffer::allocate<Timestamp>(
+      rows.size() + simd::kPadding / sizeof(Timestamp), pool_);
+  auto* timestamps = timestampValues->asMutable<Timestamp>();
+
+  const auto* moveNullsFrom = shouldMoveNulls(rows);
+  BufferPtr localNullsBuffer;
+  uint64_t* localNulls = nullptr;
+  if (moveNullsFrom) {
+    localNullsBuffer = AlignedBuffer::allocate<bool>(rows.size(), pool_);
+    localNulls = localNullsBuffer->asMutable<uint64_t>();
+  }
+
+  size_t sourceIndex{0};
+  if (moveNullsFrom) {
+    for (vector_size_t rowIndex = 0; rowIndex < rows.size();) {
+      const auto begin = rowIndex;
+      const auto end = std::min<vector_size_t>(begin + 64, rows.size());
+      uint64_t nulls = 0;
+      for (; rowIndex < end; ++rowIndex) {
+        while (sourceRows[sourceIndex] < rows[rowIndex]) {
+          ++sourceIndex;
+        }
+        VELOX_DCHECK_EQ(sourceRows[sourceIndex], rows[rowIndex]);
+        timestamps[rowIndex] = Timestamp(
+            kSecondsPerDay * static_cast<int64_t>(rawDays[sourceIndex]), 0);
+        nulls |=
+            static_cast<uint64_t>(bits::isBitSet(moveNullsFrom, sourceIndex))
+            << (rowIndex - begin);
+        ++sourceIndex;
+      }
+      localNulls[begin / 64] = nulls;
+    }
+  } else {
+    for (vector_size_t rowIndex = 0; rowIndex < rows.size(); ++rowIndex) {
+      while (sourceRows[sourceIndex] < rows[rowIndex]) {
+        ++sourceIndex;
+      }
+      VELOX_DCHECK_EQ(sourceRows[sourceIndex], rows[rowIndex]);
+      timestamps[rowIndex] = Timestamp(
+          kSecondsPerDay * static_cast<int64_t>(rawDays[sourceIndex++]), 0);
+    }
+  }
+
+  *result = std::make_shared<FlatVector<Timestamp>>(
+      pool_,
+      TIMESTAMP(),
+      moveNullsFrom ? localNullsBuffer : resultNulls(),
+      rows.size(),
+      std::move(timestampValues),
+      std::vector<BufferPtr>{});
+
+  if (isFinal) {
+    mayGetValues_ = false;
+  }
 }
 
 char* SelectiveColumnReader::copyStringValue(std::string_view value) {

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -595,6 +595,33 @@ class SelectiveColumnReader {
   template <typename T, typename TVector>
   void upcastScalarValues(const RowSet& rows);
 
+  /// Reads DATE (int32 days-since-epoch) values and converts them to
+  /// Timestamp (seconds = days × 86400, nanoseconds = 0).
+  /// Emits Timestamps for 'rows' from a buffer of int32 days-since-epoch read
+  /// by prepareRead<int32_t>.
+  ///
+  /// Reentrancy rules — the two paths differ:
+  ///  - Small-subset path (rows.size() < numValues_/2): the source int32 buffer
+  ///    and numValues_ are left intact; each call allocates a fresh Timestamp
+  ///    vector. Safe to call multiple times for arbitrary subsets of the same
+  ///    read, including disjoint ones.
+  ///  - Bulk path (rows.size() >= numValues_/2): the int32 buffer is
+  ///    transmuted to Timestamps in place (amortizing the conversion),
+  ///    valueSize_ becomes sizeof(Timestamp), and the call finishes via
+  ///    getFlatValues<Timestamp, Timestamp>. getFlatValues compacts the values
+  ///    buffer down to rows.size(), so any un-extracted rows are discarded
+  ///    and subsequent extractions must ask for rows that advance forward
+  ///    through what remains — disjoint or earlier subsets are unsupported.
+  ///
+  /// Caller (getIntValues) dispatches on valueSize_ before calling; once the
+  /// bulk path has run, valueSize_ == sizeof(Timestamp) and later calls should
+  /// go directly to getFlatValues<Timestamp, Timestamp>. Pass isFinal=true on
+  /// the last call to release the mayGetValues_ lock.
+  void convertDateToTimestampValues(
+      const RowSet& rows,
+      VectorPtr* result,
+      bool isFinal = false);
+
   // For complex type column, we need to compact only nulls if the rows are
   // shrinked.  Child fields are handled recursively in their own column
   // readers.

--- a/velox/dwio/common/TypeUtils.cpp
+++ b/velox/dwio/common/TypeUtils.cpp
@@ -130,7 +130,18 @@ void checkTypeCompatibility(
     const FKind& kind,
     const FShouldRead& shouldRead,
     const std::function<std::string()>& exceptionMessageCreator) {
-  if (shouldRead(to) && !isCompatible(from.kind(), kind(to))) {
+  // Special case: DATE (stored as int32 days-since-epoch) may be widened to
+  // TIMESTAMP (seconds-since-epoch).  The semantic conversion (days × 86400)
+  // is performed at read time by convertDateToTimestampValues().  DWRF erases
+  // DATE to plain INT in the proto schema during write, so on the read side
+  // the file-side kind() is INTEGER in both the genuine-DATE case (DateType
+  // inherits from IntegerType, kind() == INTEGER) and the post-roundtrip
+  // case.  Match on kind() == INTEGER so both shapes resolve.
+  const bool isIntToTimestamp = from.kind() == TypeKind::INTEGER &&
+      kind(to) == TypeKind::TIMESTAMP;
+
+  if (shouldRead(to) && !isIntToTimestamp &&
+      !isCompatible(from.kind(), kind(to))) {
     VELOX_SCHEMA_MISMATCH_ERROR(
         fmt::format(
             "{}, From Kind: {}, To Kind: {}",

--- a/velox/dwio/common/tests/SelectiveColumnReaderTest.cpp
+++ b/velox/dwio/common/tests/SelectiveColumnReaderTest.cpp
@@ -165,6 +165,24 @@ class TestColumnReader : public SelectiveColumnReader {
     }
   }
 
+  /// Force the all-null short-circuit path in convertDateToTimestampValues.
+  void setAllNull(bool allNull) {
+    allNull_ = allNull;
+  }
+
+  // Inspectors for post-call state assertions. Kept in the test subclass so the
+  // production class's API is unchanged.
+  int8_t valueSize() const {
+    return valueSize_;
+  }
+  bool mayGetValues() const {
+    return mayGetValues_;
+  }
+  vector_size_t numValues() const {
+    return numValues_;
+  }
+
+  using SelectiveColumnReader::convertDateToTimestampValues;
   using SelectiveColumnReader::getFlatValues;
 };
 
@@ -586,6 +604,338 @@ TEST_F(GetFlatValuesTest, int64ToInt128SparseRowsWithNulls) {
   EXPECT_EQ(flat->valueAt(0), 100);
   EXPECT_TRUE(flat->isNullAt(1));
   EXPECT_EQ(flat->valueAt(2), 500);
+}
+
+// Tests for the reentrant DATE->TIMESTAMP extraction path.
+// See convertDateToTimestampValues in SelectiveColumnReader.cpp: a single
+// read of int32 days-since-epoch can be drained across multiple disjoint
+// extraction calls. The function picks between two paths per call:
+//   - bulk path (rows.size() >= numValues_/2): transmute all numValues_
+//     days to Timestamps in place, then delegate to getFlatValues.
+//   - small-subset path (rows.size() < numValues_/2): emit a freshly
+//     allocated Timestamp vector and leave the source buffer untouched.
+// The bulk path transitions valueSize_ from sizeof(int32_t) to
+// sizeof(Timestamp) ("State B"); subsequent extractions are expected to
+// route through getFlatValues<Timestamp, Timestamp> instead of calling
+// convertDateToTimestampValues again.
+class ConvertDateToTimestampTest : public ::testing::Test {
+ protected:
+  static constexpr int64_t kSecondsPerDay{86'400};
+
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool("ConvertDateToTimestampTest");
+    stats_ = std::make_unique<ColumnReaderStatistics>();
+    params_ = std::make_unique<StubFormatParams>(*pool_, *stats_);
+    scanSpec_ = std::make_unique<velox::common::ScanSpec>("test");
+    scanSpec_->setProjectOut(true);
+  }
+
+  std::unique_ptr<TestColumnReader> makeReader() const {
+    auto fileType = TypeWithId::create(DATE());
+    return std::make_unique<TestColumnReader>(
+        DATE(), std::move(fileType), *params_, *scanSpec_);
+  }
+
+  // Asserts that flat[i] == Timestamp(days[selectedRow[i]] * 86400, 0).
+  static void expectTimestampsMatch(
+      const VectorPtr& result,
+      const std::vector<int32_t>& days,
+      const std::vector<int32_t>& selectedRows) {
+    auto* flat = result->as<FlatVector<Timestamp>>();
+    ASSERT_NE(flat, nullptr);
+    ASSERT_EQ(flat->size(), selectedRows.size());
+    for (size_t i = 0; i < selectedRows.size(); ++i) {
+      const auto src = days[selectedRows[i]];
+      EXPECT_EQ(
+          flat->valueAt(i),
+          Timestamp(kSecondsPerDay * static_cast<int64_t>(src), 0))
+          << "Mismatch at index " << i << " (source row " << selectedRows[i]
+          << ")";
+    }
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::unique_ptr<ColumnReaderStatistics> stats_;
+  std::unique_ptr<StubFormatParams> params_;
+  std::unique_ptr<velox::common::ScanSpec> scanSpec_;
+};
+
+// Single bulk call covering all rows. Triggers the in-place transmute, then
+// the isFinal flag should lock further extractions out via mayGetValues_.
+TEST_F(ConvertDateToTimestampTest, singleCallAllRows) {
+  auto reader = makeReader();
+  const std::vector<int32_t> days = {0, 1, 2, 3, 4, 5, 6, 7};
+  std::vector<int32_t> rowNums(days.size());
+  std::iota(rowNums.begin(), rowNums.end(), 0);
+  reader->setupValues(days, rowNums);
+
+  const RowSet rows(rowNums.data(), rowNums.size());
+  VectorPtr result;
+  reader->convertDateToTimestampValues(rows, &result, /*isFinal=*/true);
+
+  expectTimestampsMatch(result, days, rowNums);
+  // Bulk path transmuted the buffer in place: valueSize_ flipped to
+  // sizeof(Timestamp).
+  EXPECT_EQ(reader->valueSize(), sizeof(Timestamp));
+  EXPECT_EQ(reader->numValues(), 8);
+  // isFinal=true released the mayGetValues_ lock.
+  EXPECT_FALSE(reader->mayGetValues());
+}
+
+// Two disjoint small-subset calls, each well below the half-of-numValues_
+// threshold. valueSize_ must stay at sizeof(int32_t) (State A is preserved).
+TEST_F(ConvertDateToTimestampTest, singleCallSmallSubset) {
+  auto reader = makeReader();
+  std::vector<int32_t> days(20);
+  std::iota(days.begin(), days.end(), 0);
+  std::vector<int32_t> rowNums(days.size());
+  std::iota(rowNums.begin(), rowNums.end(), 0);
+  reader->setupValues(days, rowNums);
+
+  // First small-subset call (3 < 20/2).
+  const std::vector<int32_t> firstSelected = {2, 5, 11};
+  const RowSet firstRows(firstSelected.data(), firstSelected.size());
+  VectorPtr firstResult;
+  reader->convertDateToTimestampValues(firstRows, &firstResult);
+
+  expectTimestampsMatch(firstResult, days, firstSelected);
+  EXPECT_EQ(reader->valueSize(), sizeof(int32_t));
+  EXPECT_TRUE(reader->mayGetValues());
+
+  // Second small-subset call, disjoint from the first, marked final.
+  const std::vector<int32_t> secondSelected = {1, 7, 19};
+  const RowSet secondRows(secondSelected.data(), secondSelected.size());
+  VectorPtr secondResult;
+  reader->convertDateToTimestampValues(
+      secondRows, &secondResult, /*isFinal=*/true);
+
+  expectTimestampsMatch(secondResult, days, secondSelected);
+  // Small-subset path never transitions to State B.
+  EXPECT_EQ(reader->valueSize(), sizeof(int32_t));
+  EXPECT_FALSE(reader->mayGetValues());
+  EXPECT_EQ(reader->numValues(), 20);
+
+  // The first result must still be intact after the second extraction.
+  expectTimestampsMatch(firstResult, days, firstSelected);
+}
+
+// Three small-subset calls in sequence. Each result owns its own buffer and
+// must remain readable after the others run. valueSize_ stays in State A.
+TEST_F(ConvertDateToTimestampTest, twoSmallSubsetsThenSmallFinal) {
+  auto reader = makeReader();
+  std::vector<int32_t> days(30);
+  std::iota(days.begin(), days.end(), 100);
+  std::vector<int32_t> rowNums(days.size());
+  std::iota(rowNums.begin(), rowNums.end(), 0);
+  reader->setupValues(days, rowNums);
+
+  const std::vector<int32_t> selected1 = {0, 3};
+  const std::vector<int32_t> selected2 = {7, 11, 12};
+  const std::vector<int32_t> selected3 = {20, 29};
+  VectorPtr r1, r2, r3;
+
+  const RowSet rows1(selected1.data(), selected1.size());
+  reader->convertDateToTimestampValues(rows1, &r1);
+  EXPECT_EQ(reader->valueSize(), sizeof(int32_t));
+  EXPECT_TRUE(reader->mayGetValues());
+
+  const RowSet rows2(selected2.data(), selected2.size());
+  reader->convertDateToTimestampValues(rows2, &r2);
+  EXPECT_EQ(reader->valueSize(), sizeof(int32_t));
+  EXPECT_TRUE(reader->mayGetValues());
+
+  const RowSet rows3(selected3.data(), selected3.size());
+  reader->convertDateToTimestampValues(rows3, &r3, /*isFinal=*/true);
+  EXPECT_EQ(reader->valueSize(), sizeof(int32_t));
+  EXPECT_FALSE(reader->mayGetValues());
+
+  // All three results remain independently correct: no shared buffer.
+  expectTimestampsMatch(r1, days, selected1);
+  expectTimestampsMatch(r2, days, selected2);
+  expectTimestampsMatch(r3, days, selected3);
+}
+
+// First a small-subset call, then a bulk call that triggers in-place
+// transmute. The first result must continue to read correctly even though
+// the source int32 buffer has been overwritten with 12-byte Timestamps.
+TEST_F(ConvertDateToTimestampTest, smallSubsetThenBulk) {
+  auto reader = makeReader();
+  std::vector<int32_t> days(16);
+  for (int i = 0; i < 16; ++i) {
+    days[i] = i * 2;
+  }
+  std::vector<int32_t> rowNums(days.size());
+  std::iota(rowNums.begin(), rowNums.end(), 0);
+  reader->setupValues(days, rowNums);
+
+  // Small subset first (2 < 16/2 == 8). State A preserved.
+  const std::vector<int32_t> smallSelected = {3, 9};
+  const RowSet smallRows(smallSelected.data(), smallSelected.size());
+  VectorPtr smallResult;
+  reader->convertDateToTimestampValues(smallRows, &smallResult);
+  EXPECT_EQ(reader->valueSize(), sizeof(int32_t));
+
+  // Bulk call covering enough rows to clear the threshold (8 >= 16/2).
+  const std::vector<int32_t> bulkSelected = {0, 1, 2, 3, 4, 5, 6, 7};
+  const RowSet bulkRows(bulkSelected.data(), bulkSelected.size());
+  VectorPtr bulkResult;
+  reader->convertDateToTimestampValues(
+      bulkRows, &bulkResult, /*isFinal=*/true);
+  EXPECT_EQ(reader->valueSize(), sizeof(Timestamp));
+  EXPECT_FALSE(reader->mayGetValues());
+
+  // The small result must still be correct: it owns its own Timestamp
+  // buffer, decoupled from the source bytes that the bulk call overwrote.
+  expectTimestampsMatch(smallResult, days, smallSelected);
+  expectTimestampsMatch(bulkResult, days, bulkSelected);
+}
+
+// Bulk call transitions to State B (valueSize_ == sizeof(Timestamp)), then
+// follow-up extractions must use getFlatValues<Timestamp, Timestamp>
+// directly: this is the contract that getIntValues encodes via its
+// valueSize_ dispatch. The bulk call requests rows.size() == numValues_ so
+// compactScalarValues early-returns and the full buffer remains available
+// for subsequent subset extractions.
+TEST_F(ConvertDateToTimestampTest, bulkThenStateBExtraction) {
+  auto reader = makeReader();
+  std::vector<int32_t> days(10);
+  std::iota(days.begin(), days.end(), 50);
+  std::vector<int32_t> rowNums(days.size());
+  std::iota(rowNums.begin(), rowNums.end(), 0);
+  reader->setupValues(days, rowNums);
+
+  // First call: bulk path. rows.size() == numValues_, so
+  // getFlatValues -> compactScalarValues early-returns without compaction.
+  const RowSet allRows(rowNums.data(), rowNums.size());
+  VectorPtr firstResult;
+  reader->convertDateToTimestampValues(allRows, &firstResult);
+  expectTimestampsMatch(firstResult, days, rowNums);
+  EXPECT_EQ(reader->valueSize(), sizeof(Timestamp));
+  EXPECT_TRUE(reader->mayGetValues());
+
+  // Second extraction: dispatch through getFlatValues<Timestamp, Timestamp>
+  // because the buffer is now Timestamps (this is what getIntValues does).
+  // Compacts in place: the buffer afterward only holds the requested rows.
+  const std::vector<int32_t> secondSelected = {1, 4, 8};
+  const RowSet secondRows(secondSelected.data(), secondSelected.size());
+  VectorPtr secondResult;
+  reader->getFlatValues<Timestamp, Timestamp>(
+      secondRows, &secondResult, TIMESTAMP(), /*isFinal=*/false);
+  expectTimestampsMatch(secondResult, days, secondSelected);
+  EXPECT_TRUE(reader->mayGetValues());
+
+  // Third extraction, marked final. Subset of what's still in the buffer.
+  const std::vector<int32_t> thirdSelected = {1, 8};
+  const RowSet thirdRows(thirdSelected.data(), thirdSelected.size());
+  VectorPtr thirdResult;
+  reader->getFlatValues<Timestamp, Timestamp>(
+      thirdRows, &thirdResult, TIMESTAMP(), /*isFinal=*/true);
+  expectTimestampsMatch(thirdResult, days, thirdSelected);
+  EXPECT_FALSE(reader->mayGetValues());
+}
+
+// Two small-subset calls with nulls. Each call must produce correct null
+// flags for its requested subset, and a prior result's nulls must not be
+// clobbered by a subsequent call.
+TEST_F(ConvertDateToTimestampTest, smallSubsetWithNulls) {
+  auto reader = makeReader();
+  // 10 source values with nulls at rows 1, 4, 7.
+  const std::vector<int32_t> days = {10, 0, 20, 30, 0, 50, 60, 0, 80, 90};
+  const std::vector<bool> nulls = {
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false};
+  std::vector<int32_t> rowNums(days.size());
+  std::iota(rowNums.begin(), rowNums.end(), 0);
+  reader->setupValuesWithNulls(days, nulls, rowNums);
+
+  // First small subset: includes nulls at source positions 1 and 4.
+  const std::vector<int32_t> firstSelected = {0, 1, 4};
+  const RowSet firstRows(firstSelected.data(), firstSelected.size());
+  VectorPtr firstResult;
+  reader->convertDateToTimestampValues(firstRows, &firstResult);
+
+  ASSERT_NE(firstResult, nullptr);
+  auto* firstFlat = firstResult->as<FlatVector<Timestamp>>();
+  ASSERT_NE(firstFlat, nullptr);
+  ASSERT_EQ(firstFlat->size(), 3);
+  EXPECT_FALSE(firstFlat->isNullAt(0));
+  EXPECT_EQ(firstFlat->valueAt(0), Timestamp(kSecondsPerDay * 10, 0));
+  EXPECT_TRUE(firstFlat->isNullAt(1));
+  EXPECT_TRUE(firstFlat->isNullAt(2));
+
+  // Second small subset: includes null at source position 7.
+  const std::vector<int32_t> secondSelected = {3, 7, 9};
+  const RowSet secondRows(secondSelected.data(), secondSelected.size());
+  VectorPtr secondResult;
+  reader->convertDateToTimestampValues(
+      secondRows, &secondResult, /*isFinal=*/true);
+
+  auto* secondFlat = secondResult->as<FlatVector<Timestamp>>();
+  ASSERT_NE(secondFlat, nullptr);
+  ASSERT_EQ(secondFlat->size(), 3);
+  EXPECT_FALSE(secondFlat->isNullAt(0));
+  EXPECT_EQ(secondFlat->valueAt(0), Timestamp(kSecondsPerDay * 30, 0));
+  EXPECT_TRUE(secondFlat->isNullAt(1));
+  EXPECT_FALSE(secondFlat->isNullAt(2));
+  EXPECT_EQ(secondFlat->valueAt(2), Timestamp(kSecondsPerDay * 90, 0));
+
+  // First result's null flags must still be correct after the second
+  // extraction: nulls were allocated into a local buffer per call.
+  EXPECT_FALSE(firstFlat->isNullAt(0));
+  EXPECT_TRUE(firstFlat->isNullAt(1));
+  EXPECT_TRUE(firstFlat->isNullAt(2));
+  EXPECT_EQ(firstFlat->valueAt(0), Timestamp(kSecondsPerDay * 10, 0));
+}
+
+// allNull_ short-circuit: produces a ConstantVector<Timestamp> of the
+// requested size; mayGetValues_ is left intact unless isFinal is set.
+TEST_F(ConvertDateToTimestampTest, allNullsShortCircuit) {
+  auto reader = makeReader();
+  // numValues_ is required to be set for the function's invariants. Use
+  // an arbitrary non-empty buffer; allNull_ short-circuits before reading.
+  const std::vector<int32_t> days = {0, 0, 0, 0};
+  std::vector<int32_t> rowNums(days.size());
+  std::iota(rowNums.begin(), rowNums.end(), 0);
+  reader->setupValues(days, rowNums);
+  reader->setAllNull(true);
+
+  // First call: not final. Expect ConstantVector<Timestamp> of size 3.
+  const std::vector<int32_t> firstSelected = {0, 1, 2};
+  const RowSet firstRows(firstSelected.data(), firstSelected.size());
+  VectorPtr firstResult;
+  reader->convertDateToTimestampValues(firstRows, &firstResult);
+
+  ASSERT_NE(firstResult, nullptr);
+  auto* firstConst = firstResult->as<ConstantVector<Timestamp>>();
+  ASSERT_NE(firstConst, nullptr);
+  EXPECT_EQ(firstConst->size(), 3);
+  EXPECT_TRUE(firstConst->isNullAt(0));
+  EXPECT_TRUE(reader->mayGetValues());
+
+  // Second call: final. Expect another ConstantVector<Timestamp>; lock flips.
+  const std::vector<int32_t> secondSelected = {0, 1};
+  const RowSet secondRows(secondSelected.data(), secondSelected.size());
+  VectorPtr secondResult;
+  reader->convertDateToTimestampValues(
+      secondRows, &secondResult, /*isFinal=*/true);
+
+  auto* secondConst = secondResult->as<ConstantVector<Timestamp>>();
+  ASSERT_NE(secondConst, nullptr);
+  EXPECT_EQ(secondConst->size(), 2);
+  EXPECT_TRUE(secondConst->isNullAt(0));
+  EXPECT_FALSE(reader->mayGetValues());
 }
 
 } // namespace

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -386,6 +386,43 @@ void nextValues(
       decoder, data, numValues, nulls);
 }
 
+// Emits a FlatVector<Timestamp> by interpreting decoded int32 days-since-epoch
+// as Timestamp(days * 86400, 0). Null mask is propagated. Mirrors the semantic
+// in SelectiveColumnReader::convertDateToTimestampValues.
+void emitDaysAsTimestampVector(
+    const int32_t* days,
+    uint64_t numValues,
+    const uint64_t* nullsPtr,
+    uint64_t nullCount,
+    BufferPtr nulls,
+    memory::MemoryPool& pool,
+    VectorPtr& result) {
+  static constexpr int64_t kSecondsPerDay{86'400};
+  auto values = AlignedBuffer::allocate<Timestamp>(numValues, &pool);
+  auto* timestamps = values->asMutable<Timestamp>();
+  if (nullsPtr) {
+    for (uint64_t i = 0; i < numValues; ++i) {
+      if (!bits::isBitNull(nullsPtr, i)) {
+        timestamps[i] =
+            Timestamp(kSecondsPerDay * static_cast<int64_t>(days[i]), 0);
+      }
+    }
+  } else {
+    for (uint64_t i = 0; i < numValues; ++i) {
+      timestamps[i] =
+          Timestamp(kSecondsPerDay * static_cast<int64_t>(days[i]), 0);
+    }
+  }
+  result = std::make_shared<FlatVector<Timestamp>>(
+      &pool,
+      TIMESTAMP(),
+      std::move(nulls),
+      numValues,
+      std::move(values),
+      std::vector<BufferPtr>{});
+  result->setNullCount(nullCount);
+}
+
 template <typename DataT>
 class DecimalColumnReader : public ColumnReader {
  private:
@@ -582,6 +619,26 @@ void IntegerDirectColumnReader<ReqT>::next(
     uint64_t numValues,
     VectorPtr& result,
     const uint64_t* incomingNulls) {
+  // DATE-erased-to-INT file column requested as TIMESTAMP: decode into a
+  // scratch int32 buffer and emit a FlatVector<Timestamp>. ReqT is int32_t
+  // here (see buildTypedIntegerColumnReader's TIMESTAMP case).
+  if constexpr (std::is_same_v<ReqT, int32_t>) {
+    if (requestedType_->kind() == TypeKind::TIMESTAMP) {
+      result.reset();
+      BufferPtr nulls = readNulls(numValues, result, incomingNulls);
+      const auto* nullsPtr = nulls ? nulls->as<uint64_t>() : nullptr;
+      uint64_t nullCount =
+          nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
+      auto daysBuffer =
+          AlignedBuffer::allocate<int32_t>(numValues, &memoryPool_);
+      auto* days = daysBuffer->template asMutable<int32_t>();
+      nextValues(*ints, days, numValues, nullsPtr);
+      emitDaysAsTimestampVector(
+          days, numValues, nullsPtr, nullCount, nulls, memoryPool_, result);
+      return;
+    }
+  }
+
   auto flatVector = resetIfWrongFlatVectorType<ReqT>(result);
   BufferPtr values;
   if (flatVector) {
@@ -739,6 +796,36 @@ void IntegerDictionaryColumnReader<ReqT>::next(
     uint64_t numValues,
     VectorPtr& result,
     const uint64_t* incomingNulls) {
+  // DATE-erased-to-INT file column requested as TIMESTAMP: decode and
+  // populate into a scratch int32 buffer, then emit a FlatVector<Timestamp>.
+  // ReqT is int32_t here (see buildTypedIntegerColumnReader's TIMESTAMP case).
+  if constexpr (std::is_same_v<ReqT, int32_t>) {
+    if (requestedType_->kind() == TypeKind::TIMESTAMP) {
+      result.reset();
+      BufferPtr nulls = readNulls(numValues, result, incomingNulls);
+      const auto* nullsPtr = nulls ? nulls->as<uint64_t>() : nullptr;
+      uint64_t nullCount =
+          nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
+      auto daysBuffer =
+          AlignedBuffer::allocate<int32_t>(numValues, &memoryPool_);
+      auto* days = daysBuffer->template asMutable<int32_t>();
+      const char* inDict = nullptr;
+      if (inDictionaryReader) {
+        detail::ensureCapacity<bool>(inDictionary, numValues, &memoryPool_);
+        inDictionaryReader->next(
+            inDictionary->asMutable<char>(), numValues, nullsPtr);
+        inDict = inDictionary->as<char>();
+      }
+      ensureInitialized();
+      auto dict = dictionary->as<int64_t>();
+      nextValues(*dataReader, days, numValues, nullsPtr);
+      populateOutput(dict, days, numValues, nullsPtr, inDict);
+      emitDaysAsTimestampVector(
+          days, numValues, nullsPtr, nullCount, nulls, memoryPool_, result);
+      return;
+    }
+  }
+
   auto flatVector = resetIfWrongFlatVectorType<ReqT>(result);
   BufferPtr values;
   if (result) {
@@ -2496,6 +2583,18 @@ std::unique_ptr<ColumnReader> buildTypedIntegerColumnReader(
           std::move(flatMapContext));
     case TypeKind::SMALLINT:
       return std::make_unique<IntegerColumnReaderT<int16_t>>(
+          requestedType,
+          fileType,
+          stripe,
+          streamLabels,
+          numBytes,
+          std::move(flatMapContext));
+    case TypeKind::TIMESTAMP:
+      // DATE columns are erased to plain INTEGER on the DWRF write path,
+      // so a TIMESTAMP request against an int file column means the source
+      // is int32 days-since-epoch. Storage stays int32; the days * 86400
+      // -> Timestamp conversion happens in IntegerColumnReaderT::next.
+      return std::make_unique<IntegerColumnReaderT<int32_t>>(
           requestedType,
           fileType,
           stripe,

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -3879,5 +3879,117 @@ TEST_F(TestReader, extractionNestedChainScanSpec) {
       << "Nested extraction: " << extBytes << ", Full: " << fullBytes;
 }
 
+// ── DATE→TIMESTAMP widening coercion tests ────────────────────────────────
+//
+// DWRF stores DATE columns as int32 (days since Unix epoch). These tests
+// verify that the selective reader can widen DATE to TIMESTAMP at read time,
+// producing Timestamp(days * 86400, 0).
+
+TEST_F(TestReader, readDateColumnAsTimestamp) {
+  constexpr int kNumRows = 20;
+
+  // Write a DATE (int32 days) column.
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      1024 * 1024, dwio::common::FileSink::Options{.pool = pool()});
+  auto* sinkPtr = sink.get();
+
+  auto fileSchema = ROW({"dt"}, {DATE()});
+  dwrf::WriterOptions writerOptions;
+  writerOptions.schema = fileSchema;
+  // The Writer(options, sink, parentPool&) constructor calls
+  // addAggregateChild on the parent pool, which is only valid on an
+  // aggregate pool. VectorTestBase::pool() is a leaf, so pass the
+  // aggregate root pool here.
+  dwrf::Writer writer{writerOptions, std::move(sink), *rootPool_};
+
+  // Days 1–20 since the Unix epoch.
+  auto dateData = makeFlatVector<int32_t>(
+      kNumRows, [](auto row) { return row + 1; }, nullptr, DATE());
+  writer.write(makeRowVector({dateData}));
+  writer.close();
+
+  // Read back, requesting TIMESTAMP (widening coercion).
+  std::string data(sinkPtr->data(), sinkPtr->size());
+  auto readFile =
+      std::make_shared<facebook::velox::InMemoryReadFile>(std::move(data));
+  auto input = std::make_unique<BufferedInput>(readFile, *pool());
+
+  dwio::common::ReaderOptions readerOpts{pool()};
+  auto requestedSchema = ROW({"dt"}, {TIMESTAMP()});
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedSchema));
+
+  auto reader = DwrfReader::create(std::move(input), readerOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  VectorPtr batch;
+  ASSERT_TRUE(rowReader->next(kNumRows, batch));
+  auto* root = batch->as<RowVector>();
+  ASSERT_EQ(root->size(), kNumRows);
+  auto* tsCol = root->childAt(0)->as<SimpleVector<Timestamp>>();
+  ASSERT_NE(tsCol, nullptr);
+
+  constexpr int64_t kSecondsPerDay = 86400;
+  for (int i = 0; i < kNumRows; ++i) {
+    EXPECT_FALSE(tsCol->isNullAt(i));
+    EXPECT_EQ(tsCol->valueAt(i), Timestamp((i + 1) * kSecondsPerDay, 0))
+        << "row " << i;
+  }
+}
+
+TEST_F(TestReader, readDateColumnAsTimestampWithNulls) {
+  constexpr int kNumRows = 20;
+
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      1024 * 1024, dwio::common::FileSink::Options{.pool = pool()});
+  auto* sinkPtr = sink.get();
+
+  auto fileSchema = ROW({"dt"}, {DATE()});
+  dwrf::WriterOptions writerOptions;
+  writerOptions.schema = fileSchema;
+  // The Writer(options, sink, parentPool&) constructor calls
+  // addAggregateChild on the parent pool, which is only valid on an
+  // aggregate pool. VectorTestBase::pool() is a leaf, so pass the
+  // aggregate root pool here.
+  dwrf::Writer writer{writerOptions, std::move(sink), *rootPool_};
+
+  // Every 3rd row is null.
+  auto dateData = makeFlatVector<int32_t>(
+      kNumRows, [](auto row) { return row + 1; }, nullEvery(3), DATE());
+  writer.write(makeRowVector({dateData}));
+  writer.close();
+
+  std::string data(sinkPtr->data(), sinkPtr->size());
+  auto readFile =
+      std::make_shared<facebook::velox::InMemoryReadFile>(std::move(data));
+  auto input = std::make_unique<BufferedInput>(readFile, *pool());
+
+  dwio::common::ReaderOptions readerOpts{pool()};
+  auto requestedSchema = ROW({"dt"}, {TIMESTAMP()});
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedSchema));
+
+  auto reader = DwrfReader::create(std::move(input), readerOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  VectorPtr batch;
+  ASSERT_TRUE(rowReader->next(kNumRows, batch));
+  auto* root = batch->as<RowVector>();
+  ASSERT_EQ(root->size(), kNumRows);
+  auto* tsCol = root->childAt(0)->as<SimpleVector<Timestamp>>();
+  ASSERT_NE(tsCol, nullptr);
+
+  constexpr int64_t kSecondsPerDay = 86400;
+  for (int i = 0; i < kNumRows; ++i) {
+    // nullEvery(3): rows 0, 3, 6, ... are null (0-based).
+    bool expectNull = (i % 3 == 0);
+    EXPECT_EQ(tsCol->isNullAt(i), expectNull) << "row " << i;
+    if (!expectNull) {
+      EXPECT_EQ(tsCol->valueAt(i), Timestamp((i + 1) * kSecondsPerDay, 0))
+          << "row " << i;
+    }
+  }
+}
+
 } // namespace
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1040,7 +1040,12 @@ TypePtr ReaderBase::convertType(
                 isCompatible(
                     requestedType,
                     isRepeated,
-                    [](const TypePtr& type) { return type->isDate(); }),
+                    [](const TypePtr& type) {
+                      // DATE can be read as DATE or widened to TIMESTAMP
+                      // (days × 86400 seconds).
+                      return type->isDate() ||
+                          type->kind() == TypeKind::TIMESTAMP;
+                    }),
             kTypeMappingErrorFmtStr,
             "DATE",
             requestedType->toString(),

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2035,3 +2035,193 @@ TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
 
   EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
 }
+
+TEST_F(ParquetReaderTest, readRealColumnAsDouble) {
+  // Verify that a Parquet FLOAT (REAL) column can be read as DOUBLE via
+  // widening type coercion. The on-disk values are stored as 32-bit floats;
+  // the reader should widen them to 64-bit doubles at read time.
+  auto sink = std::make_unique<MemorySink>(
+      1024 * 1024, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto sinkPtr = sink.get();
+
+  constexpr int kNumRows = 20;
+  // Use values exactly representable in both float and double so that
+  // comparison with EXPECT_DOUBLE_EQ works precisely.
+  auto floatData = makeFlatVector<float>(
+      kNumRows, [](auto row) { return static_cast<float>(row + 1); });
+  auto writeData = makeRowVector({floatData});
+
+  auto fileSchema = ROW({"val"}, {REAL()});
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = leafPool_.get();
+  auto writer = std::make_unique<facebook::velox::parquet::Writer>(
+      std::move(sink), writerOptions, rootPool_, fileSchema);
+  writer->write(writeData);
+  writer->close();
+
+  // Request the column as DOUBLE — a widening cast from REAL.
+  auto requestedSchema = ROW({"val"}, {DOUBLE()});
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setFileSchema(requestedSchema);
+
+  std::string dataBuf(sinkPtr->data(), sinkPtr->size());
+  auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
+  auto buffer =
+      std::make_unique<dwio::common::BufferedInput>(file, *leafPool_);
+  ParquetReader reader(std::move(buffer), readerOptions);
+
+  auto rowReaderOpts = getReaderOpts(requestedSchema);
+  rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+  auto rowReader = reader.createRowReader(rowReaderOpts);
+
+  // Expected: the same numeric values, now stored as DOUBLE.
+  auto expected = makeRowVector({makeFlatVector<double>(
+      kNumRows, [](auto row) { return static_cast<double>(row + 1); })});
+
+  assertReadWithReaderAndExpected(
+      requestedSchema, *rowReader, expected, *leafPool_);
+}
+
+TEST_F(ParquetReaderTest, readRealColumnAsDoubleWithNulls) {
+  // Same as readRealColumnAsDouble but with null values interspersed to verify
+  // null handling is preserved during widening.
+  auto sink = std::make_unique<MemorySink>(
+      1024 * 1024, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto sinkPtr = sink.get();
+
+  constexpr int kNumRows = 20;
+  // Every 3rd row is null.
+  auto floatData = makeFlatVector<float>(
+      kNumRows,
+      [](auto row) { return static_cast<float>(row + 1); },
+      nullEvery(3));
+  auto writeData = makeRowVector({floatData});
+
+  auto fileSchema = ROW({"val"}, {REAL()});
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = leafPool_.get();
+  auto writer = std::make_unique<facebook::velox::parquet::Writer>(
+      std::move(sink), writerOptions, rootPool_, fileSchema);
+  writer->write(writeData);
+  writer->close();
+
+  auto requestedSchema = ROW({"val"}, {DOUBLE()});
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setFileSchema(requestedSchema);
+
+  std::string dataBuf(sinkPtr->data(), sinkPtr->size());
+  auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
+  auto buffer =
+      std::make_unique<dwio::common::BufferedInput>(file, *leafPool_);
+  ParquetReader reader(std::move(buffer), readerOptions);
+
+  auto rowReaderOpts = getReaderOpts(requestedSchema);
+  rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+  auto rowReader = reader.createRowReader(rowReaderOpts);
+
+  // Expected: widened to DOUBLE with the same null pattern.
+  auto expected = makeRowVector({makeFlatVector<double>(
+      kNumRows,
+      [](auto row) { return static_cast<double>(row + 1); },
+      nullEvery(3))});
+
+  assertReadWithReaderAndExpected(
+      requestedSchema, *rowReader, expected, *leafPool_);
+}
+
+TEST_F(ParquetReaderTest, readDateColumnAsTimestamp) {
+  // Verify that a Parquet DATE (INT32, days-since-epoch) column can be read as
+  // TIMESTAMP via widening type coercion.  The on-disk values are stored as
+  // int32 day counts; the reader should produce Timestamp(days * 86400, 0).
+  auto sink = std::make_unique<MemorySink>(
+      1024 * 1024, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto sinkPtr = sink.get();
+
+  constexpr int kNumRows = 20;
+  // Values: days 1 through 20 (positive days since Unix epoch).
+  auto dateData = makeFlatVector<int32_t>(
+      kNumRows, [](auto row) { return row + 1; }, nullptr, DATE());
+  auto writeData = makeRowVector({dateData});
+
+  auto fileSchema = ROW({"dt"}, {DATE()});
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = leafPool_.get();
+  auto writer = std::make_unique<facebook::velox::parquet::Writer>(
+      std::move(sink), writerOptions, rootPool_, fileSchema);
+  writer->write(writeData);
+  writer->close();
+
+  // Request the column as TIMESTAMP — a widening conversion from DATE.
+  auto requestedSchema = ROW({"dt"}, {TIMESTAMP()});
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setFileSchema(requestedSchema);
+
+  std::string dataBuf(sinkPtr->data(), sinkPtr->size());
+  auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
+  auto buffer =
+      std::make_unique<dwio::common::BufferedInput>(file, *leafPool_);
+  ParquetReader reader(std::move(buffer), readerOptions);
+
+  auto rowReaderOpts = getReaderOpts(requestedSchema);
+  rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+  auto rowReader = reader.createRowReader(rowReaderOpts);
+
+  // Expected: Timestamp(days * 86400, 0) for each day value.
+  constexpr int64_t kSecondsPerDay = 86400;
+  auto expected = makeRowVector({makeFlatVector<Timestamp>(
+      kNumRows,
+      [kSecondsPerDay](auto row) {
+        return Timestamp((row + 1) * kSecondsPerDay, 0);
+      })});
+
+  assertReadWithReaderAndExpected(
+      requestedSchema, *rowReader, expected, *leafPool_);
+}
+
+TEST_F(ParquetReaderTest, readDateColumnAsTimestampWithNulls) {
+  // Same as readDateColumnAsTimestamp but with null values interspersed to
+  // verify null handling is preserved during DATE→TIMESTAMP conversion.
+  auto sink = std::make_unique<MemorySink>(
+      1024 * 1024, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto sinkPtr = sink.get();
+
+  constexpr int kNumRows = 20;
+  // Every 3rd row is null.
+  auto dateData = makeFlatVector<int32_t>(
+      kNumRows, [](auto row) { return row + 1; }, nullEvery(3), DATE());
+  auto writeData = makeRowVector({dateData});
+
+  auto fileSchema = ROW({"dt"}, {DATE()});
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = leafPool_.get();
+  auto writer = std::make_unique<facebook::velox::parquet::Writer>(
+      std::move(sink), writerOptions, rootPool_, fileSchema);
+  writer->write(writeData);
+  writer->close();
+
+  auto requestedSchema = ROW({"dt"}, {TIMESTAMP()});
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setFileSchema(requestedSchema);
+
+  std::string dataBuf(sinkPtr->data(), sinkPtr->size());
+  auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
+  auto buffer =
+      std::make_unique<dwio::common::BufferedInput>(file, *leafPool_);
+  ParquetReader reader(std::move(buffer), readerOptions);
+
+  auto rowReaderOpts = getReaderOpts(requestedSchema);
+  rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+  auto rowReader = reader.createRowReader(rowReaderOpts);
+
+  // Expected: Timestamp(days * 86400, 0) with the same null pattern.
+  constexpr int64_t kSecondsPerDay = 86400;
+  auto expected = makeRowVector({makeFlatVector<Timestamp>(
+      kNumRows,
+      [kSecondsPerDay](auto row) {
+        return Timestamp((row + 1) * kSecondsPerDay, 0);
+      },
+      nullEvery(3))});
+
+  assertReadWithReaderAndExpected(
+      requestedSchema, *rowReader, expected, *leafPool_);
+}


### PR DESCRIPTION
Reading a DATE column as TIMESTAMP previously failed at schema-compatibility validation because DateType inherits from IntegerType (kind() == INTEGER), and integer→timestamp is not a numeric widening. DWIO readers now accept the coercion and emit Timestamp (days × 86400 seconds, 0 nanos) at read time.

The widening is wired in three places. TypeUtils.cpp short-circuits isCompatible() when the file type is DATE and the requested kind is TIMESTAMP. SelectiveColumnReader gains convertDateToTimestampValues(), dispatched from getIntValues() when the requested kind is TIMESTAMP and the file type is DATE — it follows the same sourceRows iteration pattern as upcastScalarValues but applies the days × 86400 conversion and stores Timestamp structs. ParquetReader.cpp's convertType() for ConvertedType::DATE now also accepts TIMESTAMP as a valid requested type, in addition to DATE itself.

Test plan:
- velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp:
  - readDateColumnAsTimestamp
  - readDateColumnAsTimestampWithNulls
  - readRealColumnAsDouble, readRealColumnAsDoubleWithNulls — coverage for pre-existing FLOAT→DOUBLE widening, no production change in this commit.
- velox/dwio/dwrf/test/ReaderTest.cpp:
  - readDateColumnAsTimestamp
  - readDateColumnAsTimestampWithNulls