### PR TITLE
refactor(expression): Add ExprV2 evaluator behind expression.eval_v2 flag

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -39,6 +39,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     // Expression evaluation.
     VELOX_REGISTER_QUERY_CONFIG(kExprEvalSimplified);
     VELOX_REGISTER_QUERY_CONFIG(kExprEvalFlatNoNulls);
+    VELOX_REGISTER_QUERY_CONFIG(kExprEvalV2);
     VELOX_REGISTER_QUERY_CONFIG(kExprTrackCpuUsage);
     VELOX_REGISTER_QUERY_CONFIG(kExprTrackCpuUsageForFunctions);
     VELOX_REGISTER_QUERY_CONFIG(kExprAdaptiveCpuSampling);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -148,6 +148,19 @@ class QueryConfig {
       true,
       "Enable FlatNoNulls fast path for expression evaluation.")
 
+  /// Whether to route expression evaluation through the V2 evaluator
+  /// (ExprEvaluatorV2 + ExprV2).  V2 is a behavior-preserving refactor
+  /// that produces bit-identical output to V1; the flag exists so V2
+  /// can be canaried per-query before the cutover.  False by default
+  /// until canary signal is positive.
+  VELOX_QUERY_CONFIG(
+      kExprEvalV2,
+      exprEvalV2,
+      "expression.eval_v2",
+      bool,
+      false,
+      "Route expression evaluation through the V2 evaluator.")
+
   /// Whether to track CPU usage for individual expressions (supported by call
   /// and cast expressions). False by default. Can be expensive when processing
   /// small batches, e.g. < 10K rows.

--- a/velox/docs/designs/expr-evaluation-refactor.md
+++ b/velox/docs/designs/expr-evaluation-refactor.md
@@ -1,0 +1,1100 @@
+# Expression Evaluation Refactor (ExprV2)
+
+*2026-06-09*
+
+## Summary
+
+`Expr.cpp` (~2500 lines) and `Expr.h` (~1100 lines) mix at least nine
+concerns: tree-shape data, immutable metadata, per-call evaluation state,
+per-Expr cross-call caches, stats, adaptive sampling, evaluator algorithm,
+tracer wiring, and `ExprSet` lifecycle.  The implicit pipeline
+(`eval -> evalEncodings -> evalWithMemo -> evalWithNulls -> evalAll ->
+evalAllImpl -> ...`) is hard to read because each method is named by what
+its predecessor did *not* do.
+
+This document proposes an additive refactor that introduces four new types
+in new files and leaves the existing `Expr` class essentially intact:
+
+| New type             | Role                                                    |
+|----------------------|---------------------------------------------------------|
+| `ExprV2`             | Immutable expression-tree node.                         |
+| `ExprRuntimeState`   | Per-node mutable state (memo, shared cache, stats).     |
+| `EvalFrame`          | Per-call state, lives on the stack of `evaluate()`.     |
+| `ExprEvaluatorV2`    | Stateless orchestrator that drives the staged pipeline. |
+| `ExprSetV2`          | Owner of `ExprV2` roots, runtime states, and evaluator. |
+
+The refactor is **behavior-preserving**.  V2 ships behind a query-config
+flag, runs alongside V1, and becomes the default only after vector-for-vector
+parity is verified across the full expression test suite.  Once parity is
+established, the V1 code path can be deleted in a separate change.
+
+## Motivation
+
+### Concrete pain points in `Expr.cpp`
+
+| Site                            | Concern                                                 |
+|---------------------------------|---------------------------------------------------------|
+| `Expr::eval` (816)              | Fast path, exception scope, empty rows, lazy load mixed together. |
+| `Expr::evalEncodings` (1101)    | Field peeling.                                          |
+| `Expr::evalWithMemo` (1246)     | Dictionary memoization, only reachable on peeled path.  |
+| `Expr::evalWithNulls` (1201)    | Null pruning.                                           |
+| `Expr::evalAll` (1450)          | Shared subexpression wrapper.                           |
+| `Expr::evalAllImpl` (1479)      | Special-form vs function-call fork; arg eval; finalize. |
+| `Expr::applyFunctionWithPeeling`(1534) | Argument peeling.                                |
+| `Expr::applyFunction` (1753)    | Listener / timing wrapper.                              |
+| `Expr::evaluateSharedSubexpr` (899) | Shared-result cache management.                     |
+
+Specific structural problems:
+
+1. **Per-call state lives on the tree node.**  `Expr::inputValues_` is a
+   buffer reset every evaluation but stored on the node.  This prevents
+   concurrent evaluation of the same `ExprSet` from multiple threads.
+2. **Per-Expr cross-call state mixes with tree data.**
+   `sharedSubexprResults_`, `baseOfDictionary*`, `cachedDictionaryIndices_`,
+   `stats_`, `adaptiveState_` are all on `Expr` alongside `inputs_` /
+   `type_` / `vectorFunction_` — making it impossible to tell which fields
+   are immutable post-compile.
+3. **Implicit pipeline order.**  Layer names (`evalEncodings`,
+   `evalWithNulls`, `evalAllImpl`) describe local actions but not pipeline
+   position.  A reader must trace calls to know where they are.
+4. **Special-form vs function-call fork is buried.**  The check happens at
+   `evalAllImpl` line 1486, four call levels below `eval()`.
+5. **No documented row-space invariant.**  Code juggles `rows` (caller's
+   original), `remainingRows` (post-pruning), translated inner rows
+   (post-peeling), and `EvalCtx::finalSelection()` without naming the
+   relationship.
+6. **`EvalCtx` mutations are inconsistently scoped.**  Some sites use
+   `ContextSaver` / `ScopedVarSetter` / `ScopedFinalSelectionSetter`,
+   others mutate and restore by hand inline.
+
+### Why not refactor `Expr` in place?
+
+Velox accepts heavy upstream churn on `Expr.cpp`.  An in-place restructure
+would generate continuous rebase conflicts for the duration of the
+refactor.  A parallel `ExprV2` type in new files isolates the change and
+lets upstream evolve `Expr` undisturbed until cutover.
+
+## Goals
+
+- **Behavior preservation.**  Bit-for-bit identical output to V1 across
+  the full expression test suite.
+- **Readable pipeline.**  One function per phase boundary, each ~5–10
+  lines, with documented invariants.
+- **Thread-safety.**  Concurrent evaluation of the same `ExprSetV2` from
+  multiple threads with separate `EvalFrame`s.  (Today impossible because
+  `Expr::inputValues_` is on the node.)
+- **Testable phases.**  Each pipeline function callable in isolation by
+  constructing an `EvalFrame` and invoking the phase directly.
+- **Incremental rollout.**  V2 ships behind a flag; V1 stays the default
+  until parity verified; cutover and V1 deletion are separate changes.
+
+## Non-goals
+
+- No new optimizations.  Performance equivalent to V1, not better.
+- No changes to `EvalCtx`'s public API.
+- No changes to special-form subclasses (`CaseExpr`, `ConjunctExpr`,
+  `CastExpr`, `CoalesceExpr`, `FieldReference`, `ConstantExpr`) initially.
+  `ExprV2` for a special-form node holds a `shared_ptr<Expr>` and
+  delegates `evaluateSpecialForm` to it.  Migrating special forms to
+  native ExprV2 nodes is a follow-up.
+- No changes to the expression compiler or function registry.  An
+  adapter walks the compiled `Expr` tree once and produces an `ExprV2` tree.
+- `ExprSetSimplified` is not subsumed initially.  After V2 stabilizes,
+  `ExprSetSimplified` is reimplemented as the same pipeline with peeling,
+  memo, and shared-subexpr phases disabled.
+
+## Target design
+
+### Component overview
+
+```
+                       ExprSetV2  (owner)
+                           |
+        +------------------+------------------+
+        |                  |                  |
+   shared_ptr<       ExprRuntime      ExprEvaluatorV2
+   ExprV2>[]         StateTree         (stateless)
+   (immutable        (mutable,
+    tree)            parallel
+                     to tree)
+```
+
+For each top-level evaluation, `ExprSetV2::eval`:
+
+1. Constructs an `EvalFrame` on the stack referencing the root `ExprV2`,
+   its `ExprRuntimeState`, the caller's `EvalCtx`, the requested rows,
+   and the output slot.
+2. Calls `ExprEvaluatorV2::evaluate(frame, this)`.
+3. The evaluator drives the pipeline, recursing by constructing inner
+   frames where row-space changes.
+
+### `ExprV2` — immutable node
+
+```cpp
+namespace facebook::velox::exec {
+
+/// Immutable expression-tree node.  All fields are set at construction
+/// from a compiled Expr; none are mutated during evaluation.  Safe to
+/// share across threads.
+class ExprV2 {
+ public:
+  /// Construct from a compiled Expr.  Recursively builds the V2 tree;
+  /// special-form nodes wrap the original Expr for delegated evaluation.
+  static std::shared_ptr<ExprV2> from(const std::shared_ptr<Expr>& expr);
+
+  const TypePtr& type() const { return type_; }
+  const std::string& name() const { return name_; }
+  const std::vector<std::shared_ptr<ExprV2>>& inputs() const { return inputs_; }
+  const VectorFunction* vectorFunction() const { return vectorFunction_.get(); }
+  const VectorFunctionMetadata& metadata() const { return metadata_; }
+  SpecialForm specialForm() const { return specialForm_; }
+
+  bool isSpecialForm() const { return specialForm_ != SpecialForm::kNone; }
+  bool deterministic() const { return deterministic_; }
+  bool propagatesNulls() const { return propagatesNulls_; }
+  bool supportsFlatNoNullsFastPath() const { return supportsFlatNoNullsFastPath_; }
+  bool hasConditionals() const { return hasConditionals_; }
+  bool skipFieldDependentOptimizations() const { return skipFieldDependentOptimizations_; }
+
+  const std::vector<FieldReferenceV2*>& distinctFields() const { return distinctFields_; }
+  const std::vector<FieldReferenceV2*>& multiplyReferencedFields() const { return multiplyReferencedFields_; }
+
+  /// Delegated path for special-form nodes during the migration period.
+  /// Returns the wrapped Expr; null for function-call nodes.
+  const std::shared_ptr<Expr>& legacySpecialForm() const { return legacySpecialForm_; }
+
+ private:
+  ExprV2(...);  // populated by from()
+
+  TypePtr type_;
+  std::string name_;
+  std::vector<std::shared_ptr<ExprV2>> inputs_;
+  std::shared_ptr<VectorFunction> vectorFunction_;  // null for special forms
+  VectorFunctionMetadata metadata_;
+  SpecialForm specialForm_;                          // enum tag
+  std::shared_ptr<Expr> legacySpecialForm_;          // delegation during migration
+
+  // Compile-time metadata derived once.
+  bool deterministic_;
+  bool propagatesNulls_;
+  bool supportsFlatNoNullsFastPath_;
+  bool hasConditionals_;
+  bool skipFieldDependentOptimizations_;
+
+  std::vector<FieldReferenceV2*> distinctFields_;
+  std::vector<FieldReferenceV2*> multiplyReferencedFields_;
+};
+
+} // namespace facebook::velox::exec
+```
+
+### `ExprRuntimeState` — per-node mutable state
+
+```cpp
+/// Mutable per-Expr state that survives across evaluations.  One instance
+/// per ExprV2 per ExprSetV2.  Owned by ExprSetV2 in a tree that mirrors
+/// the ExprV2 tree.  Not thread-safe: concurrent evaluations of the same
+/// ExprSetV2 each get their own ExprRuntimeStateTree (or share with a
+/// mutex; TBD by use case).
+struct ExprRuntimeState {
+  // Shared-subexpression cache.  Same as Expr::sharedSubexprResults_.
+  SharedSubexprCacheState sharedCache;
+
+  // Dictionary memoization.  Same as Expr's baseOfDictionary*,
+  // cachedDictionaryIndices_, dictionaryCache_.
+  DictionaryMemoState dictMemo;
+
+  // Stats accumulated across evaluations.
+  ExprStats stats;
+
+  // Adaptive CPU sampling state.
+  AdaptiveCpuSamplingState adaptiveState;
+};
+
+/// Tree of runtime state, parallel-indexed with the ExprV2 tree.
+/// Look up runtime state for a node by tree position.
+class ExprRuntimeStateTree {
+ public:
+  explicit ExprRuntimeStateTree(const ExprV2& root);
+  ExprRuntimeState& at(const ExprV2& node);
+ private:
+  // Implementation choice: flat vector keyed by in-order index, or
+  // a map keyed by ExprV2*, or a shared_ptr per node.  Trade-off TBD;
+  // flat vector is simplest if the tree is built once and never reshaped.
+  std::vector<ExprRuntimeState> states_;
+  folly::F14FastMap<const ExprV2*, size_t> indexByNode_;
+};
+```
+
+### `EvalFrame` — per-call state
+
+```cpp
+/// Per-call evaluation state for one ExprV2 node.  Lives on the stack
+/// of the outermost ExprEvaluatorV2::evaluate() call.  Inner recursion
+/// (peeling, null-pruning wrapper, shared-subexpr wrapper) constructs
+/// fresh inner EvalFrames.
+///
+/// Row-space invariant:
+///   - originalRows never changes after construction.
+///   - remainingRows.rows() is always a subset of originalRows.
+///   - Every phase operates on remainingRows.rows(), not originalRows.
+///   - remainingRows shrinks monotonically as evaluation proceeds; it
+///     never grows.
+///   - originalRows is used only for result sizing, final null-fill,
+///     and copying / wrapping back into the caller's row space.
+struct EvalFrame {
+  // === Bindings (constant after construction) ===
+
+  ExprV2& expr;
+  ExprRuntimeState& nodeRuntime;
+  EvalCtx& ctx;
+  const SelectivityVector& originalRows;
+  VectorPtr& result;
+
+  // === Mutable state flowing between phases ===
+
+  MutableRemainingRows remainingRows;
+  std::vector<VectorPtr> inputValues;  // moved off ExprV2 onto the frame
+  bool tryPeelArgs;
+
+  // === Compile-time flags cached once from expr ===
+  bool defaultNulls;
+  bool propagatesNulls;
+  bool deterministic;
+  bool isSpecialForm;
+  bool supportsFlatNoNullsFastPath;
+  bool hasConditionals;
+  bool skipFieldDependentOptimizations;
+
+  EvalFrame(
+      ExprV2& exprIn,
+      ExprRuntimeState& nodeRuntimeIn,
+      EvalCtx& ctxIn,
+      const SelectivityVector& rowsIn,
+      VectorPtr& resultIn);
+};
+```
+
+### `ExprEvaluatorV2` — stateless orchestrator
+
+```cpp
+/// Drives the staged evaluation pipeline against an EvalFrame.  Owns
+/// no state; all per-call state lives on the frame, all cross-call
+/// state lives in ExprRuntimeState.  Safe to share across threads.
+class ExprEvaluatorV2 {
+ public:
+  /// Entry point.  Constructs no state; orchestrates phases.
+  void evaluate(EvalFrame& frame, const ExprSetV2* parentSet);
+
+ private:
+  // Pipeline phases.  Order matches V1 semantics exactly.  Each name
+  // describes what wrapper or fork this layer owns, not what the
+  // previous layer did.
+  void evaluateFrame(EvalFrame& f, const ExprSetV2* parentSet);
+  void evaluateWithFieldPeeling(EvalFrame& f);
+  void evaluateWithNullPruning(EvalFrame& f);
+  void evaluateWithSharedSubexpr(EvalFrame& f);
+  void evaluateNodeBody(EvalFrame& f);
+  void evaluateFunctionCall(EvalFrame& f);
+  void evaluateSpecialForm(EvalFrame& f);
+
+  // Apply / leaf operations.
+  void applyFunction(EvalFrame& f);
+  void emitEmpty(EvalFrame& f);
+};
+```
+
+### `ExprSetV2` — owner
+
+```cpp
+class ExprSetV2 {
+ public:
+  ExprSetV2(
+      std::vector<core::TypedExprPtr> exprs,
+      core::ExecCtx* execCtx);
+
+  /// Public entry point.  Constructs an EvalFrame per root and calls
+  /// the evaluator.  Threading: each concurrent caller passes its own
+  /// EvalCtx; ExprSetV2 either provides per-thread runtime-state trees
+  /// or guards a shared one with a mutex (TBD).
+  void eval(
+      const SelectivityVector& rows,
+      EvalCtx& ctx,
+      std::vector<VectorPtr>& results);
+
+  void addToMemo(ExprV2* expr);
+
+  const std::vector<std::shared_ptr<ExprV2>>& exprs() const { return roots_; }
+
+ private:
+  std::vector<std::shared_ptr<ExprV2>> roots_;
+  std::unique_ptr<ExprRuntimeStateTree> runtimeStates_;
+  ExprEvaluatorV2 evaluator_;
+};
+```
+
+### Phases — stateless utility types
+
+Each phase is a stateless type with static methods that take `EvalFrame&`
+and (where applicable) a continuation callback.  Free functions in an
+anonymous namespace would work equally well; class form is for grouping
+and forward declaration.
+
+```cpp
+struct FastPath {
+  static bool tryFlatNoNulls(EvalFrame& f, const ExprSetV2* parentSet);
+};
+
+struct LazyInput {
+  static void loadRequiredFields(EvalFrame& f);
+};
+
+struct FieldPeeling {
+  /// Attempts to peel input field encodings for the whole subtree.
+  /// If peeling succeeds, calls continuation on a fresh inner frame
+  /// with translated rows; wraps the result back into the outer row
+  /// space.  Internally chooses DictionaryMemo::evaluate vs direct
+  /// continuation based on the peel result's mayCache flag.
+  template <typename Continuation>
+  static bool tryPeel(EvalFrame& f, Continuation continuation);
+};
+
+struct DictionaryMemo {
+  /// Reached only on the peeled, mayCache=true path.  Caches results
+  /// keyed by base dictionary and re-uses across batches.
+  template <typename Continuation>
+  static void evaluate(EvalFrame& f, Continuation continuation);
+};
+
+struct NullPruning {
+  /// Wrapping phase.  If propagatesNulls and inputs may have nulls,
+  /// computes the non-null subset of remainingRows, constructs an
+  /// inner frame on that subset, calls continuation, then null-fills
+  /// the pruned rows in the result on return.
+  template <typename Continuation>
+  static bool tryPrune(EvalFrame& f, Continuation continuation);
+};
+
+struct SharedSubexprCache {
+  /// Wrapping phase.  Checks nodeRuntime.sharedCache for a cached
+  /// result on the same input fields.  On hit, copies into result
+  /// and returns true.  On miss, calls continuation and stores
+  /// the result.
+  template <typename Continuation>
+  static bool tryReuse(EvalFrame& f, Continuation continuation);
+};
+
+struct ArgEval {
+  /// Evaluates all child inputs, populating frame.inputValues.  May
+  /// shrink frame.remainingRows in place when default-null behavior
+  /// applies.  Returns false if remainingRows becomes empty (in which
+  /// case setAllNulls has already been applied).
+  static bool evaluate(EvalFrame& f, ExprEvaluatorV2& evaluator);
+};
+
+struct ArgPeeling {
+  /// Argument-level peeling: peels the encodings of frame.inputValues
+  /// after child evaluation.  Distinct from FieldPeeling, which peels
+  /// input field encodings before children evaluate.
+  template <typename ApplyFn>
+  static bool tryApply(EvalFrame& f, ApplyFn apply);
+};
+```
+
+### `ArgEvalStrategy` — the one true policy
+
+```cpp
+/// Strategy for evaluating child inputs.  Two implementations:
+///   DefaultNullArgEval     — prune rows where any child is null.
+///   PreserveNullArgEval    — leave nulls in place for the function
+///                            to handle.
+/// Selected per-frame from expr.metadata().defaultNullBehavior.
+class ArgEvalStrategy {
+ public:
+  virtual ~ArgEvalStrategy() = default;
+
+  /// Returns true if remainingRows still has selections after
+  /// evaluation.  False means setAllNulls has been applied.
+  virtual bool evalArgs(EvalFrame& f, ExprEvaluatorV2& evaluator) = 0;
+};
+
+class DefaultNullArgEval : public ArgEvalStrategy { /* ... */ };
+class PreserveNullArgEval : public ArgEvalStrategy { /* ... */ };
+```
+
+Selected once per frame at frame construction:
+```cpp
+ArgEvalStrategy& strategy = f.defaultNulls
+    ? defaultNullStrategy_
+    : preserveNullStrategy_;
+```
+
+Strategies are shared (stateless), not allocated per call.
+
+### Debug guards
+
+Two RAII helpers verify invariants in debug builds.  Both compile to
+zero-cost no-ops in release.
+
+```cpp
+#ifndef NDEBUG
+/// Verifies the row-space invariant at every phase boundary:
+///   - remainingRows is a subset of originalRows.
+///   - remainingRows shrinks monotonically (never grows during phase).
+class DebugRemainingRowsGuard {
+ public:
+  explicit DebugRemainingRowsGuard(const EvalFrame& frame)
+      : frame_{frame},
+        countOnEntry_{frame.remainingRows.rows().countSelected()} {}
+
+  ~DebugRemainingRowsGuard() {
+    VELOX_DCHECK(frame_.remainingRows.rows().isSubset(frame_.originalRows));
+    VELOX_DCHECK_LE(
+        frame_.remainingRows.rows().countSelected(), countOnEntry_);
+  }
+
+ private:
+  const EvalFrame& frame_;
+  vector_size_t countOnEntry_;
+};
+
+/// Installed once at the top of evaluateFrame().  Verifies invariants
+/// that hold across the entire evaluation, not at each phase boundary.
+class DebugEvaluateGuard {
+ public:
+  explicit DebugEvaluateGuard(const EvalFrame& frame) : frame_{frame} {
+    VELOX_DCHECK(frame.inputValues.empty());
+  }
+
+  ~DebugEvaluateGuard() {
+    VELOX_DCHECK(frame_.inputValues.empty()); // releaseGuard ran
+    if (frame_.result) {
+      VELOX_DCHECK(frame_.result->type()->equivalent(*frame_.expr.type()));
+      VELOX_DCHECK_GE(frame_.result->size(), frame_.originalRows.end());
+    }
+  }
+
+ private:
+  const EvalFrame& frame_;
+};
+#else
+class DebugRemainingRowsGuard { public: explicit DebugRemainingRowsGuard(const EvalFrame&) {} };
+class DebugEvaluateGuard { public: explicit DebugEvaluateGuard(const EvalFrame&) {} };
+#endif
+```
+
+## Pipeline
+
+Order matches V1 semantics exactly (see `Expr.cpp` reference column).
+
+```cpp
+void ExprEvaluatorV2::evaluate(EvalFrame& f, const ExprSetV2* parentSet) {
+  evaluateFrame(f, parentSet);
+}
+
+// Entry guards.  Mirrors Expr::eval (816).
+void ExprEvaluatorV2::evaluateFrame(EvalFrame& f, const ExprSetV2* parentSet) {
+  DebugEvaluateGuard outerGuard{f};
+
+  if (FastPath::tryFlatNoNulls(f, parentSet)) return;
+
+  TopLevelExceptionScope scope{f, parentSet};
+
+  if (!f.originalRows.hasSelections()) {
+    emitEmpty(f);
+    return;
+  }
+
+  LazyInput::loadRequiredFields(f);
+  evaluateWithFieldPeeling(f);
+}
+
+// Field-peeling wrapper.  Mirrors Expr::evalEncodings (1101).
+void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  if (FieldPeeling::tryPeel(f, [this](EvalFrame& inner) {
+        evaluateWithNullPruning(inner);
+      })) {
+    return;
+  }
+  evaluateWithNullPruning(f);
+}
+
+// Null-pruning wrapper.  Mirrors Expr::evalWithNulls (1201).
+void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  if (NullPruning::tryPrune(f, [this](EvalFrame& pruned) {
+        evaluateWithSharedSubexpr(pruned);
+      })) {
+    return;
+  }
+  evaluateWithSharedSubexpr(f);
+}
+
+// Shared-subexpr wrapper.  Mirrors Expr::evalAll (1450).
+void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  if (SharedSubexprCache::tryReuse(f, [this](EvalFrame& inner) {
+        evaluateNodeBody(inner);
+      })) {
+    return;
+  }
+  evaluateNodeBody(f);
+}
+
+// Fork.  Mirrors the isSpecialForm() check in Expr::evalAllImpl (1486).
+void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& f) {
+  if (f.isSpecialForm) {
+    evaluateSpecialForm(f);
+    return;
+  }
+  evaluateFunctionCall(f);
+}
+
+// Function-call leaf.  Mirrors the rest of evalAllImpl + applyFunction*.
+void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  auto releaseGuard = folly::makeGuard([&] {
+    f.ctx.releaseVectors(f.inputValues);
+    f.inputValues.clear();
+  });
+
+  if (!ArgEval::evaluate(f, *this)) {
+    return; // setAllNulls already applied
+  }
+
+  if (!f.tryPeelArgs ||
+      !ArgPeeling::tryApply(f, [this](EvalFrame& g) { applyFunction(g); })) {
+    applyFunction(f);
+  }
+
+  if (f.remainingRows.hasChanged()) {
+    EvalCtx::addNulls(
+        f.originalRows,
+        f.remainingRows.rows().asRange().bits(),
+        f.ctx,
+        f.expr.type(),
+        f.result);
+  }
+}
+
+// Special-form leaf.  Delegates to wrapped legacy Expr during migration.
+void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  f.expr.legacySpecialForm()->evalSpecialForm(
+      f.remainingRows.rows(), f.ctx, f.result);
+}
+```
+
+### Phase-to-V1 mapping
+
+| V2 phase                       | V1 site                              | Responsibility                       |
+|--------------------------------|--------------------------------------|--------------------------------------|
+| `evaluateFrame`                | `Expr::eval` (816)                   | Fast path, exception scope, empty rows, lazy load. |
+| `evaluateWithFieldPeeling`     | `Expr::evalEncodings` (1101)         | Field peeling wrapper.               |
+| `FieldPeeling::tryPeel`        | `peelEncodings` (1025)               | Compute peel, recurse on inner rows. |
+| `DictionaryMemo::evaluate`     | `Expr::evalWithMemo` (1246)          | Cache by base dictionary.            |
+| `evaluateWithNullPruning`      | `Expr::evalWithNulls` (1201)         | Null pruning wrapper.                |
+| `evaluateWithSharedSubexpr`    | `Expr::evalAll` (1450)               | Shared-subexpr wrapper.              |
+| `SharedSubexprCache::tryReuse` | `Expr::evaluateSharedSubexpr` (899)  | Cache lookup + partial-row eval.     |
+| `evaluateNodeBody`             | `Expr::evalAllImpl` (1486) fork      | Special-form vs function-call fork.  |
+| `evaluateFunctionCall`         | `Expr::evalAllImpl` (1490–1531) tail | Arg eval, arg peeling, apply, null fill. |
+| `ArgEval::evaluate`            | `evalArgsDefaultNulls` (380) / `evalArgsWithNulls` (455) | Evaluate children. |
+| `ArgPeeling::tryApply`         | `applyFunctionWithPeeling` (1534)    | Argument-level peeling.              |
+| `applyFunction`                | `Expr::applyFunction` (1753)         | Invoke vector function + listeners.  |
+
+## UML diagrams
+
+### Class diagram
+
+```
+  Legend:  <>-- composition (owns lifetime)
+           o-- aggregation (holds reference)
+           --> uses / depends on
+           --|> implements interface
+           « »  stereotype
+
+
+  +------------------------------------------------------------------+
+  |                          ExprSetV2                               |
+  |  «owner»                                                         |
+  +------------------------------------------------------------------+
+  | - roots_     : vector<shared_ptr<ExprV2>>                        |
+  | - runtimeStates_ : unique_ptr<ExprRuntimeStateTree>              |
+  | - evaluator_ : ExprEvaluatorV2                                   |
+  +------------------------------------------------------------------+
+  | + eval(rows, ctx, results[])                                     |
+  | + addToMemo(ExprV2*)                                             |
+  +--------+-----------------+---------------------+-----------------+
+           <>                <>                    <>
+           |                 |                     |
+           v                 v                     v
+  +--------------------+ +-----------------+  +---------------------------+
+  |      ExprV2        | | ExprRuntimeStateTree |  ExprEvaluatorV2        |
+  | «immutable node»   | | «owner of nodes»|  |     «stateless»          |
+  +--------------------+ +-----------------+  +---------------------------+
+  | - type_            | | - states_       |  | + evaluate(frame,        |
+  | - name_            | | - indexByNode_  |  |     parentSet)           |
+  | - inputs_          | +-----------------+  | - evaluateFrame(f, ps)   |
+  | - vectorFunc_      |         <>           | - evaluateWithField...   |
+  | - metadata_        |         |            | - evaluateWithNull...    |
+  | - specialForm_     |         v            | - evaluateWithShared...  |
+  | - legacySpecial_   | +-----------------+  | - evaluateNodeBody       |
+  | - distinctFields_  | | ExprRuntimeState|  | - evaluateFunctionCall   |
+  +-----+--------------+ |                 |  | - evaluateSpecialForm    |
+        <>               | - sharedCache   |  | - applyFunction          |
+        | inputs_        | - dictMemo      |  +-----------+--------------+
+        |                | - stats         |              | uses
+        v                | - adaptiveState |              v
+  +--------------------+ +-----------------+   +---------------------------+
+  |      ExprV2        |                       |        «phases»           |
+  +--------------------+                       | (stateless types)         |
+                                               +---------------------------+
+                                               | FastPath                  |
+                                               | LazyInput                 |
+                                               | FieldPeeling              |
+                                               | DictionaryMemo            |
+                                               | NullPruning               |
+                                               | SharedSubexprCache        |
+                                               | ArgEval -+                |
+                                               | ArgPeeling                |
+                                               +--+----+--+----------------+
+                                                  | takes &f  | uses
+                                                  v           v
+                                       +----------------+ +------------------+
+                                       |   EvalFrame    | | ArgEvalStrategy  |
+                                       | «per-call»     | | «interface»      |
+                                       +----------------+ +--------+---------+
+                                       | & expr         |        --|--
+                                       | & nodeRuntime  |       /     \
+                                       | & ctx          |      v       v
+                                       | & originalRows |  +-------+ +---------+
+                                       | & result       |  |Default| |Preserve |
+                                       |   remainingRows|  |Null   | |Null     |
+                                       |   inputValues  |  |ArgEval| |ArgEval  |
+                                       |   tryPeelArgs  |  +-------+ +---------+
+                                       |   [flags]      |
+                                       +----+----+------+
+                                            o    o
+                                            |    |
+                                            v    v
+                            +----------------+ +-----------------+
+                            |ExprRuntimeState| |    EvalCtx      |
+                            +----------------+ | «existing»      |
+                                               +-----------------+
+```
+
+### Sequence diagram for one `evaluate()` call
+
+```
+caller        ExprSetV2     ExprEvaluatorV2     phases         EvalFrame      EvalCtx
+  |              |                |                |              (stack)         |
+  | eval(rows,   |                |                |                |             |
+  |   ctx,res[]) |                |                |                |             |
+  |------------->|                |                |                |             |
+  |              | construct      |                |                |             |
+  |              | EvalFrame------+--------------->|                |             |
+  |              |                |                |                |             |
+  |              | evaluate(f, this)               |                |             |
+  |              |--------------->|                |                |             |
+  |              |                |                |                |             |
+  |              |                | FastPath::tryFlatNoNulls(f)     |             |
+  |              |                |--------------->| read flags     |             |
+  |              |                |                |<---------------|             |
+  |              |                | false                           |             |
+  |              |                |<---------------|                |             |
+  |              |                |                |                |             |
+  |              |                | TopLevelExceptionScope installed              |
+  |              |                |-----------------------------------------------|
+  |              |                |                |                |             |
+  |              |                | LazyInput::loadRequiredFields(f)|             |
+  |              |                |--------------->| ensureFieldLoaded            |
+  |              |                |                |--------------+-------------->|
+  |              |                |                |                |             |
+  |              |                | FieldPeeling::tryPeel(f, &evaluateWith...)    |
+  |              |                |--------------->| saveAndReset, setPeeled      |
+  |              |                |                |-----------------------------> |
+  |              |                |                | construct innerFrame         |
+  |              |                |                |--------------> (new frame)   |
+  |              |                |                | recurse(innerFrame)          |
+  |              |                |<---------------|                |             |
+  |              |                | ... NullPruning, SharedSubexprCache,          |
+  |              |                |     fork, ArgEval, ArgPeeling, apply ...      |
+  |              |                |                | wrap peeled result           |
+  |              |                |                | moveOrCopyResult to outer    |
+  |              |                | true                            |             |
+  |              |                |<---------------|                |             |
+  |              | (early return; releaseGuard cleared inputValues)               |
+  |              | result[i] populated             |                |             |
+  |<-------------|                |                |                |             |
+```
+
+### State diagram for `remainingRows`
+
+```
+                  remainingRows == originalRows
+                          (initial)
+                              |
+                              | enter evaluateFrame
+                              v
+        +-----------------+---+---------------+---------------+
+        |                 |                   |               |
+   FieldPeeling      NullPruning         SharedSubexpr    (no shrink)
+   (no shrink         (no shrink         (no shrink
+    on outer;          on outer;          on outer;
+    inner frame        inner frame        inner frame
+    has its own        has its own        has its own
+    originalRows)      originalRows)      originalRows)
+        |                 |                   |               |
+        +-----------------+---+---------------+---------------+
+                              |
+                              v
+                       evaluateNodeBody
+                              |
+                +-------------+-------------+
+                |                           |
+          evaluateSpecialForm        evaluateFunctionCall
+          (no shrink)                       |
+                                            v
+                                       ArgEval::evaluate
+                                       (may shrink in place
+                                        via default-null or
+                                        error deselection)
+                                            |
+                                            v
+                                       remainingRows
+                                       <= original
+                                            |
+                                            v
+                                       ArgPeeling / applyFunction
+                                       (operate on
+                                        remainingRows.rows())
+                                            |
+                                            v
+                                       if shrank, addNulls for
+                                       originalRows \ remainingRows
+```
+
+## Recursion patterns
+
+Two distinct shapes; each phase uses exactly one.
+
+**Pattern A — wrapping recursion** (FieldPeeling, NullPruning, SharedSubexprCache):
+- Phase constructs a new `EvalFrame` with a different `originalRows`
+  (peeled inner rows, or pruned subset).
+- The outer frame's `remainingRows` is not mutated by the phase.
+- The inner frame has its own invariants; the guard on the outer
+  frame sees no change.
+
+**Pattern B — in-place mutation** (ArgEval):
+- Same frame; `remainingRows` shrinks in place as children evaluate
+  and null/error rows are deselected.
+- The guard on the frame sees the shrinkage and verifies subset +
+  monotonicity.
+
+No phase mixes both patterns.
+
+## Adapter from `Expr` to `ExprV2`
+
+```cpp
+// static
+std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& expr) {
+  // Recursively convert children.
+  std::vector<std::shared_ptr<ExprV2>> inputs;
+  inputs.reserve(expr->inputs().size());
+  for (const auto& child : expr->inputs()) {
+    inputs.push_back(ExprV2::from(child));
+  }
+
+  // For special forms, wrap the legacy Expr and delegate.
+  if (expr->isSpecialForm()) {
+    return std::shared_ptr<ExprV2>(new ExprV2(
+        expr->type(),
+        expr->name(),
+        std::move(inputs),
+        /*vectorFunction=*/nullptr,
+        expr->vectorFunctionMetadata(),
+        toSpecialFormTag(expr),
+        /*legacySpecialForm=*/expr,
+        /* ...flags from expr... */));
+  }
+
+  // Function-call node: full ExprV2.
+  return std::shared_ptr<ExprV2>(new ExprV2(
+      expr->type(),
+      expr->name(),
+      std::move(inputs),
+      expr->vectorFunction(),
+      expr->vectorFunctionMetadata(),
+      SpecialForm::kNone,
+      /*legacySpecialForm=*/nullptr,
+      /* ...flags from expr... */));
+}
+```
+
+This preserves all parsing, typing, type-coercion, function-lookup, and
+metadata-derivation logic in the existing `ExprCompiler`.  Only the
+evaluation half is re-implemented.
+
+## Implementation steps
+
+Each step is one commit, behavior-preserving and reviewable on its own.
+Steps 1–11 have landed; steps 12–15 are follow-up changes.  V2 is
+feature-flagged off until step 11.
+
+### Step 1 — design doc
+
+Land this design doc.
+
+The originally planned golden-output tests in
+`velox/expression/tests/ExprPipelineEdgeCasesTest.cpp` were not added.
+Parity is verified instead by the A/B harness from step 4
+(`ExprV2ParityTest`), which compares V1 and V2 output directly and so
+needs no checked-in goldens.  These cases from the original list have no
+direct parity test yet and are covered only by the expression fuzzer
+(step 11):
+
+- TRY × shared-subexpr partial-row reuse.
+- TRY with failing children under default-null vs preserve-null.
+- Dictionary memo with `finalSelection` set.
+- Lazy vectors under IF / AND / OR with `hasConditionals`.
+- `evalSimplified` equivalence on a representative query.
+
+### Step 2 — skeletons of all V2 types
+
+Add empty headers and minimal implementations for `ExprV2`,
+`ExprRuntimeState`, `ExprRuntimeStateTree`, `EvalFrame`,
+`ExprEvaluatorV2`, `ExprSetV2`.  All entry points are `VELOX_NYI` stubs;
+nothing routes through them yet.
+
+### Step 3 — adapter `ExprV2::from(Expr)` for function-call nodes
+
+Implement the adapter.  For special-form nodes, wrap legacy `Expr` and
+mark with `SpecialForm` tag.  `ExprV2AdapterTest` compiles a query,
+adapts it to V2, and verifies metadata round-trips.
+
+### Step 4 — trivial pipeline paths
+
+Implement `ExprEvaluatorV2::evaluate` for:
+- FastPath (delegate to existing `evalFlatNoNulls` logic in V1; keep
+  bit-identical).
+- Empty rows.
+- Special-form delegation (`evaluateSpecialForm` calls
+  `legacySpecialForm_->evalSpecialForm`).
+- Function-call without peeling, memo, or shared-subexpr: arg eval +
+  apply.
+
+At this point, V2 can evaluate simple queries.  `ExprV2ParityTest` adds
+the A/B harness that evaluates a query with both V1 and V2 and asserts
+vector equality.
+
+Lands in two commits: the pipeline plus harness, then a follow-up adding
+`ExprSetV2::sourceSet()` — callers of `ExprSetV2::eval` must construct an
+`EvalCtx`, which requires a non-null `ExprSet`.
+
+### Step 5 — FieldPeeling phase
+
+Port `evalEncodings` / `peelEncodings` logic into
+`ExprEvaluatorV2::evaluateWithFieldPeeling`.  Construct an inner
+`EvalFrame` for the peeled row space.  Verify the A/B harness passes for
+peeling-eligible queries.
+
+### Step 6 — DictionaryMemo phase
+
+Port `evalWithMemo` into `ExprEvaluatorV2::evaluateDictionaryMemo`.
+Reachable only from `evaluateWithFieldPeeling` when the peel result is
+cacheable.
+
+### Step 7 — NullPruning phase
+
+Port `evalWithNulls`'s null-pruning branch into
+`ExprEvaluatorV2::evaluateWithNullPruning`.  Wrapping recursion
+constructs an inner frame on the pruned row space.
+
+### Step 8 — SharedSubexprCache phase
+
+Port `evaluateSharedSubexpr` into
+`ExprEvaluatorV2::evaluateWithSharedSubexpr`.  This is the seam most
+likely to surface subtle TRY-interaction bugs.
+
+### Step 9 — ArgEval + ArgPeeling
+
+Port `evalArgsDefaultNulls` and `evalArgsWithNulls` into
+`ExprEvaluatorV2::evalArgsDefaultNull` and `evalArgsPreserveNull`,
+selected per frame from the node's `defaultNulls` metadata.
+
+Also ports `applyFunctionWithPeeling` into `tryApplyWithPeeling`,
+originally planned for step 10 — `evaluateFunctionCall` reads as one unit
+with the argument-peeling attempt it guards.
+
+### Step 10a — output tracer hooks
+
+Port `maybeSetupTracer` / `finishTracer` / `traceOutput` and the
+`ExprSet` wrappers.  Per-`Expr` tracer state moves onto
+`ExprRuntimeState::outputTracer`; `ExprSetV2` gains `maybeSetupTracers`
+and `finishTracers`.
+
+### Step 10b — listeners, CPU timing, adaptive sampling
+
+Port `applyFunction` and `invokeApplyWithListeners` plus the adaptive
+CPU-sampling state machine: per-node stats, `CpuWallTimer`, `isAscii`
+computation and propagation, listener invocation around `apply`, and the
+function-returned-no-result-and-no-error case.
+
+### Step 11 — feature flag + fuzzer coverage
+
+Add the query-config flag `expression.eval_v2` (default false) and branch
+`makeExprSetFromFlag` on it.  `ExprSetV2` is reshaped as a subclass of
+`ExprSet` — the same relationship `ExprSetSimplified` has — so the
+existing factory and operator callers route to V2 through polymorphic
+dispatch.  This supersedes the standalone-owner shape sketched in
+[`ExprSetV2` — owner](#exprsetv2--owner) above, and drops the
+`sourceSet()` accessor from step 4: the V1 surface is now inherited.
+`ExpressionVerifier` exercises V2 alongside V1 common + simplified, so
+the existing expression fuzzer covers the V2 path.
+
+Still outstanding from this step: running the full
+`velox_expression_test` suite under both flag values in CI and comparing
+every test case vector-for-vector.
+
+### Step 12 — migrate special forms
+
+For each of `CaseExpr`, `ConjunctExpr`, `CastExpr`, `CoalesceExpr`,
+`FieldReference`, `ConstantExpr`: produce a native `ExprV2` form and
+remove the delegation wrapper.  One PR per form.  Order suggested:
+`FieldReference` and `ConstantExpr` first (simplest), then `CastExpr`,
+then conditionals.
+
+### Step 13 — subsume `ExprSetSimplified`
+
+Reimplement `ExprSetSimplified` as `ExprSetV2` with peeling, memo, and
+shared-subexpr phases disabled.  Delete `evalSimplified` and
+`evalSimplifiedImpl` from V1.
+
+### Step 14 — cutover
+
+Flip the `expression.eval_v2` default to true after one release cycle of
+no parity bugs in production.
+
+### Step 15 — delete V1
+
+Once the flag has been default-true for one release cycle and no parity
+flag is held by any caller, delete `Expr::eval` and the chain of
+methods it calls.  Keep `Expr` as a compile-time tree node consumed by
+`ExprV2::from()`, or merge `Expr` and `ExprV2` if it makes sense.
+
+## Milestones
+
+| Milestone | Steps | Outcome |
+|-----------|-------|---------|
+| **M1: Foundations**          | 1–3   | Design locked, V2 types compile, adapter works. |
+| **M2: Trivial pipeline**     | 4     | V2 can evaluate simple function-call queries; A/B harness in test code passes for trivial cases. |
+| **M3: Encoding paths**       | 5–6   | Field peeling and dictionary memo working in V2; A/B parity for peeling-heavy queries. |
+| **M4: Null + cache paths**   | 7–8   | Null pruning and shared-subexpr working in V2; A/B parity for propagatesNulls and shared-subexpr queries. |
+| **M5: Function-call leaf**   | 9–10b | Arg eval (both strategies), arg peeling, listeners, tracer working; V2 reaches full feature parity for function-call nodes. |
+| **M6: Production rollout**   | 11    | `expression.eval_v2` flag in place; expression fuzzer covers V2; opt-in available in production. |
+| **M7: Special-form native**  | 12    | Each special form runs natively under V2 instead of delegating; legacy `Expr` no longer reached on V2 path. |
+| **M8: Simplified subsumed**  | 13    | `ExprSetSimplified` deleted; V2 covers both paths. |
+| **M9: Cutover**              | 14    | V2 is the default in production. |
+| **M10: V1 deleted**          | 15    | Legacy `Expr::eval` chain removed; codebase has one evaluator. |
+
+Each milestone is releasable independently.  No milestone (except M10)
+removes existing functionality.
+
+## Testing strategy
+
+### Golden-output tests
+
+For each of the step-1 edge cases, capture V1's output as a golden vector.
+After each subsequent step, run the same test against both V1 and V2 and
+assert byte-equal vectors (including nulls, encodings, and child vector
+shapes — not just logical values).
+
+### A/B parity harness
+
+Add a test helper that takes a query and input rows and:
+1. Evaluates with V1, captures output vector.
+2. Evaluates with V2, captures output vector.
+3. Asserts logical equality (`VectorEqualValueChecker`), null pattern
+   equality, and where possible encoding equality.
+
+Wire the existing `expression_test` to run under both flags in CI.
+
+### Debug-build invariants
+
+Compile CI debug builds with `DebugRemainingRowsGuard` and
+`DebugEvaluateGuard` enabled.  These catch the most likely refactor
+regressions (row-space violations, missing `releaseInputValues`,
+result type mismatch) at every phase boundary.
+
+### Production safety
+
+The `expression.eval_v2` flag is per-query.  A canary deploy can route a
+small percentage of production queries through V2 while V1 remains
+the default; any divergence is logged via the existing query-fingerprint
+infrastructure.
+
+## Risks and open questions
+
+### Risks
+
+- **`ExprRuntimeState` threading.**  V1 today is single-threaded per
+  `ExprSet` because state lives on `Expr`.  V2 enables concurrent
+  evaluation, but `ExprSetV2` must decide: per-thread runtime-state
+  trees, or one shared tree with a mutex.  The right answer depends on
+  whether shared-subexpr / memo benefits cross threads.  Decision
+  deferred to step 4 when the first concurrent caller appears.
+- **Special-form delegation overhead.**  Each special-form evaluation
+  in V2 calls `legacySpecialForm_->evalSpecialForm`, which does its
+  own internal pipeline work.  Should be zero overhead in practice
+  (one extra virtual call), but worth measuring at M5.
+- **Stats merging.**  V1 accumulates stats on `Expr::stats_`.  V2
+  accumulates on `ExprRuntimeState::stats`.  The reporting code
+  (`ExprSet::stats()`) must be ported to read from the V2 location
+  while V1 is still in tree.  Plan: read both, prefer V2 when
+  populated.
+- **Adapter cost on hot paths.**  `ExprV2::from(Expr)` walks the tree
+  once per `ExprSetV2` construction.  Negligible relative to eval cost,
+  but worth confirming on micro-benchmarks before M6.
+
+### Open questions
+
+- Should `ExprRuntimeStateTree` use flat-vector indexing (cheap, but
+  requires stable tree iteration order) or `F14FastMap<ExprV2*>`
+  (more flexible, slight lookup cost)?  Decide at step 2.
+- Should `ExprV2` be `final`?  No subclasses are anticipated; making it
+  `final` enables devirtualization in tight loops.
+- Are there any callers that hold raw `Expr*` pointers across a query
+  lifetime?  Audit needed before step 14.
+- `FieldReference` is currently a subclass of `Expr` with custom
+  `evalSpecialForm`.  Step 12 needs to decide whether `FieldReferenceV2`
+  is a distinct `ExprV2` subtype, or whether `ExprV2` carries a
+  `FieldReference` flag inline.
+
+## Appendix: file layout
+
+```
+velox/expression/
+  Expr.{h,cpp}                       — unchanged
+  ExprSet.{h,cpp}                    — unchanged
+
+  ExprV2.{h,cpp}                     — new: node + ExprV2::from(Expr)
+  ExprRuntimeState.{h,cpp}           — new: per-node mutable state
+  EvalFrame.{h,cpp}                  — new: per-call state
+  ExprEvaluatorV2.{h,cpp}            — new: pipeline orchestrator
+  ExprSetV2.{h,cpp}                  — new: owner type
+
+  ExprPhases/                        — new: pipeline phases
+    FastPath.{h,cpp}
+    LazyInput.{h,cpp}
+    FieldPeeling.{h,cpp}
+    DictionaryMemo.{h,cpp}
+    NullPruning.{h,cpp}
+    SharedSubexprCache.{h,cpp}
+    ArgEval.{h,cpp}
+    ArgPeeling.{h,cpp}
+
+  tests/
+    ExprPipelineEdgeCasesTest.cpp    — new: step-1 golden tests
+    ExprV2ParityTest.cpp             — new: A/B harness
+```

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -50,10 +50,14 @@ velox_add_library(
   EvalCtx.cpp
   Expr.cpp
   ExprCompiler.cpp
+  ExprEvaluatorV2.cpp
   ExprRewriteRegistry.cpp
   ExprOptimizer.cpp
+  ExprRuntimeState.cpp
+  ExprSetV2.cpp
   ExprToSubfieldFilter.cpp
   ExprUtils.cpp
+  ExprV2.cpp
   FieldReference.cpp
   FunctionCallToSpecialForm.cpp
   GenericWriter.cpp
@@ -85,16 +89,22 @@ velox_add_library(
   ConjunctExpr.h
   ConjunctRewrite.h
   ConstantExpr.h
+  DebugGuards.h
   DecodedArgs.h
   EvalCtx.h
+  EvalFrame.h
   Expr.h
   ExprCompiler.h
   ExprConstants.h
+  ExprEvaluatorV2.h
   ExprOptimizer.h
   ExprRewriteRegistry.h
+  ExprRuntimeState.h
+  ExprSetV2.h
   ExprStats.h
   ExprToSubfieldFilter.h
   ExprUtils.h
+  ExprV2.h
   FieldReference.h
   FunctionCallToSpecialForm.h
   KindToSimpleType.h

--- a/velox/expression/DebugGuards.h
+++ b/velox/expression/DebugGuards.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/EvalFrame.h"
+
+namespace facebook::velox::exec {
+
+#ifndef NDEBUG
+
+/// Verifies row-space invariants across one phase scope:
+///   - remainingRows is a subset of originalRows on exit.
+///   - remainingRows.countSelected() never increased during the scope.
+/// Install at the top of any pipeline function that may shrink (or
+/// recurse with) remainingRows.
+class DebugRemainingRowsGuard {
+ public:
+  explicit DebugRemainingRowsGuard(const EvalFrame& frame)
+      : frame_{frame},
+        countOnEntry_{frame.remainingRows.rows().countSelected()} {}
+
+  ~DebugRemainingRowsGuard() {
+    VELOX_DCHECK(frame_.remainingRows.rows().isSubset(frame_.originalRows));
+    VELOX_DCHECK_LE(
+        frame_.remainingRows.rows().countSelected(), countOnEntry_);
+  }
+
+ private:
+  const EvalFrame& frame_;
+  vector_size_t countOnEntry_;
+};
+
+/// Verifies frame-wide invariants across one top-level evaluate() call:
+///   - inputValues empty on entry and exit (releaseGuard fired).
+///   - result type matches expr type.
+///   - result vector sized to at least originalRows.end().
+/// Install once at the top of ExprEvaluatorV2::evaluateFrame().
+class DebugEvaluateGuard {
+ public:
+  explicit DebugEvaluateGuard(const EvalFrame& frame) : frame_{frame} {
+    VELOX_DCHECK(frame.inputValues.empty());
+  }
+
+  ~DebugEvaluateGuard() {
+    VELOX_DCHECK(frame_.inputValues.empty());
+    if (frame_.result != nullptr) {
+      VELOX_DCHECK(
+          frame_.result->type()->equivalent(*frame_.expr.type()));
+      VELOX_DCHECK_GE(
+          static_cast<vector_size_t>(frame_.result->size()),
+          frame_.originalRows.end());
+    }
+  }
+
+ private:
+  const EvalFrame& frame_;
+};
+
+#else
+
+class DebugRemainingRowsGuard {
+ public:
+  explicit DebugRemainingRowsGuard(const EvalFrame&) {}
+};
+
+class DebugEvaluateGuard {
+ public:
+  explicit DebugEvaluateGuard(const EvalFrame&) {}
+};
+
+#endif // NDEBUG
+
+} // namespace facebook::velox::exec

--- a/velox/expression/EvalFrame.h
+++ b/velox/expression/EvalFrame.h
@@ -60,7 +60,9 @@ struct EvalFrame {
         deterministic{exprIn.deterministic()},
         isSpecialForm{exprIn.isSpecialForm()},
         supportsFlatNoNullsFastPath{exprIn.supportsFlatNoNullsFastPath()},
-        hasConditionals{exprIn.hasConditionals()} {}
+        hasConditionals{exprIn.hasConditionals()},
+        skipFieldDependentOptimizations{
+            exprIn.skipFieldDependentOptimizations()} {}
 
   // === Bindings (constant after construction) ===
 
@@ -96,6 +98,7 @@ struct EvalFrame {
   bool isSpecialForm;
   bool supportsFlatNoNullsFastPath;
   bool hasConditionals;
+  bool skipFieldDependentOptimizations;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/EvalFrame.h
+++ b/velox/expression/EvalFrame.h
@@ -21,12 +21,11 @@
 
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/ExprRuntimeState.h"
 #include "velox/expression/ExprV2.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::exec {
-
-struct ExprRuntimeState;
 
 /// Per-call evaluation state for one ExprV2 node.  Lives on the stack of
 /// the outermost ExprEvaluatorV2::evaluate() call.  Inner recursion
@@ -44,12 +43,13 @@ struct ExprRuntimeState;
 struct EvalFrame {
   EvalFrame(
       ExprV2& exprIn,
-      ExprRuntimeState& nodeRuntimeIn,
+      ExprRuntimeStateTree& runtimeStatesIn,
       EvalCtx& ctxIn,
       const SelectivityVector& rowsIn,
       VectorPtr& resultIn)
       : expr{exprIn},
-        nodeRuntime{nodeRuntimeIn},
+        runtimeStates{runtimeStatesIn},
+        nodeRuntime{runtimeStatesIn.at(exprIn)},
         ctx{ctxIn},
         originalRows{rowsIn},
         result{resultIn},
@@ -65,6 +65,11 @@ struct EvalFrame {
   // === Bindings (constant after construction) ===
 
   ExprV2& expr;
+  // Tree-wide runtime state.  Used to look up runtime state for child
+  // nodes when constructing inner frames.
+  ExprRuntimeStateTree& runtimeStates;
+  // Cached lookup: runtime state for 'expr'.  Avoids per-phase map
+  // lookups via runtimeStates.
   ExprRuntimeState& nodeRuntime;
   EvalCtx& ctx;
   const SelectivityVector& originalRows;

--- a/velox/expression/EvalFrame.h
+++ b/velox/expression/EvalFrame.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprV2.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec {
+
+struct ExprRuntimeState;
+
+/// Per-call evaluation state for one ExprV2 node.  Lives on the stack of
+/// the outermost ExprEvaluatorV2::evaluate() call.  Inner recursion
+/// (peeling, null-pruning wrapper, shared-subexpr wrapper) constructs
+/// fresh EvalFrames.
+///
+/// Row-space invariant:
+///   - originalRows never changes after construction.
+///   - remainingRows.rows() is always a subset of originalRows.
+///   - Every phase operates on remainingRows.rows(), not originalRows.
+///   - remainingRows shrinks monotonically as evaluation proceeds; it
+///     never grows.
+///   - originalRows is used only for result sizing, final null-fill,
+///     and copying / wrapping back into the caller's row space.
+struct EvalFrame {
+  EvalFrame(
+      ExprV2& exprIn,
+      ExprRuntimeState& nodeRuntimeIn,
+      EvalCtx& ctxIn,
+      const SelectivityVector& rowsIn,
+      VectorPtr& resultIn)
+      : expr{exprIn},
+        nodeRuntime{nodeRuntimeIn},
+        ctx{ctxIn},
+        originalRows{rowsIn},
+        result{resultIn},
+        remainingRows{rowsIn, ctxIn},
+        tryPeelArgs{exprIn.deterministic()},
+        defaultNulls{exprIn.metadata().defaultNullBehavior},
+        propagatesNulls{exprIn.propagatesNulls()},
+        deterministic{exprIn.deterministic()},
+        isSpecialForm{exprIn.isSpecialForm()},
+        supportsFlatNoNullsFastPath{exprIn.supportsFlatNoNullsFastPath()},
+        hasConditionals{exprIn.hasConditionals()} {}
+
+  // === Bindings (constant after construction) ===
+
+  ExprV2& expr;
+  ExprRuntimeState& nodeRuntime;
+  EvalCtx& ctx;
+  const SelectivityVector& originalRows;
+  VectorPtr& result;
+
+  // === Mutable state flowing between phases ===
+
+  MutableRemainingRows remainingRows;
+
+  // Evaluated child results, populated by ArgEval.  Moved off ExprV2;
+  // lives on the frame so the same ExprV2 can be evaluated concurrently.
+  std::vector<VectorPtr> inputValues;
+
+  // Running conjunction tracked by ArgEval: are all evaluated child
+  // encodings peelable?  Initialized from expr.deterministic(); cleared
+  // when ArgEval sees a non-peelable encoding.
+  bool tryPeelArgs;
+
+  // === Compile-time flags cached once from expr ===
+
+  bool defaultNulls;
+  bool propagatesNulls;
+  bool deterministic;
+  bool isSpecialForm;
+  bool supportsFlatNoNullsFastPath;
+  bool hasConditionals;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -31,6 +31,7 @@
 #include "velox/common/EnumDefine.h"
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/ExprSetV2.h"
 #include "velox/expression/ExprCompiler.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/LambdaExpr.h"
@@ -2399,6 +2400,10 @@ std::unique_ptr<ExprSet> makeExprSetFromFlag(
   if (execCtx->queryCtx()->queryConfig().exprEvalSimplified() ||
       FLAGS_force_eval_simplified) {
     return std::make_unique<ExprSetSimplified>(std::move(source), execCtx);
+  }
+  if (execCtx->queryCtx()->queryConfig().exprEvalV2()) {
+    return std::make_unique<ExprSetV2>(
+        source, execCtx, /*enableConstantFolding=*/true, lazyDereference);
   }
   return std::make_unique<ExprSet>(
       std::move(source), execCtx, true, lazyDereference);

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -390,6 +390,13 @@ class Expr {
     return distinctFields_;
   }
 
+  /// Subset of distinctFields() that are referenced by more than one
+  /// input subtree.  Used by the ExprV2 adapter and by lazy-loading
+  /// decisions; exposed publicly for those consumers.
+  const std::unordered_set<FieldReference*>& multiplyReferencedFields() const {
+    return multiplyReferencedFields_;
+  }
+
   static bool isSameFields(
       const std::vector<FieldReference*>& fields1,
       const std::vector<FieldReference*>& fields2);
@@ -443,6 +450,19 @@ class Expr {
 
   const VectorFunctionMetadata& vectorFunctionMetadata() const {
     return vectorFunctionMetadata_;
+  }
+
+  /// Listeners invoked around vectorFunction_->apply().  Empty for
+  /// special-form nodes.  Exposed for the ExprV2 adapter.
+  const std::vector<VectorFunctionListeners>& listeners() const {
+    return listeners_;
+  }
+
+  /// True if this expression should always track CPU usage (set at
+  /// compile time from query config).  Distinct from adaptive
+  /// sampling, which is decided at runtime.
+  bool trackCpuUsage() const {
+    return trackCpuUsage_;
   }
 
   std::vector<VectorPtr>& inputValues() {

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -465,6 +465,14 @@ class Expr {
     return trackCpuUsage_;
   }
 
+  /// Returns the per-Expr output tracer if one has been installed by
+  /// ExprSet::maybeSetupTracers, or nullptr otherwise.  Exposed
+  /// publicly so the V2 evaluator can route trace writes through the
+  /// V1 tracer state during the migration period.
+  trace::TraceExprWriter* outputTracer() const {
+    return outputTracer_.get();
+  }
+
   std::vector<VectorPtr>& inputValues() {
     return inputValues_;
   }

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprEvaluatorV2.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec {
+
+// Pipeline implementation lands incrementally across steps 4-10.  For
+// now every entry point is a no-op stub that fails loudly if reached.
+
+void ExprEvaluatorV2::evaluate(
+    EvalFrame& /*frame*/,
+    const ExprSetV2* /*parentSet*/) {
+  VELOX_NYI("ExprEvaluatorV2::evaluate lands in step 4 of the refactor.");
+}
+
+void ExprEvaluatorV2::evaluateFrame(
+    EvalFrame& /*f*/,
+    const ExprSetV2* /*parentSet*/) {
+  VELOX_NYI();
+}
+
+void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& /*f*/) {
+  VELOX_NYI("Field peeling lands in step 5.");
+}
+
+void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& /*f*/) {
+  VELOX_NYI("Null pruning lands in step 7.");
+}
+
+void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& /*f*/) {
+  VELOX_NYI("Shared-subexpr cache lands in step 8.");
+}
+
+void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& /*f*/) {
+  VELOX_NYI();
+}
+
+void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& /*f*/) {
+  VELOX_NYI("Function-call leaf lands in step 4 / 9 / 10.");
+}
+
+void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& /*f*/) {
+  VELOX_NYI("Special-form delegation lands in step 4.");
+}
+
+void ExprEvaluatorV2::applyFunction(EvalFrame& /*f*/) {
+  VELOX_NYI();
+}
+
+void ExprEvaluatorV2::emitEmpty(EvalFrame& /*f*/) {
+  VELOX_NYI();
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -39,6 +39,34 @@ void emitNullConstant(
   }
 }
 
+// Mirrors Expr.cpp:1438.
+bool isPeelable(VectorEncoding::Simple encoding) {
+  return encoding == VectorEncoding::Simple::CONSTANT ||
+      encoding == VectorEncoding::Simple::DICTIONARY;
+}
+
+// Mirrors Expr::throwArgumentErrors (Expr.cpp:1472).
+bool throwArgumentErrors(const EvalFrame& f) {
+  return f.ctx.throwOnError() &&
+      (!f.defaultNulls ||
+       (f.supportsFlatNoNullsFastPath && f.ctx.inputFlatNoNulls()));
+}
+
+// Mirrors mergeOrThrowArgumentErrors (Expr.cpp:339).
+void mergeOrThrowArgumentErrors(
+    const SelectivityVector& rows,
+    EvalErrorsPtr& originalErrors,
+    EvalErrorsPtr& argumentErrors,
+    EvalCtx& context) {
+  if (argumentErrors) {
+    if (context.throwOnError()) {
+      argumentErrors->throwFirstError(rows);
+    }
+    context.addErrors(rows, argumentErrors, originalErrors);
+  }
+  context.swapErrors(originalErrors);
+}
+
 // Mirrors the file-private isFlat() in Expr.cpp (line 355).
 bool isFlat(const BaseVector& vector) {
   auto encoding = vector.encoding();
@@ -559,10 +587,109 @@ void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& f) {
     f.inputValues.clear();
   });
 
-  // TODO(step 9): port ArgEval::evaluate (default-null vs
-  // preserve-null strategies, error swapping).  For step 4 the
-  // harness restricts to expressions with no-null inputs, where
-  // preserve-null and default-null are equivalent.
+  // Reset before each arg-eval attempt; the strategies populate
+  // inputValues, and ArgPeeling reads tryPeelArgs.
+  f.tryPeelArgs = f.deterministic;
+
+  bool argsOk = f.defaultNulls ? evalArgsDefaultNull(f) : evalArgsPreserveNull(f);
+  if (!argsOk) {
+    // setAllNulls already applied to originalRows.
+    return;
+  }
+
+  if (!f.tryPeelArgs || !tryApplyWithPeeling(f)) {
+    applyFunction(f);
+  }
+
+  // Write nulls for any rows that ArgEval pruned (default-null path).
+  if (f.remainingRows.hasChanged()) {
+    EvalCtx::addNulls(
+        f.originalRows,
+        f.remainingRows.rows().asRange().bits(),
+        f.ctx,
+        f.expr.type(),
+        f.result);
+  }
+}
+
+bool ExprEvaluatorV2::evalArgsDefaultNull(EvalFrame& f) {
+  // Mirrors Expr::evalArgsDefaultNulls (Expr.cpp:380).  For each child:
+  // evaluate, then deselect rows that are null and have no error.
+  EvalErrorsPtr argumentErrors;
+  EvalErrorsPtr originalErrors;
+  LocalDecodedVector decoded(f.ctx);
+
+  // Set aside pre-existing errors so we can distinguish argument errors.
+  if (f.ctx.errors()) {
+    f.ctx.swapErrors(originalErrors);
+  }
+
+  f.inputValues.resize(f.expr.inputs().size());
+  {
+    ScopedVarSetter throwErrors(
+        f.ctx.mutableThrowOnError(), throwArgumentErrors(f));
+
+    for (size_t i = 0; i < f.expr.inputs().size(); ++i) {
+      auto& childExpr = *f.expr.inputs()[i];
+      EvalFrame childFrame{
+          childExpr,
+          f.runtimeStates,
+          f.ctx,
+          f.remainingRows.rows(),
+          f.inputValues[i]};
+      evaluate(childFrame, /*parentSet=*/nullptr);
+      f.tryPeelArgs =
+          f.tryPeelArgs && isPeelable(f.inputValues[i]->encoding());
+
+      const uint64_t* flatNulls = nullptr;
+      auto& arg = f.inputValues[i];
+      if (arg->mayHaveNulls()) {
+        decoded.get()->decode(*arg, f.remainingRows.rows());
+        flatNulls = decoded.get()->nulls(&f.remainingRows.rows());
+      }
+
+      if (f.ctx.errors()) {
+        f.ctx.ensureErrorsVectorSize(f.remainingRows.rows().end());
+        auto* newErrors = f.ctx.errors();
+        if (flatNulls) {
+          // Null without error removes the row; null with error keeps
+          // the error.
+          auto errorNulls = newErrors->errorFlags();
+          auto* rowBits = f.remainingRows.mutableRows().asMutableRange().bits();
+          auto nwords = bits::nwords(f.remainingRows.rows().end());
+          for (size_t w = 0; w < nwords; ++w) {
+            auto nullNoError =
+                errorNulls ? flatNulls[w] | errorNulls[w] : flatNulls[w];
+            rowBits[w] &= nullNoError;
+          }
+          f.remainingRows.mutableRows().updateBounds();
+        }
+        f.ctx.moveAppendErrors(argumentErrors);
+      } else if (flatNulls) {
+        f.remainingRows.deselectNulls(flatNulls);
+      }
+
+      if (!f.remainingRows.rows().hasSelections()) {
+        break;
+      }
+    }
+  }
+
+  mergeOrThrowArgumentErrors(
+      f.remainingRows.rows(), originalErrors, argumentErrors, f.ctx);
+
+  if (!f.remainingRows.deselectErrors()) {
+    f.ctx.releaseVectors(f.inputValues);
+    f.inputValues.clear();
+    setAllNulls(f, f.remainingRows.originalRows());
+    return false;
+  }
+  return true;
+}
+
+bool ExprEvaluatorV2::evalArgsPreserveNull(EvalFrame& f) {
+  // Mirrors Expr::evalArgsWithNulls (Expr.cpp:455).  Nulls are not
+  // pruned; only error rows are removed.
   f.inputValues.resize(f.expr.inputs().size());
   for (size_t i = 0; i < f.expr.inputs().size(); ++i) {
     auto& childExpr = *f.expr.inputs()[i];
@@ -573,16 +700,104 @@ void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& f) {
         f.remainingRows.rows(),
         f.inputValues[i]};
     evaluate(childFrame, /*parentSet=*/nullptr);
+    f.tryPeelArgs =
+        f.tryPeelArgs && isPeelable(f.inputValues[i]->encoding());
+
+    if (!f.remainingRows.deselectErrors()) {
+      break;
+    }
+  }
+  if (!f.remainingRows.rows().hasSelections()) {
+    f.ctx.releaseVectors(f.inputValues);
+    f.inputValues.clear();
+    setAllNulls(f, f.remainingRows.originalRows());
+    return false;
+  }
+  return true;
+}
+
+bool ExprEvaluatorV2::tryApplyWithPeeling(EvalFrame& f) {
+  // Mirrors Expr::applyFunctionWithPeeling (Expr.cpp:1534).
+  const auto& applyRows = f.remainingRows.rows();
+  LocalDecodedVector localDecoded(f.ctx);
+  LocalSelectivityVector newRowsHolder(f.ctx);
+
+  // Peeling-suppressed path (small batches): handle the
+  // single-dictionary and single-constant cases explicitly to preserve
+  // the "flat-or-constant inputs" guarantee that vector functions rely
+  // on.
+  if (!f.ctx.peelingEnabled(applyRows) &&
+      !(f.inputValues.size() == 1 &&
+        f.inputValues[0]->encoding() == VectorEncoding::Simple::CONSTANT)) {
+    int dictIndex = -1;
+    bool canFlatten = true;
+
+    for (int i = 0; i < static_cast<int>(f.inputValues.size()); ++i) {
+      auto encoding = f.inputValues[i]->encoding();
+      if (encoding == VectorEncoding::Simple::DICTIONARY) {
+        if (dictIndex != -1) {
+          canFlatten = false;
+          break;
+        }
+        dictIndex = i;
+      }
+    }
+    if (canFlatten && dictIndex != -1) {
+      BaseVector::flattenVector(f.inputValues[dictIndex]);
+      applyFunction(f);
+      return true;
+    }
+    return false;
   }
 
-  // TODO(step 5): port ArgPeeling::tryApply.  For step 4 we always
-  // apply on un-peeled args.
-  applyFunction(f);
+  // Attempt peeling on the evaluated input vectors.
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::peel(
+      f.inputValues,
+      applyRows,
+      localDecoded,
+      f.expr.metadata().defaultNullBehavior,
+      peeledVectors);
+  if (!peeledEncoding) {
+    return false;
+  }
+  f.inputValues = std::move(peeledVectors);
+  peeledVectors.clear();
 
-  // TODO(step 9): write nulls for any rows that ArgEval pruned.  For
-  // step 4 ArgEval never prunes, so remainingRows.hasChanged() is
-  // always false.
-  VELOX_DCHECK(!f.remainingRows.hasChanged());
+  auto* newRows = peeledEncoding->translateToInnerRows(applyRows, newRowsHolder);
+
+  withContextSaver([&](ContextSaver& saver) {
+    f.ctx.saveAndReset(saver, applyRows);
+    f.ctx.setPeeledEncoding(peeledEncoding);
+
+    VectorPtr peeledResult;
+    f.expr.vectorFunction()->apply(
+        *newRows, f.inputValues, f.expr.type(), f.ctx, peeledResult);
+
+    VectorPtr wrappedResult = f.ctx.getPeeledEncoding()->wrap(
+        f.expr.type(), f.ctx.pool(), peeledResult, applyRows);
+    f.ctx.moveOrCopyResult(wrappedResult, applyRows, f.result);
+
+    f.ctx.releaseVector(peeledResult);
+  });
+
+  return true;
+}
+
+void ExprEvaluatorV2::setAllNulls(
+    EvalFrame& f,
+    const SelectivityVector& rows) {
+  // Mirrors Expr::setAllNulls (Expr.cpp:1353).
+  if (f.result) {
+    BaseVector::ensureWritable(rows, f.expr.type(), f.ctx.pool(), f.result);
+    LocalSelectivityVector notNulls(f.ctx, rows.end());
+    notNulls.get()->setAll();
+    notNulls.get()->deselect(rows);
+    f.result->addNulls(notNulls.get()->asRange().bits(), rows);
+    return;
+  }
+  f.result =
+      BaseVector::createNullConstant(f.expr.type(), rows.end(), f.ctx.pool());
 }
 
 void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -20,6 +20,7 @@
 #include <folly/ScopeGuard.h>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/exec/trace/TraceWriter.h"
 #include "velox/expression/DebugGuards.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/PeeledEncoding.h"
@@ -809,8 +810,8 @@ void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {
 }
 
 void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
-  // TODO(step 10): port listener invocation, CPU timing, adaptive
-  // sampling, tracer hooks.  Step 4 invokes the bare function.
+  // TODO(step 10b): listener invocation, CPU timing, adaptive
+  // sampling, empty-result handling.
   VELOX_CHECK_NOT_NULL(f.expr.vectorFunction());
   f.expr.vectorFunction()->apply(
       f.remainingRows.rows(),
@@ -818,6 +819,16 @@ void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
       f.expr.type(),
       f.ctx,
       f.result);
+
+  // Tracer hook.  Mirrors Expr::traceOutput (Expr.cpp:2131).
+  auto& tracer = f.nodeRuntime.outputTracer;
+  if (FOLLY_UNLIKELY(tracer != nullptr) && f.result != nullptr) {
+    try {
+      tracer->write(f.result);
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to trace expression output: " << e.what();
+    }
+  }
 }
 
 void ExprEvaluatorV2::emitEmpty(EvalFrame& f) {

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -23,6 +23,7 @@
 #include "velox/expression/DebugGuards.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/PeeledEncoding.h"
+#include "velox/expression/ScopedVarSetter.h"
 #include "velox/vector/LazyVector.h"
 
 namespace facebook::velox::exec {
@@ -342,11 +343,101 @@ void ExprEvaluatorV2::evaluateDictionaryMemo(EvalFrame& f) {
   f.ctx.releaseVector(base);
 }
 
+namespace {
+
+// Mirrors Expr::removeSureNulls (Expr.cpp:1157).  Computes the
+// non-null subset of 'rows' across all distinct input fields.  Returns
+// true if any sure-null row was removed; in that case 'nullHolder'
+// owns the non-null SelectivityVector.
+bool removeSureNulls(
+    const ExprV2& expr,
+    EvalCtx& context,
+    const SelectivityVector& rows,
+    LocalSelectivityVector& nullHolder) {
+  SelectivityVector* result = nullptr;
+  for (auto* field : expr.distinctFields()) {
+    VectorPtr values;
+    field->evalSpecialForm(rows, context, values);
+
+    if (isLazyNotLoaded(*values)) {
+      continue;
+    }
+
+    if (values->mayHaveNulls()) {
+      LocalDecodedVector decoded(context, *values, rows);
+      if (auto* rawNulls = decoded->nulls(&rows)) {
+        if (!result) {
+          result = nullHolder.get(rows);
+        }
+        auto* bits = result->asMutableRange().bits();
+        bits::andBits(bits, rawNulls, rows.begin(), rows.end());
+      }
+    }
+  }
+  if (result == nullptr) {
+    return false;
+  }
+  result->updateBounds();
+  return result->countSelected() < rows.countSelected();
+}
+
+} // namespace
+
 void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
   DebugRemainingRowsGuard guard{f};
-  // TODO(step 7): port NullPruning::tryPrune from Expr::evalWithNulls.
-  // For now this layer is a pass-through.
-  evaluateWithSharedSubexpr(f);
+
+  // Mirrors Expr::evalWithNulls (Expr.cpp:1201).  Only attempts null
+  // pruning when the expression propagates nulls and field-dependent
+  // optimizations are not skipped.
+  if (!f.propagatesNulls || f.skipFieldDependentOptimizations) {
+    evaluateWithSharedSubexpr(f);
+    return;
+  }
+
+  // Quick reject: if no distinct field may have nulls, skip the
+  // expensive removeSureNulls work.
+  bool mayHaveNulls = false;
+  for (auto* field : f.expr.distinctFields()) {
+    const auto& vector = f.ctx.getField(field->index(f.ctx));
+    if (isLazyNotLoaded(*vector)) {
+      continue;
+    }
+    if (vector->mayHaveNulls()) {
+      mayHaveNulls = true;
+      break;
+    }
+  }
+  if (!mayHaveNulls) {
+    evaluateWithSharedSubexpr(f);
+    return;
+  }
+
+  LocalSelectivityVector nonNullHolder(f.ctx);
+  if (!removeSureNulls(
+          f.expr, f.ctx, f.remainingRows.rows(), nonNullHolder)) {
+    evaluateWithSharedSubexpr(f);
+    return;
+  }
+
+  // Default-null pruning fired.  Recurse on the non-null subset under
+  // a scoped nullsPruned flag, then null-fill the rows we removed.
+  ScopedVarSetter noMoreNulls(f.ctx.mutableNullsPruned(), true);
+  auto* nonNullRows = nonNullHolder.get();
+
+  if (nonNullRows->hasSelections()) {
+    EvalFrame innerFrame{
+        f.expr, f.runtimeStates, f.ctx, *nonNullRows, f.result};
+    evaluateWithSharedSubexpr(innerFrame);
+  }
+
+  // addNulls writes nulls into 'result' for rows in originalRows but
+  // not in nonNullRows.
+  EvalCtx::addNulls(
+      f.remainingRows.rows(),
+      nonNullRows->asRange().bits(),
+      f.ctx,
+      f.expr.type(),
+      f.result);
 }
 
 void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& f) {

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -17,55 +17,152 @@
 
 #include "velox/expression/ExprEvaluatorV2.h"
 
+#include <folly/ScopeGuard.h>
+
 #include "velox/common/base/Exceptions.h"
+#include "velox/expression/DebugGuards.h"
 
 namespace facebook::velox::exec {
 
-// Pipeline implementation lands incrementally across steps 4-10.  For
-// now every entry point is a no-op stub that fails loudly if reached.
+namespace {
 
-void ExprEvaluatorV2::evaluate(
-    EvalFrame& /*frame*/,
-    const ExprSetV2* /*parentSet*/) {
-  VELOX_NYI("ExprEvaluatorV2::evaluate lands in step 4 of the refactor.");
+void emitNullConstant(
+    const TypePtr& type,
+    memory::MemoryPool* pool,
+    VectorPtr& result) {
+  if (result == nullptr) {
+    result = BaseVector::createNullConstant(type, 0, pool);
+  }
+}
+
+} // namespace
+
+void ExprEvaluatorV2::evaluate(EvalFrame& frame, const ExprSetV2* parentSet) {
+  evaluateFrame(frame, parentSet);
 }
 
 void ExprEvaluatorV2::evaluateFrame(
-    EvalFrame& /*f*/,
+    EvalFrame& f,
     const ExprSetV2* /*parentSet*/) {
-  VELOX_NYI();
+  DebugEvaluateGuard outerGuard{f};
+
+  // Fast path: delegate to V1's evalFlatNoNulls.  Gated identically to
+  // V1's eval() (see Expr.cpp:821).  Bit-identical to V1 by
+  // construction.
+  if (f.supportsFlatNoNullsFastPath && f.ctx.throwOnError() &&
+      f.ctx.inputFlatNoNulls() &&
+      f.ctx.execCtx()->queryCtx()->queryConfig().exprEvalFlatNoNulls()) {
+    f.expr.sourceExpr()->evalFlatNoNulls(
+        f.originalRows, f.ctx, f.result, /*parentExprSet=*/nullptr);
+    return;
+  }
+
+  // TODO(step 10): install ExprExceptionContext / ExceptionContextSetter
+  // here.  Skipped during step 4 because exception-context wiring
+  // requires the V2 equivalent of Expr::onException, which lands later.
+
+  if (!f.originalRows.hasSelections()) {
+    emitEmpty(f);
+    return;
+  }
+
+  // TODO(step 5+): port the lazy-loading decision tree from
+  // Expr::eval() (lines 868-887).  For step 4 the A/B harness only
+  // covers expressions with no lazy inputs, so lazy loading is a no-op.
+
+  if (f.expr.inputs().empty()) {
+    evaluateNodeBody(f);
+    return;
+  }
+
+  evaluateWithFieldPeeling(f);
 }
 
-void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& /*f*/) {
-  VELOX_NYI("Field peeling lands in step 5.");
+void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  // TODO(step 5): port FieldPeeling::tryPeel from Expr::evalEncodings.
+  // For step 4 this layer is a pass-through.
+  evaluateWithNullPruning(f);
 }
 
-void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& /*f*/) {
-  VELOX_NYI("Null pruning lands in step 7.");
+void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  // TODO(step 7): port NullPruning::tryPrune from Expr::evalWithNulls.
+  // For step 4 this layer is a pass-through.
+  evaluateWithSharedSubexpr(f);
 }
 
-void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& /*f*/) {
-  VELOX_NYI("Shared-subexpr cache lands in step 8.");
+void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  // TODO(step 8): port SharedSubexprCache::tryReuse from
+  // Expr::evaluateSharedSubexpr.  For step 4 this layer is a
+  // pass-through.
+  evaluateNodeBody(f);
 }
 
-void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& /*f*/) {
-  VELOX_NYI();
+void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& f) {
+  if (f.isSpecialForm) {
+    evaluateSpecialForm(f);
+    return;
+  }
+  evaluateFunctionCall(f);
 }
 
-void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& /*f*/) {
-  VELOX_NYI("Function-call leaf lands in step 4 / 9 / 10.");
+void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  auto releaseGuard = folly::makeGuard([&]() {
+    f.ctx.releaseVectors(f.inputValues);
+    f.inputValues.clear();
+  });
+
+  // TODO(step 9): port ArgEval::evaluate (default-null vs
+  // preserve-null strategies, error swapping).  For step 4 the
+  // harness restricts to expressions with no-null inputs, where
+  // preserve-null and default-null are equivalent.
+  f.inputValues.resize(f.expr.inputs().size());
+  for (size_t i = 0; i < f.expr.inputs().size(); ++i) {
+    auto& childExpr = *f.expr.inputs()[i];
+    EvalFrame childFrame{
+        childExpr,
+        f.runtimeStates,
+        f.ctx,
+        f.remainingRows.rows(),
+        f.inputValues[i]};
+    evaluate(childFrame, /*parentSet=*/nullptr);
+  }
+
+  // TODO(step 5): port ArgPeeling::tryApply.  For step 4 we always
+  // apply on un-peeled args.
+  applyFunction(f);
+
+  // TODO(step 9): write nulls for any rows that ArgEval pruned.  For
+  // step 4 ArgEval never prunes, so remainingRows.hasChanged() is
+  // always false.
+  VELOX_DCHECK(!f.remainingRows.hasChanged());
 }
 
-void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& /*f*/) {
-  VELOX_NYI("Special-form delegation lands in step 4.");
+void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  // Delegate to the V1 Expr's evalSpecialForm.  Migration of each
+  // special form to a native V2 implementation happens in step 12.
+  f.expr.sourceExpr()->evalSpecialForm(
+      f.remainingRows.rows(), f.ctx, f.result);
 }
 
-void ExprEvaluatorV2::applyFunction(EvalFrame& /*f*/) {
-  VELOX_NYI();
+void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
+  // TODO(step 10): port listener invocation, CPU timing, adaptive
+  // sampling, tracer hooks.  Step 4 invokes the bare function.
+  VELOX_CHECK_NOT_NULL(f.expr.vectorFunction());
+  f.expr.vectorFunction()->apply(
+      f.remainingRows.rows(),
+      f.inputValues,
+      f.expr.type(),
+      f.ctx,
+      f.result);
 }
 
-void ExprEvaluatorV2::emitEmpty(EvalFrame& /*f*/) {
-  VELOX_NYI();
+void ExprEvaluatorV2::emitEmpty(EvalFrame& f) {
+  emitNullConstant(f.expr.type(), f.ctx.pool(), f.result);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -940,8 +940,12 @@ void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
     }
   }
 
-  // Tracer hook.  Mirrors Expr::traceOutput (Expr.cpp:2131).
-  auto& tracer = f.nodeRuntime.outputTracer;
+  // Tracer hook.  Mirrors Expr::traceOutput (Expr.cpp:2131).  V2
+  // delegates to the V1 Expr's tracer (installed by
+  // ExprSet::maybeSetupTracers, inherited via ExprSetV2) so we don't
+  // duplicate tracer state across V1 and V2 trees during the
+  // migration period.
+  auto* tracer = f.expr.sourceExpr()->outputTracer();
   if (FOLLY_UNLIKELY(tracer != nullptr) && f.result != nullptr) {
     try {
       tracer->write(f.result);

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -442,10 +442,106 @@ void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
 
 void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& f) {
   DebugRemainingRowsGuard guard{f};
-  // TODO(step 8): port SharedSubexprCache::tryReuse from
-  // Expr::evaluateSharedSubexpr.  For step 4 this layer is a
-  // pass-through.
-  evaluateNodeBody(f);
+
+  // Mirrors the wrapper in Expr::evalAll (Expr.cpp:1459): only invoke
+  // the shared-subexpr cache when the expression is a CSE candidate.
+  if (!f.deterministic || !f.expr.isMultiplyReferenced() ||
+      f.expr.inputs().empty() || !f.ctx.sharedSubExpressionReuseEnabled()) {
+    evaluateNodeBody(f);
+    return;
+  }
+
+  // Mirrors Expr::evaluateSharedSubexpr (Expr.cpp:899).  Cache keyed
+  // by the identity of all distinct input field vectors.
+  auto& cache = f.nodeRuntime.sharedCache.entries;
+
+  InputForSharedResults key;
+  for (auto* field : f.expr.distinctFields()) {
+    key.addInput(f.ctx.getField(field->index(f.ctx)));
+  }
+
+  auto it = cache.find(key);
+  if (it != cache.end() && it->first.isExpired()) {
+    cache.erase(it);
+    it = cache.end();
+  }
+
+  if (it == cache.end()) {
+    auto max = f.ctx.maxSharedSubexprResultsCached();
+    if (cache.size() < max) {
+      it = cache.insert({std::move(key), SharedResults{}}).first;
+    } else {
+      // Cache full: evaluate without caching.
+      evaluateNodeBody(f);
+      return;
+    }
+  }
+
+  auto& sharedRows = it->second.sharedSubexprRows;
+  auto& sharedValues = it->second.sharedSubexprValues;
+
+  // First observation under this key: compute, store, return.
+  if (sharedValues == nullptr) {
+    evaluateNodeBody(f);
+    if (!sharedRows) {
+      sharedRows = f.ctx.execCtx()->getSelectivityVector(
+          f.remainingRows.rows().end());
+    }
+    *sharedRows = f.remainingRows.rows();
+    if (f.ctx.errors()) {
+      f.ctx.deselectErrors(*sharedRows);
+      if (!sharedRows->hasSelections()) {
+        // No usable rows; don't cache.
+        return;
+      }
+    }
+    sharedValues = f.result;
+    return;
+  }
+
+  // Full hit: every requested row is already cached.
+  if (f.remainingRows.rows().isSubset(*sharedRows)) {
+    f.ctx.moveOrCopyResult(sharedValues, f.remainingRows.rows(), f.result);
+    return;
+  }
+
+  // Partial hit: compute the missing rows on top of cached results.
+  LocalSelectivityVector missingHolder(f.ctx, f.remainingRows.rows());
+  auto* missing = missingHolder.get();
+  missing->deselect(*sharedRows);
+  VELOX_DCHECK(missing->hasSelections());
+
+  // Final selection must cover sharedRows ∪ missing ∪ existing
+  // finalSelection so values outside 'missing' aren't lost when the
+  // child writes into sharedValues.
+  LocalSelectivityVector newFinalSelHolder(f.ctx, *sharedRows);
+  auto* newFinalSel = newFinalSelHolder.get();
+  newFinalSel->select(*missing);
+  if (!f.ctx.isFinalSelection()) {
+    newFinalSel->select(*f.ctx.finalSelection());
+  }
+  ScopedFinalSelectionSetter finalSetter(
+      f.ctx,
+      newFinalSel,
+      /*checkCondition=*/true,
+      /*override=*/true);
+
+  EvalFrame missingFrame{
+      f.expr, f.runtimeStates, f.ctx, *missing, sharedValues};
+  evaluateNodeBody(missingFrame);
+
+  f.ctx.deselectErrors(*missing);
+  sharedRows->select(*missing);
+
+  if (f.ctx.errors()) {
+    LocalSelectivityVector rowsWithoutErrorsHolder(
+        f.ctx, f.remainingRows.rows());
+    auto* rowsWithoutErrors = rowsWithoutErrorsHolder.get();
+    f.ctx.deselectErrors(*rowsWithoutErrors);
+    f.ctx.moveOrCopyResult(sharedValues, *rowsWithoutErrors, f.result);
+  } else {
+    f.ctx.moveOrCopyResult(sharedValues, f.remainingRows.rows(), f.result);
+  }
 }
 
 void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& f) {

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -21,6 +21,9 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/DebugGuards.h"
+#include "velox/expression/FieldReference.h"
+#include "velox/expression/PeeledEncoding.h"
+#include "velox/vector/LazyVector.h"
 
 namespace facebook::velox::exec {
 
@@ -33,6 +36,102 @@ void emitNullConstant(
   if (result == nullptr) {
     result = BaseVector::createNullConstant(type, 0, pool);
   }
+}
+
+// Mirrors the file-private isFlat() in Expr.cpp (line 355).
+bool isFlat(const BaseVector& vector) {
+  auto encoding = vector.encoding();
+  if (encoding == VectorEncoding::Simple::LAZY) {
+    if (!vector.asUnchecked<LazyVector>()->isLoaded()) {
+      return true;
+    }
+    encoding = vector.loadedVector()->encoding();
+  }
+  return !(
+      encoding == VectorEncoding::Simple::DICTIONARY ||
+      encoding == VectorEncoding::Simple::CONSTANT);
+}
+
+// Result of attempting to peel the input field encodings.  Mirrors
+// Expr::PeelEncodingsResult (Expr.cpp:1025).
+struct FieldPeelResult {
+  // Inner-row selection in the peeled row space.  nullptr if peel failed.
+  SelectivityVector* newRows{nullptr};
+  // True if the peel result is cacheable by base dictionary.  Triggers
+  // the DictionaryMemo phase in step 6.
+  bool mayCache{false};
+};
+
+// Peels input field encodings for the whole subtree rooted at expr.
+// Mirrors Expr::peelEncodings (Expr.cpp:1025).  On success, mutates
+// 'context' to install the peeled encoding and peeled vectors via
+// 'saver'.
+FieldPeelResult tryPeelFields(
+    const ExprV2& expr,
+    EvalCtx& context,
+    ContextSaver& saver,
+    const SelectivityVector& rows,
+    LocalDecodedVector& localDecoded,
+    LocalSelectivityVector& newRowsHolder,
+    LocalSelectivityVector& finalRowsHolder) {
+  if (context.wrapEncoding() == VectorEncoding::Simple::CONSTANT) {
+    return {};
+  }
+
+  // Use finalSelection to generate peel to ensure those rows can be
+  // translated and to ensure consistent peeling across multiple calls
+  // for a shared sub-expression.
+  const auto& rowsToPeel =
+      context.isFinalSelection() ? rows : *context.finalSelection();
+
+  std::vector<VectorPtr> vectorsToPeel;
+  vectorsToPeel.reserve(expr.distinctFields().size());
+  for (auto* field : expr.distinctFields()) {
+    auto fieldIndex = field->index(context);
+    auto fieldVector = context.getField(fieldIndex);
+    if (fieldVector->isConstantEncoding()) {
+      fieldVector = context.ensureFieldLoaded(fieldIndex, rowsToPeel);
+    }
+    vectorsToPeel.push_back(fieldVector);
+  }
+
+  VELOX_CHECK(!vectorsToPeel.empty());
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::peel(
+      vectorsToPeel,
+      rowsToPeel,
+      localDecoded,
+      expr.propagatesNulls(),
+      peeledVectors);
+  if (!peeledEncoding) {
+    return {};
+  }
+
+  SelectivityVector* newFinalSelection = nullptr;
+  if (!context.isFinalSelection()) {
+    newFinalSelection = peeledEncoding->translateToInnerRows(
+        *context.finalSelection(), finalRowsHolder);
+  }
+  auto* newRows = peeledEncoding->translateToInnerRows(rows, newRowsHolder);
+
+  context.saveAndReset(saver, rows);
+  context.setPeeledEncoding(peeledEncoding);
+  if (newFinalSelection) {
+    *context.mutableFinalSelection() = newFinalSelection;
+  }
+  VELOX_DCHECK_EQ(peeledVectors.size(), expr.distinctFields().size());
+  for (size_t i = 0; i < peeledVectors.size(); ++i) {
+    auto fieldIndex = expr.distinctFields()[i]->index(context);
+    context.setPeeled(fieldIndex, peeledVectors[i]);
+  }
+
+  bool mayCache = false;
+  if (context.dictionaryMemoizationEnabled()) {
+    mayCache = expr.distinctFields().size() == 1 &&
+        VectorEncoding::isDictionary(context.wrapEncoding()) &&
+        !peeledVectors[0]->memoDisabled();
+  }
+  return {newRows, mayCache};
 }
 
 } // namespace
@@ -80,8 +179,62 @@ void ExprEvaluatorV2::evaluateFrame(
 
 void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
   DebugRemainingRowsGuard guard{f};
-  // TODO(step 5): port FieldPeeling::tryPeel from Expr::evalEncodings.
-  // For step 4 this layer is a pass-through.
+
+  // Mirrors Expr::evalEncodings (Expr.cpp:1101).  Gating identical to
+  // V1: must be deterministic, must not skip field-dependent
+  // optimizations, peeling must be enabled, and no input field is
+  // already flat (in which case peeling can't help).
+  if (!f.deterministic || f.skipFieldDependentOptimizations ||
+      !f.ctx.peelingEnabled(f.remainingRows.rows())) {
+    evaluateWithNullPruning(f);
+    return;
+  }
+  for (auto* field : f.expr.distinctFields()) {
+    if (isFlat(*f.ctx.getField(field->index(f.ctx)))) {
+      evaluateWithNullPruning(f);
+      return;
+    }
+  }
+
+  VectorPtr wrappedResult;
+  withContextSaver([&](ContextSaver& saver) {
+    LocalSelectivityVector newRowsHolder(f.ctx);
+    LocalSelectivityVector finalRowsHolder(f.ctx);
+    LocalDecodedVector decodedHolder(f.ctx);
+
+    auto peel = tryPeelFields(
+        f.expr,
+        f.ctx,
+        saver,
+        f.remainingRows.rows(),
+        decodedHolder,
+        newRowsHolder,
+        finalRowsHolder);
+    if (peel.newRows == nullptr) {
+      return;
+    }
+
+    VectorPtr peeledResult;
+    if (peel.newRows->hasSelections()) {
+      // Construct an inner frame on the peeled inner row space and
+      // skip past evaluateWithFieldPeeling -- we've already peeled.
+      // TODO(step 6): when peel.mayCache, route through
+      // DictionaryMemo::evaluate before reaching null pruning.
+      EvalFrame innerFrame{
+          f.expr, f.runtimeStates, f.ctx, *peel.newRows, peeledResult};
+      evaluateWithNullPruning(innerFrame);
+    }
+
+    wrappedResult = f.ctx.getPeeledEncoding()->wrap(
+        f.expr.type(), f.ctx.pool(), peeledResult, f.remainingRows.rows());
+  });
+
+  if (wrappedResult != nullptr) {
+    f.ctx.moveOrCopyResult(wrappedResult, f.remainingRows.rows(), f.result);
+    return;
+  }
+  // Peeling did not produce a result (e.g. no peel possible) -- fall
+  // through to null pruning on the original row space.
   evaluateWithNullPruning(f);
 }
 

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -216,13 +216,13 @@ void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
 
     VectorPtr peeledResult;
     if (peel.newRows->hasSelections()) {
-      // Construct an inner frame on the peeled inner row space and
-      // skip past evaluateWithFieldPeeling -- we've already peeled.
-      // TODO(step 6): when peel.mayCache, route through
-      // DictionaryMemo::evaluate before reaching null pruning.
       EvalFrame innerFrame{
           f.expr, f.runtimeStates, f.ctx, *peel.newRows, peeledResult};
-      evaluateWithNullPruning(innerFrame);
+      if (peel.mayCache) {
+        evaluateDictionaryMemo(innerFrame);
+      } else {
+        evaluateWithNullPruning(innerFrame);
+      }
     }
 
     wrappedResult = f.ctx.getPeeledEncoding()->wrap(
@@ -238,10 +238,114 @@ void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
   evaluateWithNullPruning(f);
 }
 
+void ExprEvaluatorV2::evaluateDictionaryMemo(EvalFrame& f) {
+  // Mirrors Expr::evalWithMemo (Expr.cpp:1246).  Reached only from
+  // FieldPeeling when peel.mayCache is true.
+  auto& memo = f.nodeRuntime.dictMemo;
+
+  VectorPtr base;
+  f.expr.distinctFields()[0]->evalSpecialForm(
+      f.remainingRows.rows(), f.ctx, base);
+
+  // Cache miss: the base vector identity has changed or the previous
+  // weak reference expired.  Reset cache state and recompute.
+  if (base.get() != memo.baseOfDictionaryRawPtr ||
+      memo.baseOfDictionaryWeakPtr.expired()) {
+    memo.baseOfDictionaryRepeats = 0;
+    memo.baseOfDictionaryWeakPtr.reset();
+    memo.baseOfDictionaryRawPtr = nullptr;
+    f.ctx.releaseVector(memo.baseOfDictionary);
+    f.ctx.releaseVector(memo.dictionaryCache);
+
+    evaluateWithNullPruning(f);
+    memo.baseOfDictionaryWeakPtr = base;
+    memo.baseOfDictionaryRawPtr = base.get();
+    return;
+  }
+
+  // First repeat of the same base: start caching.
+  if (memo.baseOfDictionaryRepeats == 0) {
+    evaluateWithNullPruning(f);
+    ++memo.baseOfDictionaryRepeats;
+    memo.baseOfDictionary = base;
+    memo.dictionaryCache = f.result;
+    if (!memo.cachedDictionaryIndices) {
+      memo.cachedDictionaryIndices = f.ctx.execCtx()->getSelectivityVector(
+          f.remainingRows.rows().end());
+    }
+    *memo.cachedDictionaryIndices = f.remainingRows.rows();
+    f.ctx.deselectErrors(*memo.cachedDictionaryIndices);
+    return;
+  }
+
+  ++memo.baseOfDictionaryRepeats;
+
+  // Copy cached values into the result for cached rows.
+  if (memo.cachedDictionaryIndices) {
+    LocalSelectivityVector cachedHolder(f.ctx, f.remainingRows.rows());
+    auto* cached = cachedHolder.get();
+    VELOX_DCHECK(cached != nullptr);
+    cached->intersect(*memo.cachedDictionaryIndices);
+    if (cached->hasSelections()) {
+      f.ctx.ensureWritable(
+          f.remainingRows.rows(), f.expr.type(), f.result);
+      f.result->copy(memo.dictionaryCache.get(), *cached, nullptr);
+    }
+  }
+
+  // Compute uncached rows by recursing on a child frame.
+  LocalSelectivityVector uncachedHolder(f.ctx, f.remainingRows.rows());
+  auto* uncached = uncachedHolder.get();
+  VELOX_DCHECK(uncached != nullptr);
+  if (memo.cachedDictionaryIndices) {
+    uncached->deselect(*memo.cachedDictionaryIndices);
+  }
+
+  if (uncached->hasSelections()) {
+    // Fix finalSelection at the outer rows if uncached is a strict
+    // subset, to avoid losing values not in uncached that were copied
+    // earlier into 'result' from cached rows.
+    ScopedFinalSelectionSetter finalSelectionSetter(
+        f.ctx,
+        &f.remainingRows.rows(),
+        uncached->countSelected() < f.remainingRows.rows().countSelected());
+
+    EvalFrame uncachedFrame{
+        f.expr, f.runtimeStates, f.ctx, *uncached, f.result};
+    evaluateWithNullPruning(uncachedFrame);
+    f.ctx.deselectErrors(*uncached);
+
+    if (uncached->hasSelections()) {
+      // TODO(step 14): register with V2's memo invalidation registry so
+      // ExprSet::clearMemo / clearCache also clears V2 state.  V1 calls
+      // context.exprSet()->addToMemo(this) here; equivalent V2 plumbing
+      // is deferred to the cutover step.
+      auto newCacheSize = uncached->end();
+
+      LocalSelectivityVector allUncached(f.ctx, memo.dictionaryCache->size());
+      allUncached.get()->setAll();
+      allUncached.get()->deselect(*memo.cachedDictionaryIndices);
+      f.ctx.ensureWritable(
+          *allUncached.get(), f.expr.type(), memo.dictionaryCache);
+
+      if (memo.cachedDictionaryIndices->size() < newCacheSize) {
+        memo.cachedDictionaryIndices->resize(newCacheSize, false);
+      }
+      memo.cachedDictionaryIndices->select(*uncached);
+
+      if (memo.dictionaryCache->size() < uncached->end()) {
+        memo.dictionaryCache->resize(uncached->end());
+      }
+      memo.dictionaryCache->copy(f.result.get(), *uncached, nullptr);
+    }
+  }
+  f.ctx.releaseVector(base);
+}
+
 void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
   DebugRemainingRowsGuard guard{f};
   // TODO(step 7): port NullPruning::tryPrune from Expr::evalWithNulls.
-  // For step 4 this layer is a pass-through.
+  // For now this layer is a pass-through.
   evaluateWithSharedSubexpr(f);
 }
 

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -19,6 +19,8 @@
 
 #include <folly/ScopeGuard.h>
 
+#include <cmath>
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/exec/trace/TraceWriter.h"
 #include "velox/expression/DebugGuards.h"
@@ -66,6 +68,62 @@ void mergeOrThrowArgumentErrors(
     context.addErrors(rows, argumentErrors, originalErrors);
   }
   context.swapErrors(originalErrors);
+}
+
+// Mirrors the file-private computeIsAsciiForInputs in Expr.cpp:1369.
+void computeIsAsciiForInputs(
+    const VectorFunction* vectorFunction,
+    const std::vector<VectorPtr>& inputValues,
+    const SelectivityVector& rows) {
+  std::vector<size_t> indices;
+  if (vectorFunction->ensureStringEncodingSetAtAllInputs()) {
+    for (size_t i = 0; i < inputValues.size(); ++i) {
+      indices.push_back(i);
+    }
+  }
+  for (auto& index : vectorFunction->ensureStringEncodingSetAt()) {
+    indices.push_back(index);
+  }
+  for (auto& index : indices) {
+    if (index < inputValues.size() &&
+        inputValues[index]->type()->kind() == TypeKind::VARCHAR) {
+      auto* vector = inputValues[index]->template as<SimpleVector<StringView>>();
+      VELOX_CHECK(vector, inputValues[index]->toString());
+      vector->computeAndSetIsAscii(rows);
+    }
+  }
+}
+
+// Mirrors the file-private computeIsAsciiForResult in Expr.cpp:1400.
+std::optional<bool> computeIsAsciiForResult(
+    const VectorFunction* vectorFunction,
+    const std::vector<VectorPtr>& inputValues,
+    const SelectivityVector& rows) {
+  std::vector<size_t> indices;
+  if (vectorFunction->propagateStringEncodingFromAllInputs()) {
+    for (size_t i = 0; i < inputValues.size(); ++i) {
+      indices.push_back(i);
+    }
+  } else if (vectorFunction->propagateStringEncodingFrom().has_value()) {
+    indices = vectorFunction->propagateStringEncodingFrom().value();
+  }
+  if (indices.empty()) {
+    return std::nullopt;
+  }
+  bool isAsciiSet = true;
+  for (auto& index : indices) {
+    if (index < inputValues.size() &&
+        inputValues[index]->type()->kind() == TypeKind::VARCHAR) {
+      auto* vector = inputValues[index]->template as<SimpleVector<StringView>>();
+      auto isAscii = vector->isAscii(rows);
+      if (!isAscii.has_value()) {
+        isAsciiSet = false;
+      } else if (!isAscii.value()) {
+        return false;
+      }
+    }
+  }
+  return isAsciiSet ? std::optional(true) : std::nullopt;
 }
 
 // Mirrors the file-private isFlat() in Expr.cpp (line 355).
@@ -810,15 +868,77 @@ void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {
 }
 
 void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
-  // TODO(step 10b): listener invocation, CPU timing, adaptive
-  // sampling, empty-result handling.
+  // Mirrors Expr::applyFunction (Expr.cpp:1753).
   VELOX_CHECK_NOT_NULL(f.expr.vectorFunction());
-  f.expr.vectorFunction()->apply(
-      f.remainingRows.rows(),
-      f.inputValues,
-      f.expr.type(),
-      f.ctx,
-      f.result);
+  const auto* vectorFunction = f.expr.vectorFunction().get();
+  const auto& rows = f.remainingRows.rows();
+  auto& stats = f.nodeRuntime.stats;
+
+  stats.numProcessedVectors += 1;
+  stats.numProcessedRows += rows.countSelected();
+  auto timer = cpuWallTimer(f);
+
+  computeIsAsciiForInputs(vectorFunction, f.inputValues, rows);
+  auto isAscii = f.expr.type()->isVarchar()
+      ? computeIsAsciiForResult(vectorFunction, f.inputValues, rows)
+      : std::nullopt;
+
+  // Invoke listeners pre/post around apply.  Mirrors
+  // Expr::invokeApplyWithListeners (Expr.cpp:1700).
+  const auto& listeners = f.expr.listeners();
+  bool hasPostListeners = false;
+  for (const auto& listener : listeners) {
+    if (listener.pre) {
+      (*listener.pre)(f.expr.name(), rows, f.inputValues, f.expr.type(), f.ctx);
+    }
+    hasPostListeners |= (listener.post != nullptr);
+  }
+
+  std::exception_ptr applyError;
+  if (!hasPostListeners) {
+    try {
+      vectorFunction->apply(
+          rows, f.inputValues, f.expr.type(), f.ctx, f.result);
+    } catch (const VeloxException&) {
+      throw;
+    } catch (const std::exception& e) {
+      VELOX_USER_FAIL(e.what());
+    }
+  } else {
+    try {
+      vectorFunction->apply(
+          rows, f.inputValues, f.expr.type(), f.ctx, f.result);
+    } catch (const VeloxException&) {
+      applyError = std::current_exception();
+    } catch (const std::exception& e) {
+      try {
+        VELOX_USER_FAIL(e.what());
+      } catch (...) {
+        applyError = std::current_exception();
+      }
+    }
+    for (const auto& listener : listeners) {
+      if (listener.post) {
+        try {
+          (*listener.post)(
+              f.expr.name(),
+              rows,
+              f.inputValues,
+              f.expr.type(),
+              f.ctx,
+              f.result,
+              applyError);
+        } catch (const std::exception& e) {
+          FB_LOG_EVERY_MS(ERROR, 5000)
+              << "Post-apply listener threw for function '" << f.expr.name()
+              << "': " << e.what();
+        }
+      }
+    }
+    if (applyError) {
+      std::rethrow_exception(applyError);
+    }
+  }
 
   // Tracer hook.  Mirrors Expr::traceOutput (Expr.cpp:2131).
   auto& tracer = f.nodeRuntime.outputTracer;
@@ -828,6 +948,120 @@ void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
     } catch (const std::exception& e) {
       LOG(ERROR) << "Failed to trace expression output: " << e.what();
     }
+  }
+
+  // Empty-result handling.  Mirrors Expr.cpp:1770-1789: if the function
+  // returned no result and no error, it's a bug in the function; record
+  // an error and null-fill so downstream callers don't crash.
+  if (!f.result) {
+    MutableRemainingRows remaining(rows, f.ctx);
+    if (remaining.deselectErrors()) {
+      try {
+        VELOX_USER_FAIL(
+            "Function neither returned results nor threw exception.");
+      } catch (const std::exception&) {
+        f.ctx.setErrors(remaining.rows(), std::current_exception());
+      }
+    }
+    f.result =
+        BaseVector::createNullConstant(f.expr.type(), rows.end(), f.ctx.pool());
+  }
+
+  if (isAscii.has_value()) {
+    f.result->asUnchecked<SimpleVector<StringView>>()->setIsAscii(
+        isAscii.value(), rows);
+  }
+
+  // Advance adaptive calibration if we're still measuring.  After
+  // kCalibrating completes, no further calls do anything.
+  using Phase = AdaptiveSamplingState::Phase;
+  if (f.ctx.adaptiveCpuSamplingEnabled() &&
+      (f.nodeRuntime.adaptiveState.phase == Phase::kWarmup ||
+       f.nodeRuntime.adaptiveState.phase == Phase::kCalibrating)) {
+    finalizeAdaptiveCalibration(
+        f,
+        f.ctx.adaptiveCpuSamplingMaxOverheadPct(),
+        f.ctx.timerOverheadNanos());
+  }
+}
+
+std::unique_ptr<CpuWallTimer> ExprEvaluatorV2::cpuWallTimer(EvalFrame& f) {
+  auto& adaptive = f.nodeRuntime.adaptiveState;
+
+  // Compile-time tracking always wins.
+  if (f.expr.trackCpuUsage()) {
+    return std::make_unique<CpuWallTimer>(f.nodeRuntime.stats.timing);
+  }
+
+  if (f.ctx.adaptiveCpuSamplingEnabled()) {
+    using Phase = AdaptiveSamplingState::Phase;
+    switch (adaptive.phase) {
+      case Phase::kWarmup:
+        return nullptr;
+      case Phase::kCalibrating:
+        adaptive.calibrationStopWatch.emplace();
+        return nullptr;
+      case Phase::kAlwaysTrack:
+        return std::make_unique<CpuWallTimer>(f.nodeRuntime.stats.timing);
+      case Phase::kSampling:
+        if (++adaptive.samplingCounter % adaptive.samplingRate == 0) {
+          return std::make_unique<CpuWallTimer>(f.nodeRuntime.stats.timing);
+        }
+        return nullptr;
+    }
+  }
+  return nullptr;
+}
+
+void ExprEvaluatorV2::finalizeAdaptiveCalibration(
+    EvalFrame& f,
+    double maxOverheadPct,
+    uint64_t timerOverheadNanos) {
+  auto& adaptive = f.nodeRuntime.adaptiveState;
+  using Phase = AdaptiveSamplingState::Phase;
+
+  switch (adaptive.phase) {
+    case Phase::kWarmup:
+      adaptive.phase = Phase::kCalibrating;
+      break;
+    case Phase::kCalibrating: {
+      adaptive.calibrationFunctionWallNanos +=
+          adaptive.calibrationStopWatch->elapsed().wallNanos;
+      adaptive.calibrationStopWatch.reset();
+
+      if (++adaptive.calibrationBatchCount <
+          AdaptiveSamplingState::kCalibrationBatches) {
+        break;
+      }
+
+      auto totalTimerOverhead =
+          timerOverheadNanos * adaptive.calibrationBatchCount;
+
+      if (adaptive.calibrationFunctionWallNanos > 0 && maxOverheadPct > 0) {
+        double overheadPct = 100.0 *
+            static_cast<double>(totalTimerOverhead) /
+            static_cast<double>(adaptive.calibrationFunctionWallNanos);
+
+        if (overheadPct > maxOverheadPct) {
+          adaptive.samplingRate =
+              static_cast<uint32_t>(std::ceil(overheadPct / maxOverheadPct));
+          // Start counter at rate-1 so first post-calibration batch is timed.
+          adaptive.samplingCounter = adaptive.samplingRate - 1;
+          adaptive.phase = Phase::kSampling;
+        } else {
+          adaptive.phase = Phase::kAlwaysTrack;
+        }
+      } else {
+        // Function ~0ns -- timer dominates.  Aggressive sampling.
+        adaptive.samplingRate = 100;
+        adaptive.samplingCounter = adaptive.samplingRate - 1;
+        adaptive.phase = Phase::kSampling;
+      }
+      break;
+    }
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected adaptive sampling phase in finalizeAdaptiveCalibration");
   }
 }
 

--- a/velox/expression/ExprEvaluatorV2.h
+++ b/velox/expression/ExprEvaluatorV2.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/EvalFrame.h"
+
+namespace facebook::velox::exec {
+
+class ExprSetV2;
+
+/// Drives the staged evaluation pipeline against an EvalFrame.  Owns no
+/// state; all per-call state lives on the frame, all cross-call state
+/// lives in ExprRuntimeState.  Safe to share across threads.
+///
+/// Pipeline order matches V1 semantics exactly:
+///
+///   evaluateFrame                  entry guards
+///     evaluateWithFieldPeeling     field peeling wrapper
+///       evaluateWithNullPruning    null pruning wrapper
+///         evaluateWithSharedSubexpr shared subexpr wrapper
+///           evaluateNodeBody       special-form vs function-call fork
+///             evaluateSpecialForm  (delegates to legacy Expr)
+///             evaluateFunctionCall arg eval + arg peeling + apply
+class ExprEvaluatorV2 {
+ public:
+  /// Public entry point.  Drives the pipeline against 'frame'.
+  /// 'parentSet' is forwarded to the top-level exception scope; null
+  /// for nested/non-top-level calls.
+  void evaluate(EvalFrame& frame, const ExprSetV2* parentSet);
+
+ private:
+  // Pipeline phases.  Each name describes what wrapper or fork this
+  // layer owns, not what the previous layer did.
+  void evaluateFrame(EvalFrame& f, const ExprSetV2* parentSet);
+  void evaluateWithFieldPeeling(EvalFrame& f);
+  void evaluateWithNullPruning(EvalFrame& f);
+  void evaluateWithSharedSubexpr(EvalFrame& f);
+  void evaluateNodeBody(EvalFrame& f);
+  void evaluateFunctionCall(EvalFrame& f);
+  void evaluateSpecialForm(EvalFrame& f);
+
+  // Leaf operations.
+  void applyFunction(EvalFrame& f);
+  void emitEmpty(EvalFrame& f);
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprEvaluatorV2.h
+++ b/velox/expression/ExprEvaluatorV2.h
@@ -48,6 +48,7 @@ class ExprEvaluatorV2 {
   // layer owns, not what the previous layer did.
   void evaluateFrame(EvalFrame& f, const ExprSetV2* parentSet);
   void evaluateWithFieldPeeling(EvalFrame& f);
+  void evaluateDictionaryMemo(EvalFrame& f);
   void evaluateWithNullPruning(EvalFrame& f);
   void evaluateWithSharedSubexpr(EvalFrame& f);
   void evaluateNodeBody(EvalFrame& f);

--- a/velox/expression/ExprEvaluatorV2.h
+++ b/velox/expression/ExprEvaluatorV2.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/expression/EvalFrame.h"
 
 namespace facebook::velox::exec {
@@ -66,6 +67,19 @@ class ExprEvaluatorV2 {
   bool tryApplyWithPeeling(EvalFrame& f);
   void emitEmpty(EvalFrame& f);
   void setAllNulls(EvalFrame& f, const SelectivityVector& rows);
+
+  // Returns a timer that updates f.nodeRuntime.stats.timing on
+  // destruction, or nullptr if this batch should not be timed.
+  // Mirrors Expr::cpuWallTimer (Expr.cpp:1619).
+  std::unique_ptr<CpuWallTimer> cpuWallTimer(EvalFrame& f);
+
+  // Advances the adaptive sampling state machine after the function
+  // has been invoked.  Mirrors Expr::finalizeAdaptiveCalibration
+  // (Expr.cpp:1650).
+  void finalizeAdaptiveCalibration(
+      EvalFrame& f,
+      double maxOverheadPct,
+      uint64_t timerOverheadNanos);
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprEvaluatorV2.h
+++ b/velox/expression/ExprEvaluatorV2.h
@@ -55,9 +55,17 @@ class ExprEvaluatorV2 {
   void evaluateFunctionCall(EvalFrame& f);
   void evaluateSpecialForm(EvalFrame& f);
 
+  // Argument-evaluation strategies (Expr.cpp:380, 455).  Each populates
+  // f.inputValues, may shrink f.remainingRows, and returns true if at
+  // least one row survived (false means setAllNulls already applied).
+  bool evalArgsDefaultNull(EvalFrame& f);
+  bool evalArgsPreserveNull(EvalFrame& f);
+
   // Leaf operations.
   void applyFunction(EvalFrame& f);
+  bool tryApplyWithPeeling(EvalFrame& f);
   void emitEmpty(EvalFrame& f);
+  void setAllNulls(EvalFrame& f, const SelectivityVector& rows);
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprRuntimeState.cpp
+++ b/velox/expression/ExprRuntimeState.cpp
@@ -40,8 +40,13 @@ void collect(
 
 } // namespace
 
-ExprRuntimeStateTree::ExprRuntimeStateTree(const ExprV2& root) {
-  collect(root, indexByNode_);
+ExprRuntimeStateTree::ExprRuntimeStateTree(
+    const std::vector<std::shared_ptr<ExprV2>>& roots) {
+  for (const auto& root : roots) {
+    if (root != nullptr) {
+      collect(*root, indexByNode_);
+    }
+  }
   states_.resize(indexByNode_.size());
 }
 

--- a/velox/expression/ExprRuntimeState.cpp
+++ b/velox/expression/ExprRuntimeState.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprRuntimeState.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/ExprV2.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+
+void collect(
+    const ExprV2& node,
+    folly::F14FastMap<const ExprV2*, size_t>& indexByNode) {
+  if (indexByNode.contains(&node)) {
+    return;
+  }
+  indexByNode.emplace(&node, indexByNode.size());
+  for (const auto& child : node.inputs()) {
+    if (child != nullptr) {
+      collect(*child, indexByNode);
+    }
+  }
+}
+
+} // namespace
+
+ExprRuntimeStateTree::ExprRuntimeStateTree(const ExprV2& root) {
+  collect(root, indexByNode_);
+  states_.resize(indexByNode_.size());
+}
+
+ExprRuntimeState& ExprRuntimeStateTree::at(const ExprV2& node) {
+  auto it = indexByNode_.find(&node);
+  VELOX_CHECK(
+      it != indexByNode_.end(),
+      "ExprV2 node not in this ExprRuntimeStateTree");
+  return states_[it->second];
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -48,18 +48,28 @@ struct ExprRuntimeState {
   AdaptiveSamplingState adaptiveState;
 };
 
-/// Tree of runtime state parallel-indexed with an ExprV2 tree.  Look up
-/// runtime state for a node by pointer.  Implementation uses a flat
-/// vector for cache friendliness; lookups go through indexByNode_.
+/// Tree of runtime state parallel-indexed with an ExprV2 forest.  Look
+/// up runtime state for a node by pointer.  Backed by a flat vector
+/// for cache friendliness; lookups go through indexByNode_.
+///
+/// Built from the roots of an ExprSetV2.  Nodes shared between roots
+/// (e.g. CSE subtrees) appear once in the tree and share state.
 class ExprRuntimeStateTree {
  public:
-  /// Builds a runtime-state tree mirroring the shape of the ExprV2 tree
-  /// rooted at 'root'.  Each node in the tree gets one ExprRuntimeState.
-  explicit ExprRuntimeStateTree(const ExprV2& root);
+  /// Builds a runtime-state tree covering 'roots' and all their
+  /// reachable descendants.  Each unique ExprV2 node gets exactly one
+  /// ExprRuntimeState.
+  explicit ExprRuntimeStateTree(
+      const std::vector<std::shared_ptr<ExprV2>>& roots);
 
-  /// Returns the runtime state for 'node'.  'node' must be a member of
-  /// the tree this object was built from.
+  /// Returns the runtime state for 'node'.  'node' must be reachable
+  /// from one of the roots this tree was built from.
   ExprRuntimeState& at(const ExprV2& node);
+
+  /// Number of nodes covered by this tree.
+  size_t size() const {
+    return states_.size();
+  }
 
  private:
   std::vector<ExprRuntimeState> states_;

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -28,10 +28,6 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/SelectivityVector.h"
 
-namespace facebook::velox::exec::trace {
-class TraceExprWriter;
-} // namespace facebook::velox::exec::trace
-
 namespace facebook::velox::exec {
 
 class ExprV2;
@@ -159,11 +155,10 @@ struct ExprRuntimeState {
   DictionaryMemoState dictMemo;
   ExprStats stats;
   AdaptiveSamplingState adaptiveState;
-
-  // Per-Expr output tracer.  Set up by ExprSetV2::maybeSetupTracers
-  // when the containing operator has tracing enabled and this
-  // expression's name is in the trace set.  Null when tracing is off.
-  std::unique_ptr<trace::TraceExprWriter> outputTracer;
+  // Tracer is read directly from the source Expr via
+  // ExprV2::sourceExpr()->outputTracer().  V2 doesn't own its own
+  // tracer; ExprSet::maybeSetupTracers (inherited by ExprSetV2)
+  // installs tracers on the V1 Expr nodes that V2 wraps.
 };
 
 /// Tree of runtime state parallel-indexed with an ExprV2 forest.  Look

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+
+#include "velox/expression/ExprStats.h"
+
+namespace facebook::velox::exec {
+
+class ExprV2;
+
+/// Placeholder for shared-subexpression cache state.  Populated in step 8.
+struct SharedSubexprCacheState {};
+
+/// Placeholder for dictionary memoization state.  Populated in step 6.
+struct DictionaryMemoState {};
+
+/// Placeholder for adaptive CPU sampling state.  Populated in step 10.
+struct AdaptiveSamplingState {};
+
+/// Mutable per-Expr state that survives across evaluations.  One instance
+/// per ExprV2 per ExprSetV2.  Not thread-safe: concurrent evaluations of
+/// the same ExprSetV2 either need separate ExprRuntimeStateTrees or must
+/// guard a shared one with a mutex.  Decision deferred until M3.
+struct ExprRuntimeState {
+  SharedSubexprCacheState sharedCache;
+  DictionaryMemoState dictMemo;
+  ExprStats stats;
+  AdaptiveSamplingState adaptiveState;
+};
+
+/// Tree of runtime state parallel-indexed with an ExprV2 tree.  Look up
+/// runtime state for a node by pointer.  Implementation uses a flat
+/// vector for cache friendliness; lookups go through indexByNode_.
+class ExprRuntimeStateTree {
+ public:
+  /// Builds a runtime-state tree mirroring the shape of the ExprV2 tree
+  /// rooted at 'root'.  Each node in the tree gets one ExprRuntimeState.
+  explicit ExprRuntimeStateTree(const ExprV2& root);
+
+  /// Returns the runtime state for 'node'.  'node' must be a member of
+  /// the tree this object was built from.
+  ExprRuntimeState& at(const ExprV2& node);
+
+ private:
+  std::vector<ExprRuntimeState> states_;
+  folly::F14FastMap<const ExprV2*, size_t> indexByNode_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -23,6 +23,8 @@
 #include <folly/container/F14Map.h>
 
 #include "velox/expression/ExprStats.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::exec {
 
@@ -31,8 +33,33 @@ class ExprV2;
 /// Placeholder for shared-subexpression cache state.  Populated in step 8.
 struct SharedSubexprCacheState {};
 
-/// Placeholder for dictionary memoization state.  Populated in step 6.
-struct DictionaryMemoState {};
+/// Per-Expr dictionary memoization state.  Mirrors the cluster of
+/// member variables on Expr (baseOfDictionary*, dictionaryCache_,
+/// cachedDictionaryIndices_, baseOfDictionaryRepeats_).  Populated by
+/// the DictionaryMemo phase only on the peeled+mayCache path.
+struct DictionaryMemoState {
+  // Weak/raw pointers to the last cached base vector.  The weak_ptr is
+  // checked for expiration to invalidate when inputs die between
+  // batches; the raw pointer is the fast-path identity check.
+  std::weak_ptr<BaseVector> baseOfDictionaryWeakPtr;
+  BaseVector* baseOfDictionaryRawPtr{nullptr};
+
+  // Strong reference taken on the second observation of the same base
+  // (i.e. once baseOfDictionaryRepeats >= 1).  Pinning the base ensures
+  // the dictionary indices remain valid.
+  VectorPtr baseOfDictionary;
+
+  // Number of consecutive batches that have used the same base.  0 on
+  // first observation; caching begins on the transition 0 -> 1.
+  int baseOfDictionaryRepeats{0};
+
+  // Cached output values, indexed in the base dictionary's row space.
+  VectorPtr dictionaryCache;
+
+  // Set of rows in 'dictionaryCache' that are valid (have been computed
+  // successfully).
+  std::unique_ptr<SelectivityVector> cachedDictionaryIndices;
+};
 
 /// Placeholder for adaptive CPU sampling state.  Populated in step 10.
 struct AdaptiveSamplingState {};

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -30,8 +31,52 @@ namespace facebook::velox::exec {
 
 class ExprV2;
 
-/// Placeholder for shared-subexpression cache state.  Populated in step 8.
-struct SharedSubexprCacheState {};
+/// Identity of the input vectors a shared sub-expression was computed
+/// over.  Used as a key in the per-Expr SharedSubexprCacheState.
+/// Mirrors Expr::InputForSharedResults (Expr.h:738).
+class InputForSharedResults {
+ public:
+  void addInput(const std::shared_ptr<BaseVector>& input) {
+    inputVectors_.push_back(input.get());
+    inputWeakVectors_.push_back(input);
+  }
+
+  bool operator<(const InputForSharedResults& other) const {
+    return inputVectors_ < other.inputVectors_;
+  }
+
+  // True if any captured input has been freed since the entry was
+  // inserted.  Stale entries are evicted on lookup.
+  bool isExpired() const {
+    for (const auto& input : inputWeakVectors_) {
+      if (input.expired()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  // Raw pointers used for ordering only; lifetime checked via the
+  // parallel weak_ptr vector.
+  std::vector<const BaseVector*> inputVectors_;
+  std::vector<std::weak_ptr<BaseVector>> inputWeakVectors_;
+};
+
+/// Cached output for a previously-seen set of input identities.
+/// Mirrors Expr::SharedResults (Expr.h:765).
+struct SharedResults {
+  // Rows for which 'sharedSubexprValues' has a valid value.
+  std::unique_ptr<SelectivityVector> sharedSubexprRows;
+  // The cached output, indexed alongside sharedSubexprRows.
+  VectorPtr sharedSubexprValues;
+};
+
+/// Shared sub-expression result cache, indexed by the identity of the
+/// captured input vectors.  Populated by the SharedSubexprCache phase.
+struct SharedSubexprCacheState {
+  std::map<InputForSharedResults, SharedResults> entries;
+};
 
 /// Per-Expr dictionary memoization state.  Mirrors the cluster of
 /// member variables on Expr (baseOfDictionary*, dictionaryCache_,

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -23,6 +23,7 @@
 
 #include <folly/container/F14Map.h>
 
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/expression/ExprStats.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/SelectivityVector.h"
@@ -110,8 +111,44 @@ struct DictionaryMemoState {
   std::unique_ptr<SelectivityVector> cachedDictionaryIndices;
 };
 
-/// Placeholder for adaptive CPU sampling state.  Populated in step 10.
-struct AdaptiveSamplingState {};
+/// Per-Expr adaptive CPU sampling state machine.  Mirrors the cluster
+/// of fields on Expr (Expr.h:802-828).  Decides at runtime whether to
+/// pay CpuWallTimer overhead on each batch, based on a short
+/// calibration phase that measures function cost vs. timer overhead.
+struct AdaptiveSamplingState {
+  /// Number of calibration batches.  Higher = less noise, slower to
+  /// reach steady state.
+  static constexpr uint32_t kCalibrationBatches = 5;
+
+  enum class Phase : uint8_t {
+    /// First batch: warm caches, discard timing.
+    kWarmup,
+    /// Next kCalibrationBatches batches: measure cost without timer.
+    kCalibrating,
+    /// Calibration done: timer overhead acceptable, always track.
+    kAlwaysTrack,
+    /// Calibration done: timer overhead too high, sample 1-of-N.
+    kSampling,
+  };
+
+  Phase phase{Phase::kWarmup};
+
+  // Used only during kCalibrating to measure function cost without
+  // paying the CpuWallTimer overhead.
+  std::optional<DeltaCpuWallTimeStopWatch> calibrationStopWatch;
+
+  // Accumulated function wall time across calibration batches.
+  uint64_t calibrationFunctionWallNanos{0};
+
+  // Calibration batches seen so far.
+  uint32_t calibrationBatchCount{0};
+
+  // Final sampling rate decided after calibration (0 = always track).
+  uint32_t samplingRate{0};
+
+  // Counter for sampling cadence in kSampling phase.
+  uint32_t samplingCounter{0};
+};
 
 /// Mutable per-Expr state that survives across evaluations.  One instance
 /// per ExprV2 per ExprSetV2.  Not thread-safe: concurrent evaluations of

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -27,6 +27,10 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/SelectivityVector.h"
 
+namespace facebook::velox::exec::trace {
+class TraceExprWriter;
+} // namespace facebook::velox::exec::trace
+
 namespace facebook::velox::exec {
 
 class ExprV2;
@@ -118,6 +122,11 @@ struct ExprRuntimeState {
   DictionaryMemoState dictMemo;
   ExprStats stats;
   AdaptiveSamplingState adaptiveState;
+
+  // Per-Expr output tracer.  Set up by ExprSetV2::maybeSetupTracers
+  // when the containing operator has tracing enabled and this
+  // expression's name is in the trace set.  Null when tracing is off.
+  std::unique_ptr<trace::TraceExprWriter> outputTracer;
 };
 
 /// Tree of runtime state parallel-indexed with an ExprV2 forest.  Look

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -35,10 +35,18 @@ ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> source)
 }
 
 void ExprSetV2::eval(
-    const SelectivityVector& /*rows*/,
-    EvalCtx& /*ctx*/,
-    std::vector<VectorPtr>& /*results*/) {
-  VELOX_NYI("ExprSetV2::eval lands in step 4 of the refactor.");
+    const SelectivityVector& rows,
+    EvalCtx& ctx,
+    std::vector<VectorPtr>& results) {
+  VELOX_CHECK_EQ(
+      results.size(),
+      roots_.size(),
+      "results vector must be sized to the number of expression roots");
+
+  for (size_t i = 0; i < roots_.size(); ++i) {
+    EvalFrame frame{*roots_[i], *runtimeStates_, ctx, rows, results[i]};
+    evaluator_.evaluate(frame, this);
+  }
 }
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -17,119 +17,55 @@
 
 #include "velox/expression/ExprSetV2.h"
 
-#include <glog/logging.h>
-
 #include "velox/common/base/Exceptions.h"
-#include "velox/exec/trace/TraceCtx.h"
-#include "velox/exec/trace/TraceWriter.h"
-#include "velox/expression/Expr.h"
+#include "velox/expression/FieldReference.h"
 
 namespace facebook::velox::exec {
 
-namespace {
-
-// Walks the V2 tree once, installing per-Expr output tracers on
-// nodes whose name is in the trace set.  Mirrors Expr::maybeSetupTracer
-// (Expr.cpp:2081).  Uses a visited set to avoid redundant work on
-// shared CSE nodes, and an instance counter so multiple Expressions
-// sharing the same name get distinct tracer indices.
-void maybeSetupTracerRecursive(
-    ExprV2& expr,
-    ExprRuntimeStateTree& runtimeStates,
-    const Operator& op,
-    const trace::TraceCtx& traceCtx,
-    std::unordered_set<const ExprV2*>& visited,
-    std::unordered_map<std::string, int>& instanceCounts) {
-  if (!visited.insert(&expr).second) {
-    return;
-  }
-  if (traceCtx.shouldTraceExpr(expr.name())) {
-    const int index = instanceCounts[expr.name()]++;
-    try {
-      runtimeStates.at(expr).outputTracer =
-          traceCtx.createExprOutputTracer(op, expr.name(), index);
-      if (expr.vectorFunction()) {
-        traceCtx.maybeActivateIntraExprTracing(
-            op, expr.name(), *expr.vectorFunction());
-      }
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "Failed to set up expression tracer: " << e.what();
-    }
-  }
-  for (const auto& input : expr.inputs()) {
-    maybeSetupTracerRecursive(
-        *input, runtimeStates, op, traceCtx, visited, instanceCounts);
-  }
-}
-
-void finishTracerRecursive(
-    ExprV2& expr,
-    ExprRuntimeStateTree& runtimeStates,
-    std::unordered_set<const ExprV2*>& visited) {
-  if (!visited.insert(&expr).second) {
-    return;
-  }
-  auto& state = runtimeStates.at(expr);
-  if (state.outputTracer) {
-    try {
-      state.outputTracer->finish();
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "Failed to finish expression output tracer: " << e.what();
-    }
-  }
-  for (const auto& input : expr.inputs()) {
-    finishTracerRecursive(*input, runtimeStates, visited);
-  }
-}
-
-} // namespace
-
-ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> source)
-    : sourceSet_{std::move(source)} {
-  VELOX_CHECK_NOT_NULL(sourceSet_, "ExprSetV2 requires a non-null ExprSet");
-
-  roots_.reserve(sourceSet_->exprs().size());
-  for (const auto& root : sourceSet_->exprs()) {
+ExprSetV2::ExprSetV2(
+    const std::vector<core::TypedExprPtr>& source,
+    core::ExecCtx* execCtx,
+    bool enableConstantFolding,
+    bool lazyDereference)
+    : ExprSet(source, execCtx, enableConstantFolding, lazyDereference) {
+  // Base class constructor has populated exprs_ via ExprCompiler.
+  // Walk it once to build the V2 mirror tree.
+  roots_.reserve(exprs().size());
+  for (const auto& root : exprs()) {
     roots_.push_back(ExprV2::from(root));
   }
-
   runtimeStates_ = std::make_unique<ExprRuntimeStateTree>(roots_);
 }
 
 void ExprSetV2::eval(
+    int32_t begin,
+    int32_t end,
+    bool initialize,
     const SelectivityVector& rows,
-    EvalCtx& ctx,
-    std::vector<VectorPtr>& results) {
-  VELOX_CHECK_EQ(
-      results.size(),
-      roots_.size(),
-      "results vector must be sized to the number of expression roots");
+    EvalCtx& context,
+    std::vector<VectorPtr>& result) {
+  VELOX_CHECK_EQ(lazyDereference(), context.lazyDereference());
+  result.resize(exprs().size());
 
-  for (size_t i = 0; i < roots_.size(); ++i) {
-    EvalFrame frame{*roots_[i], *runtimeStates_, ctx, rows, results[i]};
+  // Match ExprSet::eval's setup work (Expr.cpp:2305-2334).  These are
+  // protected helpers on the base class.
+  if (initialize) {
+    clearSharedSubexprs();
+  }
+  if (adaptiveCpuSampling_) {
+    initializeAdaptiveCpuSampling(context);
+  }
+  if (!lazyDereference()) {
+    for (const auto& field : multiplyReferencedFields_) {
+      context.ensureFieldLoaded(field->index(context), rows);
+    }
+  }
+
+  // V2 root iteration.  Equivalent to V1's exprs_[i]->eval(...) loop,
+  // but drives the V2 evaluator against each V2 root.
+  for (int32_t i = begin; i < end; ++i) {
+    EvalFrame frame{*roots_[i], *runtimeStates_, context, rows, result[i]};
     evaluator_.evaluate(frame, this);
-  }
-}
-
-void ExprSetV2::maybeSetupTracers(
-    const Operator& op,
-    const trace::TraceCtx& traceCtx) {
-  tracingEnabled_ = true;
-  std::unordered_set<const ExprV2*> visited;
-  std::unordered_map<std::string, int> instanceCounts;
-  for (auto& root : roots_) {
-    maybeSetupTracerRecursive(
-        *root, *runtimeStates_, op, traceCtx, visited, instanceCounts);
-  }
-}
-
-void ExprSetV2::finishTracers() {
-  if (!tracingEnabled_) {
-    return;
-  }
-  std::unordered_set<const ExprV2*> visited;
-  for (auto& root : roots_) {
-    finishTracerRecursive(*root, *runtimeStates_, visited);
   }
 }
 

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -18,11 +18,20 @@
 #include "velox/expression/ExprSetV2.h"
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/expression/Expr.h"
 
 namespace facebook::velox::exec {
 
-ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> /*source*/) {
-  VELOX_NYI("ExprSetV2 construction lands in step 3 of the refactor.");
+ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> source)
+    : sourceSet_{std::move(source)} {
+  VELOX_CHECK_NOT_NULL(sourceSet_, "ExprSetV2 requires a non-null ExprSet");
+
+  roots_.reserve(sourceSet_->exprs().size());
+  for (const auto& root : sourceSet_->exprs()) {
+    roots_.push_back(ExprV2::from(root));
+  }
+
+  runtimeStates_ = std::make_unique<ExprRuntimeStateTree>(roots_);
 }
 
 void ExprSetV2::eval(

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprSetV2.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec {
+
+ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> /*source*/) {
+  VELOX_NYI("ExprSetV2 construction lands in step 3 of the refactor.");
+}
+
+void ExprSetV2::eval(
+    const SelectivityVector& /*rows*/,
+    EvalCtx& /*ctx*/,
+    std::vector<VectorPtr>& /*results*/) {
+  VELOX_NYI("ExprSetV2::eval lands in step 4 of the refactor.");
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -17,10 +17,72 @@
 
 #include "velox/expression/ExprSetV2.h"
 
+#include <glog/logging.h>
+
 #include "velox/common/base/Exceptions.h"
+#include "velox/exec/trace/TraceCtx.h"
+#include "velox/exec/trace/TraceWriter.h"
 #include "velox/expression/Expr.h"
 
 namespace facebook::velox::exec {
+
+namespace {
+
+// Walks the V2 tree once, installing per-Expr output tracers on
+// nodes whose name is in the trace set.  Mirrors Expr::maybeSetupTracer
+// (Expr.cpp:2081).  Uses a visited set to avoid redundant work on
+// shared CSE nodes, and an instance counter so multiple Expressions
+// sharing the same name get distinct tracer indices.
+void maybeSetupTracerRecursive(
+    ExprV2& expr,
+    ExprRuntimeStateTree& runtimeStates,
+    const Operator& op,
+    const trace::TraceCtx& traceCtx,
+    std::unordered_set<const ExprV2*>& visited,
+    std::unordered_map<std::string, int>& instanceCounts) {
+  if (!visited.insert(&expr).second) {
+    return;
+  }
+  if (traceCtx.shouldTraceExpr(expr.name())) {
+    const int index = instanceCounts[expr.name()]++;
+    try {
+      runtimeStates.at(expr).outputTracer =
+          traceCtx.createExprOutputTracer(op, expr.name(), index);
+      if (expr.vectorFunction()) {
+        traceCtx.maybeActivateIntraExprTracing(
+            op, expr.name(), *expr.vectorFunction());
+      }
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to set up expression tracer: " << e.what();
+    }
+  }
+  for (const auto& input : expr.inputs()) {
+    maybeSetupTracerRecursive(
+        *input, runtimeStates, op, traceCtx, visited, instanceCounts);
+  }
+}
+
+void finishTracerRecursive(
+    ExprV2& expr,
+    ExprRuntimeStateTree& runtimeStates,
+    std::unordered_set<const ExprV2*>& visited) {
+  if (!visited.insert(&expr).second) {
+    return;
+  }
+  auto& state = runtimeStates.at(expr);
+  if (state.outputTracer) {
+    try {
+      state.outputTracer->finish();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to finish expression output tracer: " << e.what();
+    }
+  }
+  for (const auto& input : expr.inputs()) {
+    finishTracerRecursive(*input, runtimeStates, visited);
+  }
+}
+
+} // namespace
 
 ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> source)
     : sourceSet_{std::move(source)} {
@@ -46,6 +108,28 @@ void ExprSetV2::eval(
   for (size_t i = 0; i < roots_.size(); ++i) {
     EvalFrame frame{*roots_[i], *runtimeStates_, ctx, rows, results[i]};
     evaluator_.evaluate(frame, this);
+  }
+}
+
+void ExprSetV2::maybeSetupTracers(
+    const Operator& op,
+    const trace::TraceCtx& traceCtx) {
+  tracingEnabled_ = true;
+  std::unordered_set<const ExprV2*> visited;
+  std::unordered_map<std::string, int> instanceCounts;
+  for (auto& root : roots_) {
+    maybeSetupTracerRecursive(
+        *root, *runtimeStates_, op, traceCtx, visited, instanceCounts);
+  }
+}
+
+void ExprSetV2::finishTracers() {
+  if (!tracingEnabled_) {
+    return;
+  }
+  std::unordered_set<const ExprV2*> visited;
+  for (auto& root : roots_) {
+    finishTracerRecursive(*root, *runtimeStates_, visited);
   }
 }
 

--- a/velox/expression/ExprSetV2.h
+++ b/velox/expression/ExprSetV2.h
@@ -24,9 +24,14 @@
 #include "velox/expression/ExprRuntimeState.h"
 #include "velox/expression/ExprV2.h"
 
+namespace facebook::velox::exec::trace {
+class TraceCtx;
+} // namespace facebook::velox::exec::trace
+
 namespace facebook::velox::exec {
 
 class ExprSet;
+class Operator;
 
 /// Owner of a tree of immutable ExprV2 nodes plus the parallel runtime
 /// state tree and the stateless evaluator.  Mirrors ExprSet's public
@@ -64,11 +69,25 @@ class ExprSetV2 {
     return sourceSet_;
   }
 
+  /// Mirrors ExprSet::maybeSetupTracers (Expr.cpp:2070).  Walks the V2
+  /// tree once and installs per-Expr output tracers on every node
+  /// whose name is in the operator's trace set.  Tracer state lives
+  /// on ExprRuntimeState::outputTracer.
+  void maybeSetupTracers(
+      const Operator& op,
+      const trace::TraceCtx& traceCtx);
+
+  /// Mirrors ExprSet::finishTracers (Expr.cpp:2105).  Flushes and
+  /// closes every output tracer set up by maybeSetupTracers.  Safe to
+  /// call when tracing was never enabled (no-op in that case).
+  void finishTracers();
+
  private:
   std::shared_ptr<ExprSet> sourceSet_;
   std::vector<std::shared_ptr<ExprV2>> roots_;
   std::unique_ptr<ExprRuntimeStateTree> runtimeStates_;
   ExprEvaluatorV2 evaluator_;
+  bool tracingEnabled_{false};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprSetV2.h
+++ b/velox/expression/ExprSetV2.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "velox/expression/ExprEvaluatorV2.h"
+#include "velox/expression/ExprRuntimeState.h"
+#include "velox/expression/ExprV2.h"
+
+namespace facebook::velox::exec {
+
+class ExprSet;
+
+/// Owner of a tree of immutable ExprV2 nodes plus the parallel runtime
+/// state tree and the stateless evaluator.  Mirrors ExprSet's public
+/// shape but routes evaluation through the V2 pipeline.
+///
+/// During the migration period, ExprSetV2 is constructed from an
+/// existing ExprSet (which already holds compiled Expr trees).  This
+/// avoids duplicating any compiler, parser, or registry logic.
+class ExprSetV2 {
+ public:
+  /// Adapts an existing compiled ExprSet to V2 by walking each root
+  /// Expr and producing a parallel ExprV2 tree.  The source ExprSet is
+  /// retained for lifetime of FieldReference pointers and for
+  /// delegated special-form evaluation.
+  explicit ExprSetV2(std::shared_ptr<ExprSet> source);
+
+  /// Evaluates all roots for 'rows' and writes outputs into 'results'.
+  void eval(
+      const SelectivityVector& rows,
+      EvalCtx& ctx,
+      std::vector<VectorPtr>& results);
+
+  const std::vector<std::shared_ptr<ExprV2>>& exprs() const {
+    return roots_;
+  }
+
+  ExprRuntimeStateTree& runtimeStates() {
+    return *runtimeStates_;
+  }
+
+ private:
+  std::shared_ptr<ExprSet> sourceSet_;
+  std::vector<std::shared_ptr<ExprV2>> roots_;
+  std::unique_ptr<ExprRuntimeStateTree> runtimeStates_;
+  ExprEvaluatorV2 evaluator_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprSetV2.h
+++ b/velox/expression/ExprSetV2.h
@@ -20,41 +20,60 @@
 #include <memory>
 #include <vector>
 
+#include "velox/expression/Expr.h"
 #include "velox/expression/ExprEvaluatorV2.h"
 #include "velox/expression/ExprRuntimeState.h"
 #include "velox/expression/ExprV2.h"
 
-namespace facebook::velox::exec::trace {
-class TraceCtx;
-} // namespace facebook::velox::exec::trace
-
 namespace facebook::velox::exec {
 
-class ExprSet;
-class Operator;
-
-/// Owner of a tree of immutable ExprV2 nodes plus the parallel runtime
-/// state tree and the stateless evaluator.  Mirrors ExprSet's public
-/// shape but routes evaluation through the V2 pipeline.
+/// Routes expression evaluation through the V2 evaluator.
 ///
-/// During the migration period, ExprSetV2 is constructed from an
-/// existing ExprSet (which already holds compiled Expr trees).  This
-/// avoids duplicating any compiler, parser, or registry logic.
-class ExprSetV2 {
+/// ExprSetV2 IS-A ExprSet (mirroring ExprSetSimplified's relationship
+/// to ExprSet).  Construction goes through the same compiler pipeline
+/// as the base class — ExprCompiler builds the V1 Expr tree first, and
+/// the parallel ExprV2 mirror tree is built on top in this
+/// constructor.  Callers hold ExprSet pointers; the virtual eval()
+/// dispatches to this override when the active ExprSet is a V2 one.
+///
+/// Constructed by makeExprSetFromFlag (Expr.cpp) when
+/// QueryConfig::exprEvalV2() is true.  Existing operator callers
+/// (FilterProject, ParallelProject) pick it up automatically through
+/// that factory.
+class ExprSetV2 : public ExprSet {
  public:
-  /// Adapts an existing compiled ExprSet to V2 by walking each root
-  /// Expr and producing a parallel ExprV2 tree.  The source ExprSet is
-  /// retained for lifetime of FieldReference pointers and for
-  /// delegated special-form evaluation.
-  explicit ExprSetV2(std::shared_ptr<ExprSet> source);
+  /// Constructs the base ExprSet (V1 Expr tree via ExprCompiler), then
+  /// adapts each root into the parallel ExprV2 mirror tree and builds
+  /// the per-node ExprRuntimeStateTree.
+  ExprSetV2(
+      const std::vector<core::TypedExprPtr>& source,
+      core::ExecCtx* execCtx,
+      bool enableConstantFolding = true,
+      bool lazyDereference = false);
 
-  /// Evaluates all roots for 'rows' and writes outputs into 'results'.
+  ~ExprSetV2() override = default;
+
+  // Un-hide the base-class eval overloads (notably the 3-argument
+  // convenience wrapper) that the eval override below would otherwise
+  // hide via name lookup.
+  using ExprSet::eval;
+
+  /// Drives the V2 pipeline.  Mirrors ExprSet::eval's setup work
+  /// (clearSharedSubexprs, initializeAdaptiveCpuSampling, lazy field
+  /// pre-loading) and then iterates V2 roots through ExprEvaluatorV2
+  /// instead of calling Expr::eval.
   void eval(
+      int32_t begin,
+      int32_t end,
+      bool initialize,
       const SelectivityVector& rows,
       EvalCtx& ctx,
-      std::vector<VectorPtr>& results);
+      std::vector<VectorPtr>& result) override;
 
-  const std::vector<std::shared_ptr<ExprV2>>& exprs() const {
+  /// V2 mirror tree, parallel to the base class's exprs() but holding
+  /// ExprV2 nodes.  Each ExprV2 retains a shared_ptr to its source
+  /// Expr (which lives in the base class's exprs_).
+  const std::vector<std::shared_ptr<ExprV2>>& exprsV2() const {
     return roots_;
   }
 
@@ -62,32 +81,10 @@ class ExprSetV2 {
     return *runtimeStates_;
   }
 
-  /// The V1 ExprSet this V2 set was adapted from.  During the migration
-  /// period, callers pass this to EvalCtx so it can route exception
-  /// context, memo updates, and tracer hooks through V1's bookkeeping.
-  const std::shared_ptr<ExprSet>& sourceSet() const {
-    return sourceSet_;
-  }
-
-  /// Mirrors ExprSet::maybeSetupTracers (Expr.cpp:2070).  Walks the V2
-  /// tree once and installs per-Expr output tracers on every node
-  /// whose name is in the operator's trace set.  Tracer state lives
-  /// on ExprRuntimeState::outputTracer.
-  void maybeSetupTracers(
-      const Operator& op,
-      const trace::TraceCtx& traceCtx);
-
-  /// Mirrors ExprSet::finishTracers (Expr.cpp:2105).  Flushes and
-  /// closes every output tracer set up by maybeSetupTracers.  Safe to
-  /// call when tracing was never enabled (no-op in that case).
-  void finishTracers();
-
  private:
-  std::shared_ptr<ExprSet> sourceSet_;
   std::vector<std::shared_ptr<ExprV2>> roots_;
   std::unique_ptr<ExprRuntimeStateTree> runtimeStates_;
   ExprEvaluatorV2 evaluator_;
-  bool tracingEnabled_{false};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprSetV2.h
+++ b/velox/expression/ExprSetV2.h
@@ -57,6 +57,13 @@ class ExprSetV2 {
     return *runtimeStates_;
   }
 
+  /// The V1 ExprSet this V2 set was adapted from.  During the migration
+  /// period, callers pass this to EvalCtx so it can route exception
+  /// context, memo updates, and tracer hooks through V1's bookkeeping.
+  const std::shared_ptr<ExprSet>& sourceSet() const {
+    return sourceSet_;
+  }
+
  private:
   std::shared_ptr<ExprSet> sourceSet_;
   std::vector<std::shared_ptr<ExprV2>> roots_;

--- a/velox/expression/ExprV2.cpp
+++ b/velox/expression/ExprV2.cpp
@@ -46,6 +46,7 @@ std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& expr) {
   node->hasConditionals_ = expr->hasConditionals();
   node->skipFieldDependentOptimizations_ =
       expr->skipFieldDependentOptimizations();
+  node->isMultiplyReferenced_ = expr->isMultiplyReferenced();
   node->trackCpuUsage_ = expr->trackCpuUsage();
   node->distinctFields_ = expr->distinctFields();
   node->multiplyReferencedFields_ = expr->multiplyReferencedFields();

--- a/velox/expression/ExprV2.cpp
+++ b/velox/expression/ExprV2.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprV2.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec {
+
+// Adapter implementation lands in step 3.  Until then, calling this is a
+// programmer error -- nothing should be constructing ExprV2 yet.
+std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& /*expr*/) {
+  VELOX_NYI("ExprV2::from is implemented in step 3 of the refactor.");
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprV2.cpp
+++ b/velox/expression/ExprV2.cpp
@@ -21,10 +21,35 @@
 
 namespace facebook::velox::exec {
 
-// Adapter implementation lands in step 3.  Until then, calling this is a
-// programmer error -- nothing should be constructing ExprV2 yet.
-std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& /*expr*/) {
-  VELOX_NYI("ExprV2::from is implemented in step 3 of the refactor.");
+std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& expr) {
+  VELOX_CHECK_NOT_NULL(expr, "ExprV2::from requires a non-null Expr");
+
+  std::vector<std::shared_ptr<ExprV2>> inputs;
+  inputs.reserve(expr->inputs().size());
+  for (const auto& child : expr->inputs()) {
+    inputs.push_back(ExprV2::from(child));
+  }
+
+  auto node = std::shared_ptr<ExprV2>(new ExprV2());
+  node->type_ = expr->type();
+  node->name_ = expr->name();
+  node->inputs_ = std::move(inputs);
+  node->vectorFunction_ = expr->vectorFunction();
+  node->metadata_ = expr->vectorFunctionMetadata();
+  node->listeners_ = expr->listeners();
+  if (expr->isSpecialForm()) {
+    node->specialFormKind_ = expr->specialFormKind();
+  }
+  node->deterministic_ = expr->isDeterministic();
+  node->propagatesNulls_ = expr->propagatesNulls();
+  node->supportsFlatNoNullsFastPath_ = expr->supportsFlatNoNullsFastPath();
+  node->hasConditionals_ = expr->hasConditionals();
+  node->trackCpuUsage_ = expr->trackCpuUsage();
+  node->distinctFields_ = expr->distinctFields();
+  node->multiplyReferencedFields_ = expr->multiplyReferencedFields();
+  node->sourceExpr_ = expr;
+
+  return node;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprV2.cpp
+++ b/velox/expression/ExprV2.cpp
@@ -44,6 +44,8 @@ std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& expr) {
   node->propagatesNulls_ = expr->propagatesNulls();
   node->supportsFlatNoNullsFastPath_ = expr->supportsFlatNoNullsFastPath();
   node->hasConditionals_ = expr->hasConditionals();
+  node->skipFieldDependentOptimizations_ =
+      expr->skipFieldDependentOptimizations();
   node->trackCpuUsage_ = expr->trackCpuUsage();
   node->distinctFields_ = expr->distinctFields();
   node->multiplyReferencedFields_ = expr->multiplyReferencedFields();

--- a/velox/expression/ExprV2.h
+++ b/velox/expression/ExprV2.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "velox/expression/Expr.h"
+#include "velox/expression/FunctionMetadata.h"
+#include "velox/expression/VectorFunctionListener.h"
+
+namespace facebook::velox::exec {
+
+class FieldReference;
+class VectorFunction;
+
+/// Immutable expression-tree node used by the V2 evaluator.
+///
+/// All fields are set at construction (from a compiled Expr via
+/// ExprV2::from()) and never mutated during evaluation.  Safe to share
+/// across threads.
+///
+/// Per-call evaluation state lives on EvalFrame.  Per-Expr cross-call
+/// state (memo, shared-subexpr cache, stats) lives on ExprRuntimeState,
+/// owned by ExprSetV2.
+///
+/// During the migration period, every ExprV2 holds a shared_ptr to the
+/// V1 Expr it was adapted from.  For special-form nodes, evaluation
+/// delegates to that Expr's evalSpecialForm().  For function-call nodes,
+/// the V1 Expr is kept alive only to ensure raw FieldReference* pointers
+/// in distinctFields_ remain valid.
+class ExprV2 {
+ public:
+  /// Builds a V2 tree from a compiled V1 Expr.  Recursively converts
+  /// children.
+  static std::shared_ptr<ExprV2> from(const std::shared_ptr<Expr>& expr);
+
+  const TypePtr& type() const {
+    return type_;
+  }
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  const std::vector<std::shared_ptr<ExprV2>>& inputs() const {
+    return inputs_;
+  }
+
+  /// Returns null for special-form nodes.  Function-call nodes return
+  /// the VectorFunction to invoke during applyFunction().
+  const std::shared_ptr<VectorFunction>& vectorFunction() const {
+    return vectorFunction_;
+  }
+
+  const VectorFunctionMetadata& metadata() const {
+    return metadata_;
+  }
+
+  const std::vector<VectorFunctionListeners>& listeners() const {
+    return listeners_;
+  }
+
+  bool isSpecialForm() const {
+    return specialFormKind_.has_value();
+  }
+
+  std::optional<SpecialFormKind> specialFormKind() const {
+    return specialFormKind_;
+  }
+
+  bool deterministic() const {
+    return deterministic_;
+  }
+
+  bool propagatesNulls() const {
+    return propagatesNulls_;
+  }
+
+  bool supportsFlatNoNullsFastPath() const {
+    return supportsFlatNoNullsFastPath_;
+  }
+
+  bool hasConditionals() const {
+    return hasConditionals_;
+  }
+
+  bool trackCpuUsage() const {
+    return trackCpuUsage_;
+  }
+
+  const std::vector<FieldReference*>& distinctFields() const {
+    return distinctFields_;
+  }
+
+  const std::unordered_set<FieldReference*>& multiplyReferencedFields() const {
+    return multiplyReferencedFields_;
+  }
+
+  /// The V1 Expr this node was adapted from.  Always non-null.  Kept
+  /// alive to ensure raw FieldReference* pointers remain valid and to
+  /// support delegated evaluation of special forms during the migration.
+  const std::shared_ptr<Expr>& sourceExpr() const {
+    return sourceExpr_;
+  }
+
+ private:
+  ExprV2() = default;
+
+  TypePtr type_;
+  std::string name_;
+  std::vector<std::shared_ptr<ExprV2>> inputs_;
+
+  // Null for special-form nodes.
+  std::shared_ptr<VectorFunction> vectorFunction_;
+  VectorFunctionMetadata metadata_;
+  std::vector<VectorFunctionListeners> listeners_;
+
+  std::optional<SpecialFormKind> specialFormKind_;
+
+  // Compile-time metadata copied from sourceExpr_ at construction.
+  bool deterministic_{true};
+  bool propagatesNulls_{false};
+  bool supportsFlatNoNullsFastPath_{false};
+  bool hasConditionals_{false};
+  bool trackCpuUsage_{false};
+
+  // Raw pointers into the V1 tree owned by sourceExpr_.  Valid as long
+  // as sourceExpr_ is held.
+  std::vector<FieldReference*> distinctFields_;
+  std::unordered_set<FieldReference*> multiplyReferencedFields_;
+
+  // Owning reference to the V1 Expr this V2 node was built from.  Kept
+  // alive for the lifetime of this ExprV2.
+  std::shared_ptr<Expr> sourceExpr_;
+
+  friend class ExprV2Builder;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprV2.h
+++ b/velox/expression/ExprV2.h
@@ -103,6 +103,10 @@ class ExprV2 {
     return hasConditionals_;
   }
 
+  bool skipFieldDependentOptimizations() const {
+    return skipFieldDependentOptimizations_;
+  }
+
   bool trackCpuUsage() const {
     return trackCpuUsage_;
   }
@@ -141,6 +145,7 @@ class ExprV2 {
   bool propagatesNulls_{false};
   bool supportsFlatNoNullsFastPath_{false};
   bool hasConditionals_{false};
+  bool skipFieldDependentOptimizations_{false};
   bool trackCpuUsage_{false};
 
   // Raw pointers into the V1 tree owned by sourceExpr_.  Valid as long

--- a/velox/expression/ExprV2.h
+++ b/velox/expression/ExprV2.h
@@ -107,6 +107,13 @@ class ExprV2 {
     return skipFieldDependentOptimizations_;
   }
 
+  /// True if this expression appears in more than one place in the
+  /// containing ExprSet (CSE candidate).  Set during compilation of
+  /// the source Expr; mirrored here for the SharedSubexprCache phase.
+  bool isMultiplyReferenced() const {
+    return isMultiplyReferenced_;
+  }
+
   bool trackCpuUsage() const {
     return trackCpuUsage_;
   }
@@ -146,6 +153,7 @@ class ExprV2 {
   bool supportsFlatNoNullsFastPath_{false};
   bool hasConditionals_{false};
   bool skipFieldDependentOptimizations_{false};
+  bool isMultiplyReferenced_{false};
   bool trackCpuUsage_{false};
 
   // Raw pointers into the V1 tree owned by sourceExpr_.  Valid as long

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
   ExprTest.cpp
   ExprToSubfieldFilterTest.cpp
   ExprV2AdapterTest.cpp
+  ExprV2ParityTest.cpp
   EvalCtxTest.cpp
   EvalErrorsTest.cpp
   EvalSimplifiedTest.cpp

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   ExprStatsTest.cpp
   ExprTest.cpp
   ExprToSubfieldFilterTest.cpp
+  ExprV2AdapterTest.cpp
   EvalCtxTest.cpp
   EvalErrorsTest.cpp
   EvalSimplifiedTest.cpp

--- a/velox/expression/tests/ExprV2AdapterTest.cpp
+++ b/velox/expression/tests/ExprV2AdapterTest.cpp
@@ -140,22 +140,23 @@ TEST_F(ExprV2AdapterTest, fieldReferencePointersPreserved) {
       root->multiplyReferencedFields().size());
 }
 
-// ExprSetV2 should adapt every root from the source ExprSet and build a
-// runtime-state tree covering all unique nodes.
+// ExprSetV2 should build both the inherited V1 tree (via the base
+// ExprSet constructor) and the parallel V2 tree covering every
+// reachable node.
 TEST_F(ExprV2AdapterTest, exprSetV2Construction) {
   auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
-  parse::ParseOptions options;
   std::vector<core::TypedExprPtr> typed{
       parseExpression("a + b", rowType),
       parseExpression("a * b", rowType),
   };
-  auto exprSet = std::make_shared<ExprSet>(std::move(typed), execCtx_.get());
+  ExprSetV2 v2{typed, execCtx_.get()};
 
-  ExprSetV2 v2{exprSet};
-
+  // Inherited V1 surface still works through ExprSetV2.
   ASSERT_EQ(v2.exprs().size(), 2);
-  EXPECT_EQ(v2.exprs()[0]->sourceExpr().get(), exprSet->exprs()[0].get());
-  EXPECT_EQ(v2.exprs()[1]->sourceExpr().get(), exprSet->exprs()[1].get());
+  // V2 mirror tree, parallel to v2.exprs().
+  ASSERT_EQ(v2.exprsV2().size(), 2);
+  EXPECT_EQ(v2.exprsV2()[0]->sourceExpr().get(), v2.exprs()[0].get());
+  EXPECT_EQ(v2.exprsV2()[1]->sourceExpr().get(), v2.exprs()[1].get());
 
   // Runtime-state tree should cover at least the 2 roots + their unique
   // descendants.  Each root is binary so total >= 2 (roots) + 4
@@ -164,8 +165,8 @@ TEST_F(ExprV2AdapterTest, exprSetV2Construction) {
   EXPECT_GE(v2.runtimeStates().size(), 6u);
 
   // at() returns distinct state instances per node.
-  auto& s0 = v2.runtimeStates().at(*v2.exprs()[0]);
-  auto& s1 = v2.runtimeStates().at(*v2.exprs()[1]);
+  auto& s0 = v2.runtimeStates().at(*v2.exprsV2()[0]);
+  auto& s1 = v2.runtimeStates().at(*v2.exprsV2()[1]);
   EXPECT_NE(&s0, &s1);
 }
 

--- a/velox/expression/tests/ExprV2AdapterTest.cpp
+++ b/velox/expression/tests/ExprV2AdapterTest.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprV2.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/core/Expressions.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprRuntimeState.h"
+#include "velox/expression/ExprSetV2.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class ExprV2AdapterTest : public testing::Test,
+                          public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
+  }
+
+  core::TypedExprPtr parseExpression(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr(text);
+    return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
+  }
+
+  std::shared_ptr<ExprSet> compile(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    return std::make_shared<ExprSet>(
+        std::vector<core::TypedExprPtr>{parseExpression(text, rowType)},
+        execCtx_.get());
+  }
+
+  std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
+  parse::ParseOptions options_;
+};
+
+// Adapter must produce a tree of the same shape as the source Expr,
+// with every node populated and sourceExpr pointing back to the source.
+TEST_F(ExprV2AdapterTest, functionCallShape) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  auto exprSet = compile("a + b * 2::bigint", rowType);
+  const auto& root = exprSet->exprs().front();
+
+  auto v2 = ExprV2::from(root);
+  ASSERT_NE(v2, nullptr);
+
+  // Root: plus(a, multiply(b, 2)).
+  EXPECT_EQ(v2->type()->toString(), root->type()->toString());
+  EXPECT_EQ(v2->name(), root->name());
+  EXPECT_EQ(v2->inputs().size(), root->inputs().size());
+  EXPECT_FALSE(v2->isSpecialForm());
+  EXPECT_EQ(v2->deterministic(), root->isDeterministic());
+  EXPECT_EQ(v2->propagatesNulls(), root->propagatesNulls());
+  EXPECT_EQ(
+      v2->supportsFlatNoNullsFastPath(), root->supportsFlatNoNullsFastPath());
+  EXPECT_EQ(v2->hasConditionals(), root->hasConditionals());
+  EXPECT_EQ(v2->sourceExpr().get(), root.get());
+
+  // Function pointer and metadata round-trip.
+  EXPECT_EQ(v2->vectorFunction().get(), root->vectorFunction().get());
+  EXPECT_EQ(
+      v2->metadata().defaultNullBehavior,
+      root->vectorFunctionMetadata().defaultNullBehavior);
+
+  // Recurse into children and verify the same.
+  for (size_t i = 0; i < v2->inputs().size(); ++i) {
+    const auto& childV2 = v2->inputs()[i];
+    const auto& childV1 = root->inputs()[i];
+    EXPECT_EQ(childV2->sourceExpr().get(), childV1.get());
+    EXPECT_EQ(childV2->inputs().size(), childV1->inputs().size());
+    EXPECT_EQ(childV2->name(), childV1->name());
+  }
+}
+
+// Adapter must tag special-form nodes with their SpecialFormKind.
+TEST_F(ExprV2AdapterTest, specialFormTag) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  // Switch is a special form.
+  auto exprSet = compile("case when a > 0 then b else 0::bigint end", rowType);
+  const auto& root = exprSet->exprs().front();
+
+  auto v2 = ExprV2::from(root);
+
+  EXPECT_TRUE(v2->isSpecialForm());
+  EXPECT_EQ(v2->specialFormKind(), root->specialFormKind());
+
+  // Special-form nodes still retain sourceExpr for delegation.
+  EXPECT_EQ(v2->sourceExpr().get(), root.get());
+}
+
+// distinctFields and multiplyReferencedFields raw pointers must remain
+// valid after adaptation -- they still point into the V1 tree, which
+// is kept alive via sourceExpr.
+TEST_F(ExprV2AdapterTest, fieldReferencePointersPreserved) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  auto exprSet = compile("a + a + b", rowType);
+  const auto& root = exprSet->exprs().front();
+
+  auto v2 = ExprV2::from(root);
+
+  EXPECT_EQ(v2->distinctFields().size(), root->distinctFields().size());
+  for (size_t i = 0; i < v2->distinctFields().size(); ++i) {
+    // Raw pointers should be bit-identical to the V1 set.
+    EXPECT_EQ(v2->distinctFields()[i], root->distinctFields()[i]);
+  }
+  EXPECT_EQ(
+      v2->multiplyReferencedFields().size(),
+      root->multiplyReferencedFields().size());
+}
+
+// ExprSetV2 should adapt every root from the source ExprSet and build a
+// runtime-state tree covering all unique nodes.
+TEST_F(ExprV2AdapterTest, exprSetV2Construction) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  parse::ParseOptions options;
+  std::vector<core::TypedExprPtr> typed{
+      parseExpression("a + b", rowType),
+      parseExpression("a * b", rowType),
+  };
+  auto exprSet = std::make_shared<ExprSet>(std::move(typed), execCtx_.get());
+
+  ExprSetV2 v2{exprSet};
+
+  ASSERT_EQ(v2.exprs().size(), 2);
+  EXPECT_EQ(v2.exprs()[0]->sourceExpr().get(), exprSet->exprs()[0].get());
+  EXPECT_EQ(v2.exprs()[1]->sourceExpr().get(), exprSet->exprs()[1].get());
+
+  // Runtime-state tree should cover at least the 2 roots + their unique
+  // descendants.  Each root is binary so total >= 2 (roots) + 4
+  // (FieldReferences) = 6.  Use >= to keep the test robust to minor
+  // tree-shape variation.
+  EXPECT_GE(v2.runtimeStates().size(), 6u);
+
+  // at() returns distinct state instances per node.
+  auto& s0 = v2.runtimeStates().at(*v2.exprs()[0]);
+  auto& s1 = v2.runtimeStates().at(*v2.exprs()[1]);
+  EXPECT_NE(&s0, &s1);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -140,6 +140,35 @@ TEST_F(ExprV2ParityTest, constantEncodedInput) {
   assertParity("a + 1::bigint", input);
 }
 
+// Null-containing input on a propagatesNulls expression -- exercises
+// NullPruning::removeSureNulls.
+TEST_F(ExprV2ParityTest, propagatesNullsWithNullInput) {
+  auto a = makeNullableFlatVector<int64_t>(
+      {1, std::nullopt, 3, std::nullopt, 5});
+  auto b = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  auto input = makeRowVector({"a", "b"}, {a, b});
+  assertParity("a + b", input);
+}
+
+// Both inputs may have nulls -- exercises multi-field null pruning.
+TEST_F(ExprV2ParityTest, propagatesNullsBothInputs) {
+  auto a = makeNullableFlatVector<int64_t>(
+      {1, std::nullopt, 3, std::nullopt, 5});
+  auto b = makeNullableFlatVector<int64_t>(
+      {10, 20, std::nullopt, 40, std::nullopt});
+  auto input = makeRowVector({"a", "b"}, {a, b});
+  assertParity("a + b", input);
+}
+
+// All-null input -- pruning should produce all-null result.
+TEST_F(ExprV2ParityTest, allNullInput) {
+  auto a = makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  auto b = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  auto input = makeRowVector({"a", "b"}, {a, b});
+  assertParity("a + b", input);
+}
+
 // Multi-batch dictionary input with the same base -- exercises the
 // DictionaryMemo phase, including the "first repeat" cache fill and
 // the subsequent cache-hit / cache-miss merge paths.

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -66,8 +66,9 @@ class ExprV2ParityTest : public testing::Test,
     v1Set->eval(rows, v1Ctx, v1Results);
 
     // V2 path -- adapt the same compiled ExprSet.
-    ExprSetV2 v2Set{v1Set};
-    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    ExprSetV2 v2Set{
+        std::vector<core::TypedExprPtr>{typed}, execCtx_.get()};
+    EvalCtx v2Ctx{execCtx_.get(), &v2Set, input.get()};
     std::vector<VectorPtr> v2Results(1);
     v2Set.eval(rows, v2Ctx, v2Results);
 
@@ -192,7 +193,8 @@ TEST_F(ExprV2ParityTest, dictionaryMemoAcrossBatches) {
 
   auto v1Set = std::make_shared<ExprSet>(
       std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
-  ExprSetV2 v2Set{v1Set};
+  ExprSetV2 v2Set{
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get()};
 
   for (const auto& input : inputs) {
     SelectivityVector rows{input->size()};
@@ -201,7 +203,7 @@ TEST_F(ExprV2ParityTest, dictionaryMemoAcrossBatches) {
     std::vector<VectorPtr> v1Results(1);
     v1Set->eval(rows, v1Ctx, v1Results);
 
-    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    EvalCtx v2Ctx{execCtx_.get(), &v2Set, input.get()};
     std::vector<VectorPtr> v2Results(1);
     v2Set.eval(rows, v2Ctx, v2Results);
 
@@ -244,7 +246,8 @@ TEST_F(ExprV2ParityTest, sharedSubexprAcrossBatches) {
 
   auto v1Set = std::make_shared<ExprSet>(
       std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
-  ExprSetV2 v2Set{v1Set};
+  ExprSetV2 v2Set{
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get()};
 
   for (int batch = 0; batch < 2; ++batch) {
     auto input = makeRowVector(
@@ -257,7 +260,7 @@ TEST_F(ExprV2ParityTest, sharedSubexprAcrossBatches) {
     std::vector<VectorPtr> v1Results(1);
     v1Set->eval(rows, v1Ctx, v1Results);
 
-    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    EvalCtx v2Ctx{execCtx_.get(), &v2Set, input.get()};
     std::vector<VectorPtr> v2Results(1);
     v2Set.eval(rows, v2Ctx, v2Results);
 
@@ -285,8 +288,9 @@ TEST_F(ExprV2ParityTest, emptyRows) {
   std::vector<VectorPtr> v1Results(1);
   v1Set->eval(rows, v1Ctx, v1Results);
 
-  ExprSetV2 v2Set{v1Set};
-  EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+  ExprSetV2 v2Set{
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get()};
+  EvalCtx v2Ctx{execCtx_.get(), &v2Set, input.get()};
   std::vector<VectorPtr> v2Results(1);
   v2Set.eval(rows, v2Ctx, v2Results);
 

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -123,6 +123,35 @@ TEST_F(ExprV2ParityTest, comparison) {
   assertParity("a < b", input);
 }
 
+// Dictionary-encoded input -- exercises FieldPeeling.
+TEST_F(ExprV2ParityTest, dictionaryEncodedInput) {
+  auto flatA = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  // Dictionary that reverses the input.
+  auto indices = makeIndicesInReverse(5);
+  auto dictA = BaseVector::wrapInDictionary(nullptr, indices, 5, flatA);
+  auto input = makeRowVector({"a"}, {dictA});
+  assertParity("a + 1::bigint", input);
+}
+
+// Constant-encoded input -- exercises FieldPeeling's constant path.
+TEST_F(ExprV2ParityTest, constantEncodedInput) {
+  auto constA = BaseVector::createConstant(BIGINT(), int64_t(7), 5, pool_.get());
+  auto input = makeRowVector({"a"}, {constA});
+  assertParity("a + 1::bigint", input);
+}
+
+// Two dictionary inputs over the same base -- exercises peeling of
+// multiple field references.
+TEST_F(ExprV2ParityTest, twoDictionariesSameBase) {
+  auto flatA = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto flatB = makeFlatVector<int64_t>({100, 200, 300, 400, 500});
+  auto indices = makeIndicesInReverse(5);
+  auto dictA = BaseVector::wrapInDictionary(nullptr, indices, 5, flatA);
+  auto dictB = BaseVector::wrapInDictionary(nullptr, indices, 5, flatB);
+  auto input = makeRowVector({"a", "b"}, {dictA, dictB});
+  assertParity("a + b", input);
+}
+
 // Empty selectivity vector -- emitEmpty path.
 TEST_F(ExprV2ParityTest, emptyRows) {
   auto input = makeRowVector(

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/core/Expressions.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprSetV2.h"
+#include "velox/expression/ExprV2.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+/// Compares V1 (ExprSet) and V2 (ExprSetV2) on a restricted subset of
+/// queries that V2 supports as of step 4: no-null inputs, no lazy
+/// vectors, no shared sub-expressions, no encodings, no special forms
+/// requiring conditional row evaluation.
+class ExprV2ParityTest : public testing::Test,
+                         public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
+  }
+
+  void assertParity(
+      const std::string& exprText,
+      const RowVectorPtr& input) {
+    auto rowType = std::dynamic_pointer_cast<const RowType>(input->type());
+    ASSERT_NE(rowType, nullptr);
+
+    auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr(exprText);
+    auto typed = core::Expressions::inferTypes(
+        untyped, rowType, execCtx_->pool());
+
+    // V1 path.
+    auto v1Set = std::make_shared<ExprSet>(
+        std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
+    SelectivityVector rows{input->size()};
+    EvalCtx v1Ctx{execCtx_.get(), v1Set.get(), input.get()};
+    std::vector<VectorPtr> v1Results(1);
+    v1Set->eval(rows, v1Ctx, v1Results);
+
+    // V2 path -- adapt the same compiled ExprSet.
+    ExprSetV2 v2Set{v1Set};
+    EvalCtx v2Ctx{execCtx_.get(), nullptr, input.get()};
+    std::vector<VectorPtr> v2Results(1);
+    v2Set.eval(rows, v2Ctx, v2Results);
+
+    velox::test::assertEqualVectors(v1Results[0], v2Results[0]);
+  }
+
+  std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
+  parse::ParseOptions options_;
+};
+
+// Bare field reference: a -> a.  Goes through special-form delegation
+// (FieldAccess).
+TEST_F(ExprV2ParityTest, fieldReference) {
+  auto input = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5})});
+  assertParity("a", input);
+}
+
+// Two-arg deterministic function on no-null flat inputs.
+TEST_F(ExprV2ParityTest, simplePlus) {
+  auto input = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<int64_t>({10, 20, 30, 40, 50})});
+  assertParity("a + b", input);
+}
+
+// Nested function calls on no-null flat inputs.
+TEST_F(ExprV2ParityTest, nestedArith) {
+  auto input = makeRowVector(
+      {"a", "b", "c"},
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+       makeFlatVector<int64_t>({100, 200, 300, 400, 500})});
+  assertParity("a + b * c", input);
+}
+
+// Constant inputs in the expression tree (special-form delegation).
+TEST_F(ExprV2ParityTest, constantInExpr) {
+  auto input = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5})});
+  assertParity("a + 100::bigint", input);
+}
+
+// Boolean function on no-null flat inputs.
+TEST_F(ExprV2ParityTest, comparison) {
+  auto input = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>({1, 5, 3, 2, 4}),
+       makeFlatVector<int64_t>({4, 4, 4, 4, 4})});
+  assertParity("a < b", input);
+}
+
+// Empty selectivity vector -- emitEmpty path.
+TEST_F(ExprV2ParityTest, emptyRows) {
+  auto input = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int64_t>({10, 20, 30})});
+  auto rowType = std::dynamic_pointer_cast<const RowType>(input->type());
+  auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr("a + b");
+  auto typed = core::Expressions::inferTypes(
+      untyped, rowType, execCtx_->pool());
+
+  auto v1Set = std::make_shared<ExprSet>(
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
+  SelectivityVector rows{input->size()};
+  rows.clearAll();
+
+  EvalCtx v1Ctx{execCtx_.get(), v1Set.get(), input.get()};
+  std::vector<VectorPtr> v1Results(1);
+  v1Set->eval(rows, v1Ctx, v1Results);
+
+  ExprSetV2 v2Set{v1Set};
+  EvalCtx v2Ctx{execCtx_.get(), nullptr, input.get()};
+  std::vector<VectorPtr> v2Results(1);
+  v2Set.eval(rows, v2Ctx, v2Results);
+
+  // Both should produce a 0-size constant; just check sizes match.
+  EXPECT_EQ(v1Results[0]->size(), v2Results[0]->size());
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -221,6 +221,50 @@ TEST_F(ExprV2ParityTest, twoDictionariesSameBase) {
   assertParity("a + b", input);
 }
 
+// Repeated sub-expression (a + b) -- the compiler may identify this as
+// a shared sub-expression and mark it isMultiplyReferenced, exercising
+// SharedSubexprCache.  Even if the compiler doesn't dedupe, V2 falls
+// back to evaluateNodeBody and still matches V1.
+TEST_F(ExprV2ParityTest, repeatedSubexpression) {
+  auto a = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto b = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  auto input = makeRowVector({"a", "b"}, {a, b});
+  assertParity("(a + b) * (a + b)", input);
+}
+
+// Same shared sub-expression evaluated across multiple batches.  If
+// the compiler shares the AST node, the second batch will hit the
+// cache; if not, V2 still matches V1.
+TEST_F(ExprV2ParityTest, sharedSubexprAcrossBatches) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr(
+      "(a + b) + (a + b) + (a + b)");
+  auto typed =
+      core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
+
+  auto v1Set = std::make_shared<ExprSet>(
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
+  ExprSetV2 v2Set{v1Set};
+
+  for (int batch = 0; batch < 2; ++batch) {
+    auto input = makeRowVector(
+        {"a", "b"},
+        {makeFlatVector<int64_t>({1 + batch, 2 + batch, 3 + batch}),
+         makeFlatVector<int64_t>({10 + batch, 20 + batch, 30 + batch})});
+    SelectivityVector rows{input->size()};
+
+    EvalCtx v1Ctx{execCtx_.get(), v1Set.get(), input.get()};
+    std::vector<VectorPtr> v1Results(1);
+    v1Set->eval(rows, v1Ctx, v1Results);
+
+    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    std::vector<VectorPtr> v2Results(1);
+    v2Set.eval(rows, v2Ctx, v2Results);
+
+    velox::test::assertEqualVectors(v1Results[0], v2Results[0]);
+  }
+}
+
 // Empty selectivity vector -- emitEmpty path.
 TEST_F(ExprV2ParityTest, emptyRows) {
   auto input = makeRowVector(

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -67,7 +67,7 @@ class ExprV2ParityTest : public testing::Test,
 
     // V2 path -- adapt the same compiled ExprSet.
     ExprSetV2 v2Set{v1Set};
-    EvalCtx v2Ctx{execCtx_.get(), nullptr, input.get()};
+    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
     std::vector<VectorPtr> v2Results(1);
     v2Set.eval(rows, v2Ctx, v2Results);
 
@@ -144,7 +144,7 @@ TEST_F(ExprV2ParityTest, emptyRows) {
   v1Set->eval(rows, v1Ctx, v1Results);
 
   ExprSetV2 v2Set{v1Set};
-  EvalCtx v2Ctx{execCtx_.get(), nullptr, input.get()};
+  EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
   std::vector<VectorPtr> v2Results(1);
   v2Set.eval(rows, v2Ctx, v2Results);
 

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -140,6 +140,46 @@ TEST_F(ExprV2ParityTest, constantEncodedInput) {
   assertParity("a + 1::bigint", input);
 }
 
+// Multi-batch dictionary input with the same base -- exercises the
+// DictionaryMemo phase, including the "first repeat" cache fill and
+// the subsequent cache-hit / cache-miss merge paths.
+TEST_F(ExprV2ParityTest, dictionaryMemoAcrossBatches) {
+  auto base = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  // Three batches all using the same base dictionary but different
+  // index permutations.  V2's DictionaryMemo should cache after batch 1
+  // and reuse on subsequent batches.
+  std::vector<RowVectorPtr> inputs;
+  for (int batch = 0; batch < 3; ++batch) {
+    auto indices = makeIndicesInReverse(5);
+    auto dict = BaseVector::wrapInDictionary(nullptr, indices, 5, base);
+    inputs.push_back(makeRowVector({"a"}, {dict}));
+  }
+
+  auto rowType = std::dynamic_pointer_cast<const RowType>(inputs[0]->type());
+  auto untyped =
+      parse::DuckSqlExpressionsParser(options_).parseExpr("a + 1::bigint");
+  auto typed =
+      core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
+
+  auto v1Set = std::make_shared<ExprSet>(
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
+  ExprSetV2 v2Set{v1Set};
+
+  for (const auto& input : inputs) {
+    SelectivityVector rows{input->size()};
+
+    EvalCtx v1Ctx{execCtx_.get(), v1Set.get(), input.get()};
+    std::vector<VectorPtr> v1Results(1);
+    v1Set->eval(rows, v1Ctx, v1Results);
+
+    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    std::vector<VectorPtr> v2Results(1);
+    v2Set.eval(rows, v2Ctx, v2Results);
+
+    velox::test::assertEqualVectors(v1Results[0], v2Results[0]);
+  }
+}
+
 // Two dictionary inputs over the same base -- exercises peeling of
 // multiple field references.
 TEST_F(ExprV2ParityTest, twoDictionariesSameBase) {

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -22,6 +22,7 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/ExprSetV2.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/VectorSaver.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
@@ -308,6 +309,30 @@ ExpressionVerifier::verify(
       createExprSetCommon(plans, execCtx_, options_.disableConstantFolding);
   exec::ExprSetSimplified exprSetSimplified(plans, execCtx_);
 
+  // Optional V2 ExprSet built alongside the canonical V1 pair so the
+  // fuzzer can compare V2 output against V1 common on every test case.
+  // The compiler must see exprEvalV2=true during construction so it
+  // emits V2 special-form classes (e.g., CastExprV2).  We save and
+  // restore the full QueryConfig because testingOverrideConfigUnsafe
+  // replaces (not merges) the underlying config map.
+  std::optional<exec::ExprSetV2> exprSetV2;
+  if (options_.enableV2Fuzzing) {
+    auto savedConfig =
+        execCtx_->queryCtx()->queryConfig().rawConfigsCopy();
+    auto v2Config = savedConfig;
+    v2Config[core::QueryConfig::kExprEvalV2] = "true";
+    execCtx_->queryCtx()->testingOverrideConfigUnsafe(std::move(v2Config));
+    try {
+      exprSetV2.emplace(
+          plans, execCtx_, !options_.disableConstantFolding);
+    } catch (...) {
+      execCtx_->queryCtx()->testingOverrideConfigUnsafe(
+          std::move(savedConfig));
+      throw;
+    }
+    execCtx_->queryCtx()->testingOverrideConfigUnsafe(std::move(savedConfig));
+  }
+
   int testCaseItr = 0;
   for (auto [rowVector, rows] : transformedInputTestCases) {
     LOG(INFO) << "Executing test case: " << testCaseItr++;
@@ -383,6 +408,8 @@ ExpressionVerifier::verify(
       }
       LOG(INFO) << "Common eval succeeded.";
     } catch (const VeloxException& e) {
+      // Capture common eval failure pre-V2.  V2 comparison below is
+      // gated on whether common path threw too.
       LOG(INFO) << "Common eval failed.";
       if (e.errorCode() == error_code::kUnsupportedInputUncatchable) {
         unsupportedInputUncatchableError = true;
@@ -413,6 +440,115 @@ ExpressionVerifier::verify(
           sql,
           complexConstants);
       throw;
+    }
+
+    // === V2 fuzzing — evaluate the same expression through ExprSetV2
+    // and compare against the V1 common path's results / exception
+    // pattern.  Any divergence is a V2 bug; we throw out of the test
+    // case so the fuzzer harness reports it with the full repro
+    // context.
+    std::vector<VectorPtr> v2EvalResult;
+    std::exception_ptr exceptionV2Ptr;
+    if (exprSetV2.has_value()) {
+      VLOG(1) << "Starting V2 eval execution.";
+      if (resultVector) {
+        auto resultRowVector = resultVector->asUnchecked<RowVector>();
+        v2EvalResult.resize(resultRowVector->children().size());
+        for (int i = 0; i < resultRowVector->children().size(); ++i) {
+          v2EvalResult[i] = resultRowVector->children()[i];
+        }
+      }
+      try {
+        // Re-fuzz lazy wrapping using the same metadata so V1 and V2
+        // see equivalent inputs.  V2 uses its own freshly-wrapped row
+        // vector; the V1 common path already consumed the previous
+        // wrap above.
+        auto v2InputRowVector = transformInput(
+            rowVector,
+            execCtx_,
+            options_.disableConstantFolding,
+            transformPlans,
+            originalInputFields);
+        v2InputRowVector = VectorFuzzer::fuzzRowChildrenToLazy(
+            v2InputRowVector, inputRowMetadata.columnsToWrapInLazy);
+        exec::EvalCtx evalCtxV2(
+            execCtx_, &*exprSetV2, v2InputRowVector.get());
+        exprSetV2->eval(
+            0,
+            exprSetV2->size(),
+            true /*initialize*/,
+            rows,
+            evalCtxV2,
+            v2EvalResult);
+        LOG(INFO) << "V2 eval succeeded.";
+      } catch (const VeloxException& e) {
+        if (e.errorCode() == error_code::kUnsupportedInputUncatchable) {
+          unsupportedInputUncatchableError = true;
+        } else if (!(canThrow && e.isUserError())) {
+          if (!canThrow) {
+            LOG(ERROR)
+                << "V2 eval wasn't supposed to throw, but it did. Aborting.";
+          } else if (!e.isUserError()) {
+            LOG(ERROR)
+                << "V2 eval: VeloxRuntimeErrors other than UNSUPPORTED_INPUT_UNCATCHABLE are not allowed.";
+          }
+          persistReproInfoIfNeeded(
+              inputTestCases,
+              inputRowMetadata,
+              copiedResult,
+              sql,
+              complexConstants);
+          throw;
+        }
+        exceptionV2Ptr = std::current_exception();
+      } catch (...) {
+        LOG(ERROR) << "V2 eval threw a non-Velox exception.";
+        persistReproInfoIfNeeded(
+            inputTestCases,
+            inputRowMetadata,
+            copiedResult,
+            sql,
+            complexConstants);
+        throw;
+      }
+
+      // Compare V1 common vs V2.  Any mismatch is a V2 parity bug.
+      try {
+        if (exceptionCommonPtr || exceptionV2Ptr) {
+          if (!unsupportedInputUncatchableError) {
+            if (exceptionCommonPtr && exceptionV2Ptr) {
+              fuzzer::compareExceptions(exceptionCommonPtr, exceptionV2Ptr);
+            } else {
+              LOG(ERROR) << fmt::format(
+                  "V1 common vs V2 divergence: only {} threw an exception.",
+                  exceptionCommonPtr ? "V1 common" : "V2");
+              if (exceptionCommonPtr) {
+                std::rethrow_exception(exceptionCommonPtr);
+              } else {
+                std::rethrow_exception(exceptionV2Ptr);
+              }
+            }
+          }
+        } else {
+          VELOX_CHECK_EQ(commonEvalResult.size(), v2EvalResult.size());
+          for (int i = 0; i < commonEvalResult.size(); ++i) {
+            fuzzer::compareVectors(
+                commonEvalResult[i],
+                v2EvalResult[i],
+                "V1 common path results",
+                "V2 path results",
+                rows);
+          }
+        }
+      } catch (...) {
+        persistReproInfoIfNeeded(
+            inputTestCases,
+            inputRowMetadata,
+            copiedResult,
+            sql,
+            complexConstants);
+        throw;
+      }
     }
 
     VLOG(1) << "Starting reference eval execution.";

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -36,6 +36,12 @@ struct ExpressionVerifierOptions {
   bool disableConstantFolding{false};
   std::string reproPersistPath;
   bool persistAndRunOnce{false};
+  // When true, the verifier additionally evaluates each expression
+  // through the V2 evaluator (ExprSetV2) and asserts bit-identical
+  // output (and matching exception patterns) against the V1 common
+  // path.  Defaults to true while V2 is in experimental mode to
+  // maximize divergence coverage from fuzzer runs.
+  bool enableV2Fuzzing{true};
 };
 
 class ExpressionVerifier {


### PR DESCRIPTION
Parallel expression evaluator (V2) that separates concerns Expr.cpp currently mixes — immutable tree, per-node runtime state, per-call frame, evaluator algorithm, ExprSet lifecycle. V1 left untouched; V2 gated by expression.eval_v2 (default false). This PR is behavior-preserving and is bit-for-bit parity with V1 expected.
  
Design: velox/docs/designs/expr-evaluation-refactor.md