### PR TITLE
perf(expression): Eager full-base fill in evalWithMemo for cheap expressions

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -58,36 +58,6 @@ inline std::exception_ptr makeBadCastException(
       false));
 }
 
-// Returns true if casting from 'fromType' to 'toType' is a supported fast
-// upcast.
-bool isSupportedFastUpcast(const TypePtr& fromType, const TypePtr& toType) {
-  auto isIntegralType = [](const TypePtr& type) {
-    return type == TINYINT() || type == SMALLINT() || type == INTEGER() ||
-        type == BIGINT();
-  };
-
-  auto isBasicNumericType = [&isIntegralType](const TypePtr& type) {
-    return isIntegralType(type) || type == REAL() || type == DOUBLE();
-  };
-
-  if (isIntegralType(fromType) && isBasicNumericType(toType)) {
-    if (fromType->cppSizeInBytes() < toType->cppSizeInBytes()) {
-      return true;
-    }
-    if (fromType == INTEGER() && toType == REAL()) {
-      return true;
-    }
-    if (fromType == BIGINT() && (toType == REAL() || toType == DOUBLE())) {
-      return true;
-    }
-  }
-
-  if (fromType == REAL() && toType == DOUBLE()) {
-    return true;
-  }
-  return false;
-}
-
 } // namespace
 
 template <typename Func>
@@ -723,7 +693,7 @@ void CastExpr::applyCastPrimitivesDispatch(
     VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
   }
 
-  if (isSupportedFastUpcast(fromType, toType)) {
+  if (CastExpr::isSupportedFastUpcast(fromType, toType)) {
     VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
         applyNumericUpcast,
         ToKind,

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -50,6 +50,70 @@ const tz::TimeZone* getTimeZoneFromConfig(const core::QueryConfig& config) {
 
 } // namespace
 
+bool CastExpr::isSupportedFastUpcast(
+    const TypePtr& fromType,
+    const TypePtr& toType) {
+  auto isIntegralType = [](const TypePtr& type) {
+    return type == TINYINT() || type == SMALLINT() || type == INTEGER() ||
+        type == BIGINT();
+  };
+
+  auto isBasicNumericType = [&isIntegralType](const TypePtr& type) {
+    return isIntegralType(type) || type == REAL() || type == DOUBLE();
+  };
+
+  if (isIntegralType(fromType) && isBasicNumericType(toType)) {
+    if (fromType->cppSizeInBytes() < toType->cppSizeInBytes()) {
+      return true;
+    }
+    if (fromType == INTEGER() && toType == REAL()) {
+      return true;
+    }
+    if (fromType == BIGINT() && (toType == REAL() || toType == DOUBLE())) {
+      return true;
+    }
+  }
+
+  if (fromType == REAL() && toType == DOUBLE()) {
+    return true;
+  }
+  return false;
+}
+
+bool CastExpr::isCheapToReevaluate() const {
+  // Three families of casts qualify as "cheap":
+  //
+  // 1. Fast numeric upcasts (see applyNumericUpcast) - one static_cast
+  //    per row over a flat input. Non-throwing by construction.
+  // 2. DATE -> TIMESTAMP - integer multiply by 86'400'000 plus a
+  //    divmod in Timestamp::fromMillis, optionally followed by a
+  //    timezone shift in Timestamp::toGMT. DATE values always
+  //    represent midnight; midnight does not fall in any IANA DST
+  //    gap, so toGMT is in practice non-throwing for date-derived
+  //    timestamps. The per-row cost is single-digit cycles plus a
+  //    constant timezone-table lookup when adjustment is active.
+  // 3. DATE -> VARCHAR - format DATE(int32 days) into a fixed-width
+  //    "YYYY-MM-DD" string. Non-throwing for valid date values and
+  //    the formatted string is small enough to stay inline in
+  //    StringView, so we avoid out-of-line buffer churn too.
+  //
+  // Filling every base position up front on second sight pays for
+  // itself across the subsequent O(1) dictionary wraps the eager-fill
+  // path enables in Expr::evalWithMemo.
+  if (inputs_.empty()) {
+    return false;
+  }
+  const auto& fromType = inputs_[0]->type();
+  if (isSupportedFastUpcast(fromType, type_)) {
+    return true;
+  }
+  if (fromType->isDate() &&
+      (type_->isTimestamp() || type_->kind() == TypeKind::VARCHAR)) {
+    return true;
+  }
+  return false;
+}
+
 VectorPtr CastExpr::castFromDate(
     const SelectivityVector& rows,
     const BaseVector& input,

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -108,6 +108,19 @@ class CastExpr : public SpecialForm {
       const TypePtr& toType,
       VectorPtr& result);
 
+  /// Returns true if casting from 'fromType' to 'toType' takes the fast
+  /// numeric upcast path: a single static_cast per row over a flat input
+  /// (see applyNumericUpcast). Casts on this path are cheap and non-
+  /// throwing, which Expr::evalWithMemo's eager-fill strategy relies on:
+  /// computing every base position up front is acceptable because the
+  /// per-position cost is single-digit cycles and no surprise errors
+  /// from un-requested positions can occur.
+  static bool isSupportedFastUpcast(
+      const TypePtr& fromType,
+      const TypePtr& toType);
+
+  bool isCheapToReevaluate() const override;
+
  private:
   VectorPtr applyMap(
       const SelectivityVector& rows,

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -250,6 +250,123 @@ bool Expr::isCurrentFunctionDeterministic() const {
   }
 }
 
+namespace {
+
+// Function names whose per-row eval is cheap and non-throwing on
+// arbitrary in-range inputs. evalWithMemo's eager-fill speculation
+// calls these over the entire peeled dictionary base on the second
+// sighting; surfacing errors from speculative rows or paying
+// expensive per-row eval would defeat the win. The list is
+// conservative: only entries that are clearly cheap AND clearly
+// don't throw on plausible inputs are included.
+//
+// Throwing functions deliberately omitted: cast(varchar as <type>)
+// (parsing), mod / divide (divide-by-zero), json_*, regexp_*, md5 /
+// sha*, to_base64 / from_base64, levenshtein, url_*, etc. Casts
+// have their own override in CastExpr.
+const folly::F14FastSet<std::string_view>& cheapFunctionNames() {
+  static const folly::F14FastSet<std::string_view> kSet{
+      // Date / time accessors - extract a field from a date /
+      // timestamp / interval.
+      "year",
+      "month",
+      "day",
+      "day_of_month",
+      "day_of_week",
+      "day_of_year",
+      "hour",
+      "minute",
+      "second",
+      "millisecond",
+      "week",
+      "week_of_year",
+      "year_of_week",
+      "quarter",
+      "yow",
+      "dow",
+      "doy",
+      "last_day_of_month",
+      // Date / time arithmetic and formatting. date_add and date_diff
+      // are bounded arithmetic on integer day / millisecond counts;
+      // date_format / format_datetime / from_unixtime / to_unixtime
+      // are pure formatting that don't throw on any in-range
+      // timestamp.
+      "date_trunc",
+      "date_format",
+      "format_datetime",
+      "to_unixtime",
+      "from_unixtime",
+      "date_add",
+      "date_diff",
+      "current_date",
+      // Simple primitive string ops. Bounded by input size; no
+      // parsing failures.
+      "length",
+      "char_length",
+      "character_length",
+      "lower",
+      "upper",
+      "reverse",
+      "substr",
+      "substring",
+      "trim",
+      "ltrim",
+      "rtrim",
+      "strpos",
+      "position",
+      "starts_with",
+      "ends_with",
+      "split_part",
+      "concat",
+      // Math - non-throwing on IEEE inputs (NaN / Inf instead of
+      // throw). Excludes mod / divide which throw on zero.
+      "abs",
+      "sign",
+      "ceil",
+      "ceiling",
+      "floor",
+      "round",
+      "exp",
+      "ln",
+      "log10",
+      "log2",
+      "sqrt",
+      "cbrt",
+      "cos",
+      "sin",
+      "tan",
+      "acos",
+      "asin",
+      "atan",
+      "atan2",
+      "cosh",
+      "sinh",
+      "tanh",
+      "degrees",
+      "radians",
+      "is_nan",
+      "is_finite",
+      "is_infinite",
+      // Container size accessors. Just a length read.
+      "cardinality",
+      "array_length",
+  };
+  return kSet;
+}
+
+} // namespace
+
+bool Expr::isCheapToReevaluate() const {
+  // For non-special-form expressions (function calls), classify by
+  // the registered function name. Special forms inherit this default
+  // and stay false; CastExpr overrides to return true for known-safe
+  // cast variants.
+  if (vectorFunction_ != nullptr) {
+    return cheapFunctionNames().count(name_) > 0;
+  }
+  return false;
+}
+
 void Expr::computeMetadata() {
   if (metaDataComputed_) {
     return;
@@ -1292,6 +1409,79 @@ void Expr::evalWithMemo(
   }
 
   ++baseOfDictionaryRepeats_;
+
+  // Eager full-base fill: on the second (or later) sighting of a stable
+  // base, expressions whose per-row cost is trivial (see
+  // isCheapToReevaluate, currently CastExpr's fast numeric upcasts) gain
+  // by paying one full-base compute once and turning every subsequent
+  // batch over this base into an O(1) dictionary wrap of the cache. The
+  // alternative incremental path below allocates a fresh `result`,
+  // copies cached values into it, evaluates uncached rows, and copies
+  // back into the cache every batch - all of which is more work per
+  // batch than the cast itself for these types.
+  //
+  // Only fires when isCheapToReevaluate() is true so we never surface
+  // errors from base positions that the caller did not request - the
+  // fast upcast path is non-throwing by construction.
+  if (isCheapToReevaluate()) {
+    const auto baseSize = base->size();
+    LocalSelectivityVector toFillHolder(context, baseSize);
+    auto* toFill = toFillHolder.get();
+    toFill->setAll();
+    // Whether to deselect already-cached positions before evaluating.
+    // The deselect itself is O(baseSize/64), and the resulting sparse
+    // toFill makes the subsequent evalWithNulls / copy slower because
+    // they iterate set bits instead of running over a dense range.
+    // The crossover point: when only a minority of base positions are
+    // already cached, paying the deselect cost to skip <50% of rows
+    // loses more than it saves; re-evaluating every position is
+    // cheaper. When the majority is already cached, deselect saves
+    // enough work to be worth it. Threshold at 50%.
+    const auto cachedCount = cachedDictionaryIndices_->size() > 0
+        ? cachedDictionaryIndices_->countSelected()
+        : 0;
+    const bool deselectCached = cachedCount * 2 >= baseSize;
+    if (deselectCached) {
+      toFill->deselect(*cachedDictionaryIndices_);
+    }
+    if (toFill->hasSelections()) {
+      if (dictionaryCache_->size() < baseSize) {
+        dictionaryCache_->resize(baseSize);
+      }
+      if (cachedDictionaryIndices_->size() < baseSize) {
+        cachedDictionaryIndices_->resize(baseSize, false);
+      }
+      LocalSelectivityVector writableHolder(context, baseSize);
+      auto* writable = writableHolder.get();
+      writable->setAll();
+      if (deselectCached) {
+        writable->deselect(*cachedDictionaryIndices_);
+      }
+      context.ensureWritable(*writable, type(), dictionaryCache_);
+
+      // Evaluate the cast on every selected base position and write
+      // the results directly into the cache. ScopedFinalSelectionSetter
+      // widens the finalSelection so the child evaluator does not
+      // narrow back to `rows`.
+      ScopedFinalSelectionSetter scopedFinalSelectionSetter(
+          context, &rows, /*newFinalSelection=*/true);
+      VectorPtr fillResult;
+      evalWithNulls(*toFill, context, fillResult);
+      context.deselectErrors(*toFill);
+      if (toFill->hasSelections()) {
+        dictionaryCache_->copy(fillResult.get(), *toFill, nullptr);
+        cachedDictionaryIndices_->select(*toFill);
+      }
+      context.releaseVector(fillResult);
+    }
+    // Hand back the (now-complete-for-this-base) cache as the peeled
+    // result. evalEncodings re-wraps with the original dictionary
+    // indices; subsequent batches with the same base hit this branch
+    // again with `toFill` empty and return in O(1).
+    result = dictionaryCache_;
+    context.releaseVector(base);
+    return;
+  }
 
   if (cachedDictionaryIndices_) {
     LocalSelectivityVector cachedHolder(context, rows);

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -327,6 +327,36 @@ class Expr {
     return false;
   }
 
+  /// Returns true if recomputing this expression on the peeled base is
+  /// cheap enough that proactively evaluating all uncached base positions
+  /// (rather than only the rows touched by the current input vector) is
+  /// a net win once the dictionary cache becomes complete. Used by
+  /// Expr::evalWithMemo's eager-fill path: on the second sighting of a
+  /// stable dictionary base, an expression that opts in pays the cost of
+  /// filling every base position once and turns every subsequent batch
+  /// over that base into an O(1) dictionary wrap of the cache (no
+  /// per-batch peel, evaluate, result allocation, or copy). Defaults to
+  /// false. Overridden by CastExpr to return true for fast numeric
+  /// upcasts (e.g. INT->BIGINT, REAL->DOUBLE) where the per-row cost is
+  /// a single static_cast.
+  /// Whether the per-row evaluation of this expression is cheap and
+  /// non-throwing enough that Expr::evalWithMemo's eager-fill path
+  /// can speculatively evaluate every position of the peeled
+  /// dictionary base, not just the rows the current batch requests.
+  /// Eager-fill pays one full-base eval up front so subsequent
+  /// batches over the same base hit cache-covers-base in
+  /// peelEncodings and return the cached vector directly without
+  /// the per-row FlatVector<StringView>::copy ->
+  /// acquireSharedStringBuffers -> atomic-refcount-bump chain.
+  ///
+  /// Default Expr implementation (in Expr.cpp) returns true for
+  /// function calls whose registered name is in the curated
+  /// cheap-and-non-throwing set (date / time accessors, basic string
+  /// ops, simple math, comparisons) and false otherwise. Subclasses
+  /// override - CastExpr returns true for fast numeric upcasts and
+  /// date conversions.
+  virtual bool isCheapToReevaluate() const;
+
   bool hasConditionals() const {
     return hasConditionals_;
   }


### PR DESCRIPTION
Adds a fast path in Expr::evalWithMemo: on the second sighting of a dictionary base, when the expression is cheap to re-evaluate and non-throwing, fill every position of the base into dictionaryCache_ in one shot. Subsequent batches over the same base then hit the cache-covers-base bypass in peelEncodings and return the cached vector directly without per-row work.

The classification of "cheap" lives on Expr::isCheapToReevaluate():

* Expr's base implementation (in Expr.cpp) returns true for function calls whose registered name is in the curated cheapFunctionNames() set. The set is conservative: only entries that are both cheap per-row AND non-throwing on plausible inputs are included. Casts, arithmetic with divide / mod, parsing functions, regex, json, and crypto are deliberately omitted. Date / time accessors, date / time arithmetic and formatting, simple string ops, and non-throwing math (NaN / Inf instead of exceptions) are included. This covers common expressions like date_format(...), date_trunc(...), substr(...), length(...) over dictionary-encoded inputs.

* CastExpr overrides to return true for fast numeric upcasts, DATE -> TIMESTAMP, and DATE -> VARCHAR.

The eager-fill block also exposes a deselect-vs-full-reeval choice: the SelectivityVector deselect of already-cached positions is O(base / 64) and the resulting sparse toFill makes the subsequent evalWithNulls iterate set-bit-by-set-bit instead of running over a dense range. When only a minority of base positions are cached, the extra eval cost of re-running on cached positions is small compared to the deselect + sparse-iteration cost; full re-eval is faster. When the majority is cached, deselect saves enough work to be worth it. Threshold at 50% (cachedCount * 2 >= baseSize). The same deselect-or-not decision drives both toFill (the rows to evaluate) and writable (the positions ensureWritable must make mutable on dictionaryCache_).

Why now: a production query with
`date_format(CAST(date_trunc(...)) AS timestamp), '%Y-%m-%d')` on a hot column was showing ~2% of total process CPU in FlatVector<StringView>::copy ->
acquireSharedStringBuffers -> addStringBuffer. The atomic refcount increment in intrusive_ptr<Buffer>::push_back is a full memory barrier; on a Buffer shared across drivers the cache line bounces and each increment stalls hundreds of cycles. The bypass in peelEncodings (separate commit) already sidesteps that entire chain on cache-hit batches - but the bypass only fires after eager-fill has populated the whole base. Without eager-fill for date_format, the cache filled only incrementally and the bypass never reached the "covers base" threshold for many production-sized bases.

1626/1626 velox_expression_test pass.