### PR TITLE
fix(build): Gate velox_date_extract_benchmark on Presto+Spark functions

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -126,11 +126,13 @@ target_link_libraries(
   velox_row_fast
 )
 
-add_executable(velox_date_extract_benchmark DateExtractBenchmark.cpp)
-target_link_libraries(
-  velox_date_extract_benchmark
-  ${velox_benchmark_deps}
-  velox_vector_test_lib
-  velox_functions_prestosql
-  velox_functions_spark
-)
+if(${VELOX_ENABLE_PRESTO_FUNCTIONS} AND ${VELOX_ENABLE_SPARK_FUNCTIONS})
+  add_executable(velox_date_extract_benchmark DateExtractBenchmark.cpp)
+  target_link_libraries(
+    velox_date_extract_benchmark
+    ${velox_benchmark_deps}
+    velox_vector_test_lib
+    velox_functions_prestosql
+    velox_functions_spark
+  )
+endif()


### PR DESCRIPTION
velox/benchmarks/basic/CMakeLists.txt unconditionally declared the velox_date_extract_benchmark target and linked it against both velox_functions_prestosql and velox_functions_spark. The benchmark's source (DateExtractBenchmark.cpp) genuinely uses both:

  - Line 29: functions::prestosql::registerDateTimeFunctions("") plus benchmark sets for year / month / day / quarter / day_of_year / last_day_of_month on DATE and TIMESTAMP inputs.
  - Line 30: functions::sparksql::registerFunctions("spark_") plus a spark_make_date(y, m, d) benchmark set at line 116.

Either library being absent breaks the link. The presto-native-execution build configures with VELOX_ENABLE_SPARK_FUNCTIONS=OFF -- Spark functions are not needed for the native Presto worker -- which leaves velox_functions_spark undefined and produces:

  ld: library 'velox_functions_spark' not found
  c++: error: linker command failed with exit code 1

This benchmark is the only target in the tree that requires the consumer to opt into both function libraries simultaneously; every other consumer either uses only Presto functions or already guards its dependency on the matching VELOX_ENABLE_* flag. Existing parallel guards in the tree:

  - velox/functions/CMakeLists.txt:20,24 -- the top-level subdirectory adds for prestosql and sparksql are already gated on VELOX_ENABLE_PRESTO_FUNCTIONS and VELOX_ENABLE_SPARK_FUNCTIONS respectively.
  - velox/experimental/cudf/tests/CMakeLists.txt:233 -- the Spark-dependent cudf test is gated on VELOX_ENABLE_SPARK_FUNCTIONS.

Gate add_executable and target_link_libraries on
(VELOX_ENABLE_PRESTO_FUNCTIONS AND VELOX_ENABLE_SPARK_FUNCTIONS) so the benchmark is only built where both function libraries actually exist. Source is unchanged: the benchmark genuinely needs both at runtime, so building it with one disabled would not be useful.