### PR TITLE
[ExprV2 2/7] Add V2 evaluator skeleton, adapter, A/B harness

### DIFF
--- a/velox/docs/designs/expr-evaluation-refactor.md
+++ b/velox/docs/designs/expr-evaluation-refactor.md
@@ -1,0 +1,1068 @@
+# Expression Evaluation Refactor (ExprV2)
+
+*2026-06-09*
+
+## Summary
+
+`Expr.cpp` (~2500 lines) and `Expr.h` (~1100 lines) mix at least nine
+concerns: tree-shape data, immutable metadata, per-call evaluation state,
+per-Expr cross-call caches, stats, adaptive sampling, evaluator algorithm,
+tracer wiring, and `ExprSet` lifecycle.  The implicit pipeline
+(`eval -> evalEncodings -> evalWithMemo -> evalWithNulls -> evalAll ->
+evalAllImpl -> ...`) is hard to read because each method is named by what
+its predecessor did *not* do.
+
+This document proposes an additive refactor that introduces four new types
+in new files and leaves the existing `Expr` class essentially intact:
+
+| New type             | Role                                                    |
+|----------------------|---------------------------------------------------------|
+| `ExprV2`             | Immutable expression-tree node.                         |
+| `ExprRuntimeState`   | Per-node mutable state (memo, shared cache, stats).     |
+| `EvalFrame`          | Per-call state, lives on the stack of `evaluate()`.     |
+| `ExprEvaluatorV2`    | Stateless orchestrator that drives the staged pipeline. |
+| `ExprSetV2`          | Owner of `ExprV2` roots, runtime states, and evaluator. |
+
+The refactor is **behavior-preserving**.  V2 ships behind a query-config
+flag, runs alongside V1, and becomes the default only after vector-for-vector
+parity is verified across the full expression test suite.  Once parity is
+established, the V1 code path can be deleted in a separate change.
+
+## Motivation
+
+### Concrete pain points in `Expr.cpp`
+
+| Site                            | Concern                                                 |
+|---------------------------------|---------------------------------------------------------|
+| `Expr::eval` (816)              | Fast path, exception scope, empty rows, lazy load mixed together. |
+| `Expr::evalEncodings` (1101)    | Field peeling.                                          |
+| `Expr::evalWithMemo` (1246)     | Dictionary memoization, only reachable on peeled path.  |
+| `Expr::evalWithNulls` (1201)    | Null pruning.                                           |
+| `Expr::evalAll` (1450)          | Shared subexpression wrapper.                           |
+| `Expr::evalAllImpl` (1479)      | Special-form vs function-call fork; arg eval; finalize. |
+| `Expr::applyFunctionWithPeeling`(1534) | Argument peeling.                                |
+| `Expr::applyFunction` (1753)    | Listener / timing wrapper.                              |
+| `Expr::evaluateSharedSubexpr` (899) | Shared-result cache management.                     |
+
+Specific structural problems:
+
+1. **Per-call state lives on the tree node.**  `Expr::inputValues_` is a
+   buffer reset every evaluation but stored on the node.  This prevents
+   concurrent evaluation of the same `ExprSet` from multiple threads.
+2. **Per-Expr cross-call state mixes with tree data.**
+   `sharedSubexprResults_`, `baseOfDictionary*`, `cachedDictionaryIndices_`,
+   `stats_`, `adaptiveState_` are all on `Expr` alongside `inputs_` /
+   `type_` / `vectorFunction_` — making it impossible to tell which fields
+   are immutable post-compile.
+3. **Implicit pipeline order.**  Layer names (`evalEncodings`,
+   `evalWithNulls`, `evalAllImpl`) describe local actions but not pipeline
+   position.  A reader must trace calls to know where they are.
+4. **Special-form vs function-call fork is buried.**  The check happens at
+   `evalAllImpl` line 1486, four call levels below `eval()`.
+5. **No documented row-space invariant.**  Code juggles `rows` (caller's
+   original), `remainingRows` (post-pruning), translated inner rows
+   (post-peeling), and `EvalCtx::finalSelection()` without naming the
+   relationship.
+6. **`EvalCtx` mutations are inconsistently scoped.**  Some sites use
+   `ContextSaver` / `ScopedVarSetter` / `ScopedFinalSelectionSetter`,
+   others mutate and restore by hand inline.
+
+### Why not refactor `Expr` in place?
+
+Velox accepts heavy upstream churn on `Expr.cpp`.  An in-place restructure
+would generate continuous rebase conflicts for the duration of the
+refactor.  A parallel `ExprV2` type in new files isolates the change and
+lets upstream evolve `Expr` undisturbed until cutover.
+
+## Goals
+
+- **Behavior preservation.**  Bit-for-bit identical output to V1 across
+  the full expression test suite.
+- **Readable pipeline.**  One function per phase boundary, each ~5–10
+  lines, with documented invariants.
+- **Thread-safety.**  Concurrent evaluation of the same `ExprSetV2` from
+  multiple threads with separate `EvalFrame`s.  (Today impossible because
+  `Expr::inputValues_` is on the node.)
+- **Testable phases.**  Each pipeline function callable in isolation by
+  constructing an `EvalFrame` and invoking the phase directly.
+- **Incremental rollout.**  V2 ships behind a flag; V1 stays the default
+  until parity verified; cutover and V1 deletion are separate changes.
+
+## Non-goals
+
+- No new optimizations.  Performance equivalent to V1, not better.
+- No changes to `EvalCtx`'s public API.
+- No changes to special-form subclasses (`CaseExpr`, `ConjunctExpr`,
+  `CastExpr`, `CoalesceExpr`, `FieldReference`, `ConstantExpr`) initially.
+  `ExprV2` for a special-form node holds a `shared_ptr<Expr>` and
+  delegates `evaluateSpecialForm` to it.  Migrating special forms to
+  native ExprV2 nodes is a follow-up.
+- No changes to the expression compiler or function registry.  An
+  adapter walks the compiled `Expr` tree once and produces an `ExprV2` tree.
+- `ExprSetSimplified` is not subsumed initially.  After V2 stabilizes,
+  `ExprSetSimplified` is reimplemented as the same pipeline with peeling,
+  memo, and shared-subexpr phases disabled.
+
+## Target design
+
+### Component overview
+
+```
+                       ExprSetV2  (owner)
+                           |
+        +------------------+------------------+
+        |                  |                  |
+   shared_ptr<       ExprRuntime      ExprEvaluatorV2
+   ExprV2>[]         StateTree         (stateless)
+   (immutable        (mutable,
+    tree)            parallel
+                     to tree)
+```
+
+For each top-level evaluation, `ExprSetV2::eval`:
+
+1. Constructs an `EvalFrame` on the stack referencing the root `ExprV2`,
+   its `ExprRuntimeState`, the caller's `EvalCtx`, the requested rows,
+   and the output slot.
+2. Calls `ExprEvaluatorV2::evaluate(frame, this)`.
+3. The evaluator drives the pipeline, recursing by constructing inner
+   frames where row-space changes.
+
+### `ExprV2` — immutable node
+
+```cpp
+namespace facebook::velox::exec {
+
+/// Immutable expression-tree node.  All fields are set at construction
+/// from a compiled Expr; none are mutated during evaluation.  Safe to
+/// share across threads.
+class ExprV2 {
+ public:
+  /// Construct from a compiled Expr.  Recursively builds the V2 tree;
+  /// special-form nodes wrap the original Expr for delegated evaluation.
+  static std::shared_ptr<ExprV2> from(const std::shared_ptr<Expr>& expr);
+
+  const TypePtr& type() const { return type_; }
+  const std::string& name() const { return name_; }
+  const std::vector<std::shared_ptr<ExprV2>>& inputs() const { return inputs_; }
+  const VectorFunction* vectorFunction() const { return vectorFunction_.get(); }
+  const VectorFunctionMetadata& metadata() const { return metadata_; }
+  SpecialForm specialForm() const { return specialForm_; }
+
+  bool isSpecialForm() const { return specialForm_ != SpecialForm::kNone; }
+  bool deterministic() const { return deterministic_; }
+  bool propagatesNulls() const { return propagatesNulls_; }
+  bool supportsFlatNoNullsFastPath() const { return supportsFlatNoNullsFastPath_; }
+  bool hasConditionals() const { return hasConditionals_; }
+  bool skipFieldDependentOptimizations() const { return skipFieldDependentOptimizations_; }
+
+  const std::vector<FieldReferenceV2*>& distinctFields() const { return distinctFields_; }
+  const std::vector<FieldReferenceV2*>& multiplyReferencedFields() const { return multiplyReferencedFields_; }
+
+  /// Delegated path for special-form nodes during the migration period.
+  /// Returns the wrapped Expr; null for function-call nodes.
+  const std::shared_ptr<Expr>& legacySpecialForm() const { return legacySpecialForm_; }
+
+ private:
+  ExprV2(...);  // populated by from()
+
+  TypePtr type_;
+  std::string name_;
+  std::vector<std::shared_ptr<ExprV2>> inputs_;
+  std::shared_ptr<VectorFunction> vectorFunction_;  // null for special forms
+  VectorFunctionMetadata metadata_;
+  SpecialForm specialForm_;                          // enum tag
+  std::shared_ptr<Expr> legacySpecialForm_;          // delegation during migration
+
+  // Compile-time metadata derived once.
+  bool deterministic_;
+  bool propagatesNulls_;
+  bool supportsFlatNoNullsFastPath_;
+  bool hasConditionals_;
+  bool skipFieldDependentOptimizations_;
+
+  std::vector<FieldReferenceV2*> distinctFields_;
+  std::vector<FieldReferenceV2*> multiplyReferencedFields_;
+};
+
+} // namespace facebook::velox::exec
+```
+
+### `ExprRuntimeState` — per-node mutable state
+
+```cpp
+/// Mutable per-Expr state that survives across evaluations.  One instance
+/// per ExprV2 per ExprSetV2.  Owned by ExprSetV2 in a tree that mirrors
+/// the ExprV2 tree.  Not thread-safe: concurrent evaluations of the same
+/// ExprSetV2 each get their own ExprRuntimeStateTree (or share with a
+/// mutex; TBD by use case).
+struct ExprRuntimeState {
+  // Shared-subexpression cache.  Same as Expr::sharedSubexprResults_.
+  SharedSubexprCacheState sharedCache;
+
+  // Dictionary memoization.  Same as Expr's baseOfDictionary*,
+  // cachedDictionaryIndices_, dictionaryCache_.
+  DictionaryMemoState dictMemo;
+
+  // Stats accumulated across evaluations.
+  ExprStats stats;
+
+  // Adaptive CPU sampling state.
+  AdaptiveCpuSamplingState adaptiveState;
+};
+
+/// Tree of runtime state, parallel-indexed with the ExprV2 tree.
+/// Look up runtime state for a node by tree position.
+class ExprRuntimeStateTree {
+ public:
+  explicit ExprRuntimeStateTree(const ExprV2& root);
+  ExprRuntimeState& at(const ExprV2& node);
+ private:
+  // Implementation choice: flat vector keyed by in-order index, or
+  // a map keyed by ExprV2*, or a shared_ptr per node.  Trade-off TBD;
+  // flat vector is simplest if the tree is built once and never reshaped.
+  std::vector<ExprRuntimeState> states_;
+  folly::F14FastMap<const ExprV2*, size_t> indexByNode_;
+};
+```
+
+### `EvalFrame` — per-call state
+
+```cpp
+/// Per-call evaluation state for one ExprV2 node.  Lives on the stack
+/// of the outermost ExprEvaluatorV2::evaluate() call.  Inner recursion
+/// (peeling, null-pruning wrapper, shared-subexpr wrapper) constructs
+/// fresh inner EvalFrames.
+///
+/// Row-space invariant:
+///   - originalRows never changes after construction.
+///   - remainingRows.rows() is always a subset of originalRows.
+///   - Every phase operates on remainingRows.rows(), not originalRows.
+///   - remainingRows shrinks monotonically as evaluation proceeds; it
+///     never grows.
+///   - originalRows is used only for result sizing, final null-fill,
+///     and copying / wrapping back into the caller's row space.
+struct EvalFrame {
+  // === Bindings (constant after construction) ===
+
+  ExprV2& expr;
+  ExprRuntimeState& nodeRuntime;
+  EvalCtx& ctx;
+  const SelectivityVector& originalRows;
+  VectorPtr& result;
+
+  // === Mutable state flowing between phases ===
+
+  MutableRemainingRows remainingRows;
+  std::vector<VectorPtr> inputValues;  // moved off ExprV2 onto the frame
+  bool tryPeelArgs;
+
+  // === Compile-time flags cached once from expr ===
+  bool defaultNulls;
+  bool propagatesNulls;
+  bool deterministic;
+  bool isSpecialForm;
+  bool supportsFlatNoNullsFastPath;
+  bool hasConditionals;
+  bool skipFieldDependentOptimizations;
+
+  EvalFrame(
+      ExprV2& exprIn,
+      ExprRuntimeState& nodeRuntimeIn,
+      EvalCtx& ctxIn,
+      const SelectivityVector& rowsIn,
+      VectorPtr& resultIn);
+};
+```
+
+### `ExprEvaluatorV2` — stateless orchestrator
+
+```cpp
+/// Drives the staged evaluation pipeline against an EvalFrame.  Owns
+/// no state; all per-call state lives on the frame, all cross-call
+/// state lives in ExprRuntimeState.  Safe to share across threads.
+class ExprEvaluatorV2 {
+ public:
+  /// Entry point.  Constructs no state; orchestrates phases.
+  void evaluate(EvalFrame& frame, const ExprSetV2* parentSet);
+
+ private:
+  // Pipeline phases.  Order matches V1 semantics exactly.  Each name
+  // describes what wrapper or fork this layer owns, not what the
+  // previous layer did.
+  void evaluateFrame(EvalFrame& f, const ExprSetV2* parentSet);
+  void evaluateWithFieldPeeling(EvalFrame& f);
+  void evaluateWithNullPruning(EvalFrame& f);
+  void evaluateWithSharedSubexpr(EvalFrame& f);
+  void evaluateNodeBody(EvalFrame& f);
+  void evaluateFunctionCall(EvalFrame& f);
+  void evaluateSpecialForm(EvalFrame& f);
+
+  // Apply / leaf operations.
+  void applyFunction(EvalFrame& f);
+  void emitEmpty(EvalFrame& f);
+};
+```
+
+### `ExprSetV2` — owner
+
+```cpp
+class ExprSetV2 {
+ public:
+  ExprSetV2(
+      std::vector<core::TypedExprPtr> exprs,
+      core::ExecCtx* execCtx);
+
+  /// Public entry point.  Constructs an EvalFrame per root and calls
+  /// the evaluator.  Threading: each concurrent caller passes its own
+  /// EvalCtx; ExprSetV2 either provides per-thread runtime-state trees
+  /// or guards a shared one with a mutex (TBD).
+  void eval(
+      const SelectivityVector& rows,
+      EvalCtx& ctx,
+      std::vector<VectorPtr>& results);
+
+  void addToMemo(ExprV2* expr);
+
+  const std::vector<std::shared_ptr<ExprV2>>& exprs() const { return roots_; }
+
+ private:
+  std::vector<std::shared_ptr<ExprV2>> roots_;
+  std::unique_ptr<ExprRuntimeStateTree> runtimeStates_;
+  ExprEvaluatorV2 evaluator_;
+};
+```
+
+### Phases — stateless utility types
+
+Each phase is a stateless type with static methods that take `EvalFrame&`
+and (where applicable) a continuation callback.  Free functions in an
+anonymous namespace would work equally well; class form is for grouping
+and forward declaration.
+
+```cpp
+struct FastPath {
+  static bool tryFlatNoNulls(EvalFrame& f, const ExprSetV2* parentSet);
+};
+
+struct LazyInput {
+  static void loadRequiredFields(EvalFrame& f);
+};
+
+struct FieldPeeling {
+  /// Attempts to peel input field encodings for the whole subtree.
+  /// If peeling succeeds, calls continuation on a fresh inner frame
+  /// with translated rows; wraps the result back into the outer row
+  /// space.  Internally chooses DictionaryMemo::evaluate vs direct
+  /// continuation based on the peel result's mayCache flag.
+  template <typename Continuation>
+  static bool tryPeel(EvalFrame& f, Continuation continuation);
+};
+
+struct DictionaryMemo {
+  /// Reached only on the peeled, mayCache=true path.  Caches results
+  /// keyed by base dictionary and re-uses across batches.
+  template <typename Continuation>
+  static void evaluate(EvalFrame& f, Continuation continuation);
+};
+
+struct NullPruning {
+  /// Wrapping phase.  If propagatesNulls and inputs may have nulls,
+  /// computes the non-null subset of remainingRows, constructs an
+  /// inner frame on that subset, calls continuation, then null-fills
+  /// the pruned rows in the result on return.
+  template <typename Continuation>
+  static bool tryPrune(EvalFrame& f, Continuation continuation);
+};
+
+struct SharedSubexprCache {
+  /// Wrapping phase.  Checks nodeRuntime.sharedCache for a cached
+  /// result on the same input fields.  On hit, copies into result
+  /// and returns true.  On miss, calls continuation and stores
+  /// the result.
+  template <typename Continuation>
+  static bool tryReuse(EvalFrame& f, Continuation continuation);
+};
+
+struct ArgEval {
+  /// Evaluates all child inputs, populating frame.inputValues.  May
+  /// shrink frame.remainingRows in place when default-null behavior
+  /// applies.  Returns false if remainingRows becomes empty (in which
+  /// case setAllNulls has already been applied).
+  static bool evaluate(EvalFrame& f, ExprEvaluatorV2& evaluator);
+};
+
+struct ArgPeeling {
+  /// Argument-level peeling: peels the encodings of frame.inputValues
+  /// after child evaluation.  Distinct from FieldPeeling, which peels
+  /// input field encodings before children evaluate.
+  template <typename ApplyFn>
+  static bool tryApply(EvalFrame& f, ApplyFn apply);
+};
+```
+
+### `ArgEvalStrategy` — the one true policy
+
+```cpp
+/// Strategy for evaluating child inputs.  Two implementations:
+///   DefaultNullArgEval     — prune rows where any child is null.
+///   PreserveNullArgEval    — leave nulls in place for the function
+///                            to handle.
+/// Selected per-frame from expr.metadata().defaultNullBehavior.
+class ArgEvalStrategy {
+ public:
+  virtual ~ArgEvalStrategy() = default;
+
+  /// Returns true if remainingRows still has selections after
+  /// evaluation.  False means setAllNulls has been applied.
+  virtual bool evalArgs(EvalFrame& f, ExprEvaluatorV2& evaluator) = 0;
+};
+
+class DefaultNullArgEval : public ArgEvalStrategy { /* ... */ };
+class PreserveNullArgEval : public ArgEvalStrategy { /* ... */ };
+```
+
+Selected once per frame at frame construction:
+```cpp
+ArgEvalStrategy& strategy = f.defaultNulls
+    ? defaultNullStrategy_
+    : preserveNullStrategy_;
+```
+
+Strategies are shared (stateless), not allocated per call.
+
+### Debug guards
+
+Two RAII helpers verify invariants in debug builds.  Both compile to
+zero-cost no-ops in release.
+
+```cpp
+#ifndef NDEBUG
+/// Verifies the row-space invariant at every phase boundary:
+///   - remainingRows is a subset of originalRows.
+///   - remainingRows shrinks monotonically (never grows during phase).
+class DebugRemainingRowsGuard {
+ public:
+  explicit DebugRemainingRowsGuard(const EvalFrame& frame)
+      : frame_{frame},
+        countOnEntry_{frame.remainingRows.rows().countSelected()} {}
+
+  ~DebugRemainingRowsGuard() {
+    VELOX_DCHECK(frame_.remainingRows.rows().isSubset(frame_.originalRows));
+    VELOX_DCHECK_LE(
+        frame_.remainingRows.rows().countSelected(), countOnEntry_);
+  }
+
+ private:
+  const EvalFrame& frame_;
+  vector_size_t countOnEntry_;
+};
+
+/// Installed once at the top of evaluateFrame().  Verifies invariants
+/// that hold across the entire evaluation, not at each phase boundary.
+class DebugEvaluateGuard {
+ public:
+  explicit DebugEvaluateGuard(const EvalFrame& frame) : frame_{frame} {
+    VELOX_DCHECK(frame.inputValues.empty());
+  }
+
+  ~DebugEvaluateGuard() {
+    VELOX_DCHECK(frame_.inputValues.empty()); // releaseGuard ran
+    if (frame_.result) {
+      VELOX_DCHECK(frame_.result->type()->equivalent(*frame_.expr.type()));
+      VELOX_DCHECK_GE(frame_.result->size(), frame_.originalRows.end());
+    }
+  }
+
+ private:
+  const EvalFrame& frame_;
+};
+#else
+class DebugRemainingRowsGuard { public: explicit DebugRemainingRowsGuard(const EvalFrame&) {} };
+class DebugEvaluateGuard { public: explicit DebugEvaluateGuard(const EvalFrame&) {} };
+#endif
+```
+
+## Pipeline
+
+Order matches V1 semantics exactly (see `Expr.cpp` reference column).
+
+```cpp
+void ExprEvaluatorV2::evaluate(EvalFrame& f, const ExprSetV2* parentSet) {
+  evaluateFrame(f, parentSet);
+}
+
+// Entry guards.  Mirrors Expr::eval (816).
+void ExprEvaluatorV2::evaluateFrame(EvalFrame& f, const ExprSetV2* parentSet) {
+  DebugEvaluateGuard outerGuard{f};
+
+  if (FastPath::tryFlatNoNulls(f, parentSet)) return;
+
+  TopLevelExceptionScope scope{f, parentSet};
+
+  if (!f.originalRows.hasSelections()) {
+    emitEmpty(f);
+    return;
+  }
+
+  LazyInput::loadRequiredFields(f);
+  evaluateWithFieldPeeling(f);
+}
+
+// Field-peeling wrapper.  Mirrors Expr::evalEncodings (1101).
+void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  if (FieldPeeling::tryPeel(f, [this](EvalFrame& inner) {
+        evaluateWithNullPruning(inner);
+      })) {
+    return;
+  }
+  evaluateWithNullPruning(f);
+}
+
+// Null-pruning wrapper.  Mirrors Expr::evalWithNulls (1201).
+void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  if (NullPruning::tryPrune(f, [this](EvalFrame& pruned) {
+        evaluateWithSharedSubexpr(pruned);
+      })) {
+    return;
+  }
+  evaluateWithSharedSubexpr(f);
+}
+
+// Shared-subexpr wrapper.  Mirrors Expr::evalAll (1450).
+void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  if (SharedSubexprCache::tryReuse(f, [this](EvalFrame& inner) {
+        evaluateNodeBody(inner);
+      })) {
+    return;
+  }
+  evaluateNodeBody(f);
+}
+
+// Fork.  Mirrors the isSpecialForm() check in Expr::evalAllImpl (1486).
+void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& f) {
+  if (f.isSpecialForm) {
+    evaluateSpecialForm(f);
+    return;
+  }
+  evaluateFunctionCall(f);
+}
+
+// Function-call leaf.  Mirrors the rest of evalAllImpl + applyFunction*.
+void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  auto releaseGuard = folly::makeGuard([&] {
+    f.ctx.releaseVectors(f.inputValues);
+    f.inputValues.clear();
+  });
+
+  if (!ArgEval::evaluate(f, *this)) {
+    return; // setAllNulls already applied
+  }
+
+  if (!f.tryPeelArgs ||
+      !ArgPeeling::tryApply(f, [this](EvalFrame& g) { applyFunction(g); })) {
+    applyFunction(f);
+  }
+
+  if (f.remainingRows.hasChanged()) {
+    EvalCtx::addNulls(
+        f.originalRows,
+        f.remainingRows.rows().asRange().bits(),
+        f.ctx,
+        f.expr.type(),
+        f.result);
+  }
+}
+
+// Special-form leaf.  Delegates to wrapped legacy Expr during migration.
+void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  f.expr.legacySpecialForm()->evalSpecialForm(
+      f.remainingRows.rows(), f.ctx, f.result);
+}
+```
+
+### Phase-to-V1 mapping
+
+| V2 phase                       | V1 site                              | Responsibility                       |
+|--------------------------------|--------------------------------------|--------------------------------------|
+| `evaluateFrame`                | `Expr::eval` (816)                   | Fast path, exception scope, empty rows, lazy load. |
+| `evaluateWithFieldPeeling`     | `Expr::evalEncodings` (1101)         | Field peeling wrapper.               |
+| `FieldPeeling::tryPeel`        | `peelEncodings` (1025)               | Compute peel, recurse on inner rows. |
+| `DictionaryMemo::evaluate`     | `Expr::evalWithMemo` (1246)          | Cache by base dictionary.            |
+| `evaluateWithNullPruning`      | `Expr::evalWithNulls` (1201)         | Null pruning wrapper.                |
+| `evaluateWithSharedSubexpr`    | `Expr::evalAll` (1450)               | Shared-subexpr wrapper.              |
+| `SharedSubexprCache::tryReuse` | `Expr::evaluateSharedSubexpr` (899)  | Cache lookup + partial-row eval.     |
+| `evaluateNodeBody`             | `Expr::evalAllImpl` (1486) fork      | Special-form vs function-call fork.  |
+| `evaluateFunctionCall`         | `Expr::evalAllImpl` (1490–1531) tail | Arg eval, arg peeling, apply, null fill. |
+| `ArgEval::evaluate`            | `evalArgsDefaultNulls` (380) / `evalArgsWithNulls` (455) | Evaluate children. |
+| `ArgPeeling::tryApply`         | `applyFunctionWithPeeling` (1534)    | Argument-level peeling.              |
+| `applyFunction`                | `Expr::applyFunction` (1753)         | Invoke vector function + listeners.  |
+
+## UML diagrams
+
+### Class diagram
+
+```
+  Legend:  <>-- composition (owns lifetime)
+           o-- aggregation (holds reference)
+           --> uses / depends on
+           --|> implements interface
+           « »  stereotype
+
+
+  +------------------------------------------------------------------+
+  |                          ExprSetV2                               |
+  |  «owner»                                                         |
+  +------------------------------------------------------------------+
+  | - roots_     : vector<shared_ptr<ExprV2>>                        |
+  | - runtimeStates_ : unique_ptr<ExprRuntimeStateTree>              |
+  | - evaluator_ : ExprEvaluatorV2                                   |
+  +------------------------------------------------------------------+
+  | + eval(rows, ctx, results[])                                     |
+  | + addToMemo(ExprV2*)                                             |
+  +--------+-----------------+---------------------+-----------------+
+           <>                <>                    <>
+           |                 |                     |
+           v                 v                     v
+  +--------------------+ +-----------------+  +---------------------------+
+  |      ExprV2        | | ExprRuntimeStateTree |  ExprEvaluatorV2        |
+  | «immutable node»   | | «owner of nodes»|  |     «stateless»          |
+  +--------------------+ +-----------------+  +---------------------------+
+  | - type_            | | - states_       |  | + evaluate(frame,        |
+  | - name_            | | - indexByNode_  |  |     parentSet)           |
+  | - inputs_          | +-----------------+  | - evaluateFrame(f, ps)   |
+  | - vectorFunc_      |         <>           | - evaluateWithField...   |
+  | - metadata_        |         |            | - evaluateWithNull...    |
+  | - specialForm_     |         v            | - evaluateWithShared...  |
+  | - legacySpecial_   | +-----------------+  | - evaluateNodeBody       |
+  | - distinctFields_  | | ExprRuntimeState|  | - evaluateFunctionCall   |
+  +-----+--------------+ |                 |  | - evaluateSpecialForm    |
+        <>               | - sharedCache   |  | - applyFunction          |
+        | inputs_        | - dictMemo      |  +-----------+--------------+
+        |                | - stats         |              | uses
+        v                | - adaptiveState |              v
+  +--------------------+ +-----------------+   +---------------------------+
+  |      ExprV2        |                       |        «phases»           |
+  +--------------------+                       | (stateless types)         |
+                                               +---------------------------+
+                                               | FastPath                  |
+                                               | LazyInput                 |
+                                               | FieldPeeling              |
+                                               | DictionaryMemo            |
+                                               | NullPruning               |
+                                               | SharedSubexprCache        |
+                                               | ArgEval -+                |
+                                               | ArgPeeling                |
+                                               +--+----+--+----------------+
+                                                  | takes &f  | uses
+                                                  v           v
+                                       +----------------+ +------------------+
+                                       |   EvalFrame    | | ArgEvalStrategy  |
+                                       | «per-call»     | | «interface»      |
+                                       +----------------+ +--------+---------+
+                                       | & expr         |        --|--
+                                       | & nodeRuntime  |       /     \
+                                       | & ctx          |      v       v
+                                       | & originalRows |  +-------+ +---------+
+                                       | & result       |  |Default| |Preserve |
+                                       |   remainingRows|  |Null   | |Null     |
+                                       |   inputValues  |  |ArgEval| |ArgEval  |
+                                       |   tryPeelArgs  |  +-------+ +---------+
+                                       |   [flags]      |
+                                       +----+----+------+
+                                            o    o
+                                            |    |
+                                            v    v
+                            +----------------+ +-----------------+
+                            |ExprRuntimeState| |    EvalCtx      |
+                            +----------------+ | «existing»      |
+                                               +-----------------+
+```
+
+### Sequence diagram for one `evaluate()` call
+
+```
+caller        ExprSetV2     ExprEvaluatorV2     phases         EvalFrame      EvalCtx
+  |              |                |                |              (stack)         |
+  | eval(rows,   |                |                |                |             |
+  |   ctx,res[]) |                |                |                |             |
+  |------------->|                |                |                |             |
+  |              | construct      |                |                |             |
+  |              | EvalFrame------+--------------->|                |             |
+  |              |                |                |                |             |
+  |              | evaluate(f, this)               |                |             |
+  |              |--------------->|                |                |             |
+  |              |                |                |                |             |
+  |              |                | FastPath::tryFlatNoNulls(f)     |             |
+  |              |                |--------------->| read flags     |             |
+  |              |                |                |<---------------|             |
+  |              |                | false                           |             |
+  |              |                |<---------------|                |             |
+  |              |                |                |                |             |
+  |              |                | TopLevelExceptionScope installed              |
+  |              |                |-----------------------------------------------|
+  |              |                |                |                |             |
+  |              |                | LazyInput::loadRequiredFields(f)|             |
+  |              |                |--------------->| ensureFieldLoaded            |
+  |              |                |                |--------------+-------------->|
+  |              |                |                |                |             |
+  |              |                | FieldPeeling::tryPeel(f, &evaluateWith...)    |
+  |              |                |--------------->| saveAndReset, setPeeled      |
+  |              |                |                |-----------------------------> |
+  |              |                |                | construct innerFrame         |
+  |              |                |                |--------------> (new frame)   |
+  |              |                |                | recurse(innerFrame)          |
+  |              |                |<---------------|                |             |
+  |              |                | ... NullPruning, SharedSubexprCache,          |
+  |              |                |     fork, ArgEval, ArgPeeling, apply ...      |
+  |              |                |                | wrap peeled result           |
+  |              |                |                | moveOrCopyResult to outer    |
+  |              |                | true                            |             |
+  |              |                |<---------------|                |             |
+  |              | (early return; releaseGuard cleared inputValues)               |
+  |              | result[i] populated             |                |             |
+  |<-------------|                |                |                |             |
+```
+
+### State diagram for `remainingRows`
+
+```
+                  remainingRows == originalRows
+                          (initial)
+                              |
+                              | enter evaluateFrame
+                              v
+        +-----------------+---+---------------+---------------+
+        |                 |                   |               |
+   FieldPeeling      NullPruning         SharedSubexpr    (no shrink)
+   (no shrink         (no shrink         (no shrink
+    on outer;          on outer;          on outer;
+    inner frame        inner frame        inner frame
+    has its own        has its own        has its own
+    originalRows)      originalRows)      originalRows)
+        |                 |                   |               |
+        +-----------------+---+---------------+---------------+
+                              |
+                              v
+                       evaluateNodeBody
+                              |
+                +-------------+-------------+
+                |                           |
+          evaluateSpecialForm        evaluateFunctionCall
+          (no shrink)                       |
+                                            v
+                                       ArgEval::evaluate
+                                       (may shrink in place
+                                        via default-null or
+                                        error deselection)
+                                            |
+                                            v
+                                       remainingRows
+                                       <= original
+                                            |
+                                            v
+                                       ArgPeeling / applyFunction
+                                       (operate on
+                                        remainingRows.rows())
+                                            |
+                                            v
+                                       if shrank, addNulls for
+                                       originalRows \ remainingRows
+```
+
+## Recursion patterns
+
+Two distinct shapes; each phase uses exactly one.
+
+**Pattern A — wrapping recursion** (FieldPeeling, NullPruning, SharedSubexprCache):
+- Phase constructs a new `EvalFrame` with a different `originalRows`
+  (peeled inner rows, or pruned subset).
+- The outer frame's `remainingRows` is not mutated by the phase.
+- The inner frame has its own invariants; the guard on the outer
+  frame sees no change.
+
+**Pattern B — in-place mutation** (ArgEval):
+- Same frame; `remainingRows` shrinks in place as children evaluate
+  and null/error rows are deselected.
+- The guard on the frame sees the shrinkage and verifies subset +
+  monotonicity.
+
+No phase mixes both patterns.
+
+## Adapter from `Expr` to `ExprV2`
+
+```cpp
+// static
+std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& expr) {
+  // Recursively convert children.
+  std::vector<std::shared_ptr<ExprV2>> inputs;
+  inputs.reserve(expr->inputs().size());
+  for (const auto& child : expr->inputs()) {
+    inputs.push_back(ExprV2::from(child));
+  }
+
+  // For special forms, wrap the legacy Expr and delegate.
+  if (expr->isSpecialForm()) {
+    return std::shared_ptr<ExprV2>(new ExprV2(
+        expr->type(),
+        expr->name(),
+        std::move(inputs),
+        /*vectorFunction=*/nullptr,
+        expr->vectorFunctionMetadata(),
+        toSpecialFormTag(expr),
+        /*legacySpecialForm=*/expr,
+        /* ...flags from expr... */));
+  }
+
+  // Function-call node: full ExprV2.
+  return std::shared_ptr<ExprV2>(new ExprV2(
+      expr->type(),
+      expr->name(),
+      std::move(inputs),
+      expr->vectorFunction(),
+      expr->vectorFunctionMetadata(),
+      SpecialForm::kNone,
+      /*legacySpecialForm=*/nullptr,
+      /* ...flags from expr... */));
+}
+```
+
+This preserves all parsing, typing, type-coercion, function-lookup, and
+metadata-derivation logic in the existing `ExprCompiler`.  Only the
+evaluation half is re-implemented.
+
+## Implementation steps
+
+Each step is a behavior-preserving PR, reviewed and merged independently.
+V2 is feature-flagged off until step 11.
+
+### Step 1 — design doc + edge-case tests
+
+Land this design doc.  Add tests in
+`velox/expression/tests/ExprPipelineEdgeCasesTest.cpp` that lock in
+current behavior for the subtle cases the refactor must preserve:
+
+- TRY × shared-subexpr partial-row reuse.
+- TRY with failing children under default-null vs preserve-null.
+- Dictionary peeling with nulls in the indices.
+- Dictionary memo with `finalSelection` set.
+- Shared-subexpr with multiple input fields, partial-row hit.
+- Lazy vectors under IF / AND / OR with `hasConditionals`.
+- Flat-no-nulls fast path compatibility with each operator.
+- `evalSimplified` equivalence on a representative query.
+
+These tests run against V1 first to capture the current expected output
+as golden vectors; they will later run against V2 to confirm parity.
+
+### Step 2 — skeletons of all V2 types
+
+Add empty headers and minimal implementations for `ExprV2`,
+`ExprRuntimeState`, `ExprRuntimeStateTree`, `EvalFrame`,
+`ExprEvaluatorV2`, `ExprSetV2`.  Nothing routes through them yet.
+Compiles, does not link into any executable path.
+
+### Step 3 — adapter `ExprV2::from(Expr)` for function-call nodes
+
+Implement the adapter.  For special-form nodes, wrap legacy `Expr` and
+mark with `SpecialForm` tag.  Add unit tests that compile a query,
+adapt to V2, and verify metadata round-trips.
+
+### Step 4 — trivial pipeline paths
+
+Implement `ExprEvaluatorV2::evaluate` for:
+- FastPath (delegate to existing `evalFlatNoNulls` logic in V1; keep
+  bit-identical).
+- Empty rows.
+- Special-form delegation (`evaluateSpecialForm` calls
+  `legacySpecialForm_->evalSpecialForm`).
+- Function-call without peeling, memo, or shared-subexpr: arg eval +
+  apply.
+
+At this point, V2 can evaluate simple queries.  Add an A/B harness in
+test code that evaluates a query with both V1 and V2 and asserts vector
+equality.
+
+### Step 5 — FieldPeeling phase
+
+Port `evalEncodings` / `peelEncodings` logic into `FieldPeeling::tryPeel`.
+Construct an inner `EvalFrame` for the peeled row space.  Verify the
+A/B harness passes for peeling-eligible queries.
+
+### Step 6 — DictionaryMemo phase
+
+Port `evalWithMemo` into `DictionaryMemo::evaluate`.  Reachable only
+from `FieldPeeling::tryPeel` when the peel result is cacheable.
+
+### Step 7 — NullPruning phase
+
+Port `evalWithNulls`'s null-pruning branch into `NullPruning::tryPrune`.
+Wrapping recursion constructs an inner frame on the pruned row space.
+
+### Step 8 — SharedSubexprCache phase
+
+Port `evaluateSharedSubexpr` into `SharedSubexprCache::tryReuse`.
+This is the seam most likely to surface subtle TRY-interaction bugs;
+run the step-1 edge-case tests carefully.
+
+### Step 9 — ArgEval + ArgEvalStrategy
+
+Port `evalArgsDefaultNulls` and `evalArgsWithNulls` into
+`DefaultNullArgEval::evalArgs` and `PreserveNullArgEval::evalArgs`.
+
+### Step 10 — ArgPeeling + listener / timing / tracer
+
+Port `applyFunctionWithPeeling`, `invokeApplyWithListeners`, the
+adaptive CPU-sampling logic, and tracer hooks.
+
+### Step 11 — feature flag + A/B in production tests
+
+Add a query-config flag `expr_eval_v2`.  When set, `ExprSetV2` runs;
+otherwise V1.  Run the full `velox_expression_test` suite under both
+flags.  Compare results vector-for-vector for every test case.
+
+### Step 12 — migrate special forms
+
+For each of `CaseExpr`, `ConjunctExpr`, `CastExpr`, `CoalesceExpr`,
+`FieldReference`, `ConstantExpr`: produce a native `ExprV2` form and
+remove the delegation wrapper.  One PR per form.  Order suggested:
+`FieldReference` and `ConstantExpr` first (simplest), then `CastExpr`,
+then conditionals.
+
+### Step 13 — subsume `ExprSetSimplified`
+
+Reimplement `ExprSetSimplified` as `ExprSetV2` with peeling, memo, and
+shared-subexpr phases disabled.  Delete `evalSimplified` and
+`evalSimplifiedImpl` from V1.
+
+### Step 14 — cutover
+
+Flip the `expr_eval_v2` default to true after one release cycle of
+no parity bugs in production.
+
+### Step 15 — delete V1
+
+Once the flag has been default-true for one release cycle and no parity
+flag is held by any caller, delete `Expr::eval` and the chain of
+methods it calls.  Keep `Expr` as a compile-time tree node consumed by
+`ExprV2::from()`, or merge `Expr` and `ExprV2` if it makes sense.
+
+## Milestones
+
+| Milestone | Steps | Outcome |
+|-----------|-------|---------|
+| **M1: Foundations**          | 1–3   | Design locked, edge cases captured as golden tests, V2 types compile, adapter works. |
+| **M2: Trivial pipeline**     | 4     | V2 can evaluate simple function-call queries; A/B harness in test code passes for trivial cases. |
+| **M3: Encoding paths**       | 5–6   | Field peeling and dictionary memo working in V2; A/B parity for peeling-heavy queries. |
+| **M4: Null + cache paths**   | 7–8   | Null pruning and shared-subexpr working in V2; A/B parity for TRY / propagatesNulls queries. |
+| **M5: Function-call leaf**   | 9–10  | Arg eval (both strategies), arg peeling, listeners, tracer working; V2 reaches full feature parity for function-call nodes. |
+| **M6: Production rollout**   | 11    | `expr_eval_v2` flag in place; full test suite passes under V2; opt-in available in production. |
+| **M7: Special-form native**  | 12    | Each special form runs natively under V2 instead of delegating; legacy `Expr` no longer reached on V2 path. |
+| **M8: Simplified subsumed**  | 13    | `ExprSetSimplified` deleted; V2 covers both paths. |
+| **M9: Cutover**              | 14    | V2 is the default in production. |
+| **M10: V1 deleted**          | 15    | Legacy `Expr::eval` chain removed; codebase has one evaluator. |
+
+Each milestone is releasable independently.  No milestone (except M10)
+removes existing functionality.
+
+## Testing strategy
+
+### Golden-output tests
+
+For each of the step-1 edge cases, capture V1's output as a golden vector.
+After each subsequent step, run the same test against both V1 and V2 and
+assert byte-equal vectors (including nulls, encodings, and child vector
+shapes — not just logical values).
+
+### A/B parity harness
+
+Add a test helper that takes a query and input rows and:
+1. Evaluates with V1, captures output vector.
+2. Evaluates with V2, captures output vector.
+3. Asserts logical equality (`VectorEqualValueChecker`), null pattern
+   equality, and where possible encoding equality.
+
+Wire the existing `expression_test` to run under both flags in CI.
+
+### Debug-build invariants
+
+Compile CI debug builds with `DebugRemainingRowsGuard` and
+`DebugEvaluateGuard` enabled.  These catch the most likely refactor
+regressions (row-space violations, missing `releaseInputValues`,
+result type mismatch) at every phase boundary.
+
+### Production safety
+
+The `expr_eval_v2` flag is per-query.  A canary deploy can route a
+small percentage of production queries through V2 while V1 remains
+the default; any divergence is logged via the existing query-fingerprint
+infrastructure.
+
+## Risks and open questions
+
+### Risks
+
+- **`ExprRuntimeState` threading.**  V1 today is single-threaded per
+  `ExprSet` because state lives on `Expr`.  V2 enables concurrent
+  evaluation, but `ExprSetV2` must decide: per-thread runtime-state
+  trees, or one shared tree with a mutex.  The right answer depends on
+  whether shared-subexpr / memo benefits cross threads.  Decision
+  deferred to step 4 when the first concurrent caller appears.
+- **Special-form delegation overhead.**  Each special-form evaluation
+  in V2 calls `legacySpecialForm_->evalSpecialForm`, which does its
+  own internal pipeline work.  Should be zero overhead in practice
+  (one extra virtual call), but worth measuring at M5.
+- **Stats merging.**  V1 accumulates stats on `Expr::stats_`.  V2
+  accumulates on `ExprRuntimeState::stats`.  The reporting code
+  (`ExprSet::stats()`) must be ported to read from the V2 location
+  while V1 is still in tree.  Plan: read both, prefer V2 when
+  populated.
+- **Adapter cost on hot paths.**  `ExprV2::from(Expr)` walks the tree
+  once per `ExprSetV2` construction.  Negligible relative to eval cost,
+  but worth confirming on micro-benchmarks before M6.
+
+### Open questions
+
+- Should `ExprRuntimeStateTree` use flat-vector indexing (cheap, but
+  requires stable tree iteration order) or `F14FastMap<ExprV2*>`
+  (more flexible, slight lookup cost)?  Decide at step 2.
+- Should `ExprV2` be `final`?  No subclasses are anticipated; making it
+  `final` enables devirtualization in tight loops.
+- Are there any callers that hold raw `Expr*` pointers across a query
+  lifetime?  Audit needed before step 14.
+- `FieldReference` is currently a subclass of `Expr` with custom
+  `evalSpecialForm`.  Step 12 needs to decide whether `FieldReferenceV2`
+  is a distinct `ExprV2` subtype, or whether `ExprV2` carries a
+  `FieldReference` flag inline.
+
+## Appendix: file layout
+
+```
+velox/expression/
+  Expr.{h,cpp}                       — unchanged
+  ExprSet.{h,cpp}                    — unchanged
+
+  ExprV2.{h,cpp}                     — new: node + ExprV2::from(Expr)
+  ExprRuntimeState.{h,cpp}           — new: per-node mutable state
+  EvalFrame.{h,cpp}                  — new: per-call state
+  ExprEvaluatorV2.{h,cpp}            — new: pipeline orchestrator
+  ExprSetV2.{h,cpp}                  — new: owner type
+
+  ExprPhases/                        — new: pipeline phases
+    FastPath.{h,cpp}
+    LazyInput.{h,cpp}
+    FieldPeeling.{h,cpp}
+    DictionaryMemo.{h,cpp}
+    NullPruning.{h,cpp}
+    SharedSubexprCache.{h,cpp}
+    ArgEval.{h,cpp}
+    ArgPeeling.{h,cpp}
+
+  tests/
+    ExprPipelineEdgeCasesTest.cpp    — new: step-1 golden tests
+    ExprV2ParityTest.cpp             — new: A/B harness
+```

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -50,10 +50,14 @@ velox_add_library(
   EvalCtx.cpp
   Expr.cpp
   ExprCompiler.cpp
+  ExprEvaluatorV2.cpp
   ExprRewriteRegistry.cpp
   ExprOptimizer.cpp
+  ExprRuntimeState.cpp
+  ExprSetV2.cpp
   ExprToSubfieldFilter.cpp
   ExprUtils.cpp
+  ExprV2.cpp
   FieldReference.cpp
   FunctionCallToSpecialForm.cpp
   GenericWriter.cpp
@@ -85,16 +89,22 @@ velox_add_library(
   ConjunctExpr.h
   ConjunctRewrite.h
   ConstantExpr.h
+  DebugGuards.h
   DecodedArgs.h
   EvalCtx.h
+  EvalFrame.h
   Expr.h
   ExprCompiler.h
   ExprConstants.h
+  ExprEvaluatorV2.h
   ExprOptimizer.h
   ExprRewriteRegistry.h
+  ExprRuntimeState.h
+  ExprSetV2.h
   ExprStats.h
   ExprToSubfieldFilter.h
   ExprUtils.h
+  ExprV2.h
   FieldReference.h
   FunctionCallToSpecialForm.h
   KindToSimpleType.h

--- a/velox/expression/DebugGuards.h
+++ b/velox/expression/DebugGuards.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/EvalFrame.h"
+
+namespace facebook::velox::exec {
+
+#ifndef NDEBUG
+
+/// Verifies row-space invariants across one phase scope:
+///   - remainingRows is a subset of originalRows on exit.
+///   - remainingRows.countSelected() never increased during the scope.
+/// Install at the top of any pipeline function that may shrink (or
+/// recurse with) remainingRows.
+class DebugRemainingRowsGuard {
+ public:
+  explicit DebugRemainingRowsGuard(const EvalFrame& frame)
+      : frame_{frame},
+        countOnEntry_{frame.remainingRows.rows().countSelected()} {}
+
+  ~DebugRemainingRowsGuard() {
+    VELOX_DCHECK(frame_.remainingRows.rows().isSubset(frame_.originalRows));
+    VELOX_DCHECK_LE(
+        frame_.remainingRows.rows().countSelected(), countOnEntry_);
+  }
+
+ private:
+  const EvalFrame& frame_;
+  vector_size_t countOnEntry_;
+};
+
+/// Verifies frame-wide invariants across one top-level evaluate() call:
+///   - inputValues empty on entry and exit (releaseGuard fired).
+///   - result type matches expr type.
+///   - result vector sized to at least originalRows.end().
+/// Install once at the top of ExprEvaluatorV2::evaluateFrame().
+class DebugEvaluateGuard {
+ public:
+  explicit DebugEvaluateGuard(const EvalFrame& frame) : frame_{frame} {
+    VELOX_DCHECK(frame.inputValues.empty());
+  }
+
+  ~DebugEvaluateGuard() {
+    VELOX_DCHECK(frame_.inputValues.empty());
+    if (frame_.result != nullptr) {
+      VELOX_DCHECK(
+          frame_.result->type()->equivalent(*frame_.expr.type()));
+      VELOX_DCHECK_GE(
+          static_cast<vector_size_t>(frame_.result->size()),
+          frame_.originalRows.end());
+    }
+  }
+
+ private:
+  const EvalFrame& frame_;
+};
+
+#else
+
+class DebugRemainingRowsGuard {
+ public:
+  explicit DebugRemainingRowsGuard(const EvalFrame&) {}
+};
+
+class DebugEvaluateGuard {
+ public:
+  explicit DebugEvaluateGuard(const EvalFrame&) {}
+};
+
+#endif // NDEBUG
+
+} // namespace facebook::velox::exec

--- a/velox/expression/EvalFrame.h
+++ b/velox/expression/EvalFrame.h
@@ -20,12 +20,11 @@
 
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/ExprRuntimeState.h"
 #include "velox/expression/ExprV2.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::exec {
-
-struct ExprRuntimeState;
 
 /// Per-call evaluation state for one ExprV2 node.  Lives on the stack of
 /// the outermost ExprEvaluatorV2::evaluate() call.  Inner recursion
@@ -43,12 +42,13 @@ struct ExprRuntimeState;
 struct EvalFrame {
   EvalFrame(
       ExprV2& exprIn,
-      ExprRuntimeState& nodeRuntimeIn,
+      ExprRuntimeStateTree& runtimeStatesIn,
       EvalCtx& ctxIn,
       const SelectivityVector& rowsIn,
       VectorPtr& resultIn)
       : expr{exprIn},
-        nodeRuntime{nodeRuntimeIn},
+        runtimeStates{runtimeStatesIn},
+        nodeRuntime{runtimeStatesIn.at(exprIn)},
         ctx{ctxIn},
         originalRows{rowsIn},
         result{resultIn},
@@ -64,6 +64,11 @@ struct EvalFrame {
   // === Bindings (constant after construction) ===
 
   ExprV2& expr;
+  // Tree-wide runtime state.  Used to look up runtime state for child
+  // nodes when constructing inner frames.
+  ExprRuntimeStateTree& runtimeStates;
+  // Cached lookup: runtime state for 'expr'.  Avoids per-phase map
+  // lookups via runtimeStates.
   ExprRuntimeState& nodeRuntime;
   EvalCtx& ctx;
   const SelectivityVector& originalRows;

--- a/velox/expression/EvalFrame.h
+++ b/velox/expression/EvalFrame.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprV2.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec {
+
+struct ExprRuntimeState;
+
+/// Per-call evaluation state for one ExprV2 node.  Lives on the stack of
+/// the outermost ExprEvaluatorV2::evaluate() call.  Inner recursion
+/// (peeling, null-pruning wrapper, shared-subexpr wrapper) constructs
+/// fresh EvalFrames.
+///
+/// Row-space invariant:
+///   - originalRows never changes after construction.
+///   - remainingRows.rows() is always a subset of originalRows.
+///   - Every phase operates on remainingRows.rows(), not originalRows.
+///   - remainingRows shrinks monotonically as evaluation proceeds; it
+///     never grows.
+///   - originalRows is used only for result sizing, final null-fill,
+///     and copying / wrapping back into the caller's row space.
+struct EvalFrame {
+  EvalFrame(
+      ExprV2& exprIn,
+      ExprRuntimeState& nodeRuntimeIn,
+      EvalCtx& ctxIn,
+      const SelectivityVector& rowsIn,
+      VectorPtr& resultIn)
+      : expr{exprIn},
+        nodeRuntime{nodeRuntimeIn},
+        ctx{ctxIn},
+        originalRows{rowsIn},
+        result{resultIn},
+        remainingRows{rowsIn, ctxIn},
+        tryPeelArgs{exprIn.deterministic()},
+        defaultNulls{exprIn.metadata().defaultNullBehavior},
+        propagatesNulls{exprIn.propagatesNulls()},
+        deterministic{exprIn.deterministic()},
+        isSpecialForm{exprIn.isSpecialForm()},
+        supportsFlatNoNullsFastPath{exprIn.supportsFlatNoNullsFastPath()},
+        hasConditionals{exprIn.hasConditionals()} {}
+
+  // === Bindings (constant after construction) ===
+
+  ExprV2& expr;
+  ExprRuntimeState& nodeRuntime;
+  EvalCtx& ctx;
+  const SelectivityVector& originalRows;
+  VectorPtr& result;
+
+  // === Mutable state flowing between phases ===
+
+  MutableRemainingRows remainingRows;
+
+  // Evaluated child results, populated by ArgEval.  Moved off ExprV2;
+  // lives on the frame so the same ExprV2 can be evaluated concurrently.
+  std::vector<VectorPtr> inputValues;
+
+  // Running conjunction tracked by ArgEval: are all evaluated child
+  // encodings peelable?  Initialized from expr.deterministic(); cleared
+  // when ArgEval sees a non-peelable encoding.
+  bool tryPeelArgs;
+
+  // === Compile-time flags cached once from expr ===
+
+  bool defaultNulls;
+  bool propagatesNulls;
+  bool deterministic;
+  bool isSpecialForm;
+  bool supportsFlatNoNullsFastPath;
+  bool hasConditionals;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -390,6 +390,13 @@ class Expr {
     return distinctFields_;
   }
 
+  /// Subset of distinctFields() that are referenced by more than one
+  /// input subtree.  Used by the ExprV2 adapter and by lazy-loading
+  /// decisions; exposed publicly for those consumers.
+  const std::unordered_set<FieldReference*>& multiplyReferencedFields() const {
+    return multiplyReferencedFields_;
+  }
+
   static bool isSameFields(
       const std::vector<FieldReference*>& fields1,
       const std::vector<FieldReference*>& fields2);
@@ -443,6 +450,19 @@ class Expr {
 
   const VectorFunctionMetadata& vectorFunctionMetadata() const {
     return vectorFunctionMetadata_;
+  }
+
+  /// Listeners invoked around vectorFunction_->apply().  Empty for
+  /// special-form nodes.  Exposed for the ExprV2 adapter.
+  const std::vector<VectorFunctionListeners>& listeners() const {
+    return listeners_;
+  }
+
+  /// True if this expression should always track CPU usage (set at
+  /// compile time from query config).  Distinct from adaptive
+  /// sampling, which is decided at runtime.
+  bool trackCpuUsage() const {
+    return trackCpuUsage_;
   }
 
   std::vector<VectorPtr>& inputValues() {

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -16,55 +16,152 @@
 
 #include "velox/expression/ExprEvaluatorV2.h"
 
+#include <folly/ScopeGuard.h>
+
 #include "velox/common/base/Exceptions.h"
+#include "velox/expression/DebugGuards.h"
 
 namespace facebook::velox::exec {
 
-// Pipeline implementation lands incrementally across steps 4-10.  For
-// now every entry point is a no-op stub that fails loudly if reached.
+namespace {
 
-void ExprEvaluatorV2::evaluate(
-    EvalFrame& /*frame*/,
-    const ExprSetV2* /*parentSet*/) {
-  VELOX_NYI("ExprEvaluatorV2::evaluate lands in step 4 of the refactor.");
+void emitNullConstant(
+    const TypePtr& type,
+    memory::MemoryPool* pool,
+    VectorPtr& result) {
+  if (result == nullptr) {
+    result = BaseVector::createNullConstant(type, 0, pool);
+  }
+}
+
+} // namespace
+
+void ExprEvaluatorV2::evaluate(EvalFrame& frame, const ExprSetV2* parentSet) {
+  evaluateFrame(frame, parentSet);
 }
 
 void ExprEvaluatorV2::evaluateFrame(
-    EvalFrame& /*f*/,
+    EvalFrame& f,
     const ExprSetV2* /*parentSet*/) {
-  VELOX_NYI();
+  DebugEvaluateGuard outerGuard{f};
+
+  // Fast path: delegate to V1's evalFlatNoNulls.  Gated identically to
+  // V1's eval() (see Expr.cpp:821).  Bit-identical to V1 by
+  // construction.
+  if (f.supportsFlatNoNullsFastPath && f.ctx.throwOnError() &&
+      f.ctx.inputFlatNoNulls() &&
+      f.ctx.execCtx()->queryCtx()->queryConfig().exprEvalFlatNoNulls()) {
+    f.expr.sourceExpr()->evalFlatNoNulls(
+        f.originalRows, f.ctx, f.result, /*parentExprSet=*/nullptr);
+    return;
+  }
+
+  // TODO(step 10): install ExprExceptionContext / ExceptionContextSetter
+  // here.  Skipped during step 4 because exception-context wiring
+  // requires the V2 equivalent of Expr::onException, which lands later.
+
+  if (!f.originalRows.hasSelections()) {
+    emitEmpty(f);
+    return;
+  }
+
+  // TODO(step 5+): port the lazy-loading decision tree from
+  // Expr::eval() (lines 868-887).  For step 4 the A/B harness only
+  // covers expressions with no lazy inputs, so lazy loading is a no-op.
+
+  if (f.expr.inputs().empty()) {
+    evaluateNodeBody(f);
+    return;
+  }
+
+  evaluateWithFieldPeeling(f);
 }
 
-void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& /*f*/) {
-  VELOX_NYI("Field peeling lands in step 5.");
+void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  // TODO(step 5): port FieldPeeling::tryPeel from Expr::evalEncodings.
+  // For step 4 this layer is a pass-through.
+  evaluateWithNullPruning(f);
 }
 
-void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& /*f*/) {
-  VELOX_NYI("Null pruning lands in step 7.");
+void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  // TODO(step 7): port NullPruning::tryPrune from Expr::evalWithNulls.
+  // For step 4 this layer is a pass-through.
+  evaluateWithSharedSubexpr(f);
 }
 
-void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& /*f*/) {
-  VELOX_NYI("Shared-subexpr cache lands in step 8.");
+void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  // TODO(step 8): port SharedSubexprCache::tryReuse from
+  // Expr::evaluateSharedSubexpr.  For step 4 this layer is a
+  // pass-through.
+  evaluateNodeBody(f);
 }
 
-void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& /*f*/) {
-  VELOX_NYI();
+void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& f) {
+  if (f.isSpecialForm) {
+    evaluateSpecialForm(f);
+    return;
+  }
+  evaluateFunctionCall(f);
 }
 
-void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& /*f*/) {
-  VELOX_NYI("Function-call leaf lands in step 4 / 9 / 10.");
+void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  auto releaseGuard = folly::makeGuard([&]() {
+    f.ctx.releaseVectors(f.inputValues);
+    f.inputValues.clear();
+  });
+
+  // TODO(step 9): port ArgEval::evaluate (default-null vs
+  // preserve-null strategies, error swapping).  For step 4 the
+  // harness restricts to expressions with no-null inputs, where
+  // preserve-null and default-null are equivalent.
+  f.inputValues.resize(f.expr.inputs().size());
+  for (size_t i = 0; i < f.expr.inputs().size(); ++i) {
+    auto& childExpr = *f.expr.inputs()[i];
+    EvalFrame childFrame{
+        childExpr,
+        f.runtimeStates,
+        f.ctx,
+        f.remainingRows.rows(),
+        f.inputValues[i]};
+    evaluate(childFrame, /*parentSet=*/nullptr);
+  }
+
+  // TODO(step 5): port ArgPeeling::tryApply.  For step 4 we always
+  // apply on un-peeled args.
+  applyFunction(f);
+
+  // TODO(step 9): write nulls for any rows that ArgEval pruned.  For
+  // step 4 ArgEval never prunes, so remainingRows.hasChanged() is
+  // always false.
+  VELOX_DCHECK(!f.remainingRows.hasChanged());
 }
 
-void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& /*f*/) {
-  VELOX_NYI("Special-form delegation lands in step 4.");
+void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {
+  DebugRemainingRowsGuard guard{f};
+  // Delegate to the V1 Expr's evalSpecialForm.  Migration of each
+  // special form to a native V2 implementation happens in step 12.
+  f.expr.sourceExpr()->evalSpecialForm(
+      f.remainingRows.rows(), f.ctx, f.result);
 }
 
-void ExprEvaluatorV2::applyFunction(EvalFrame& /*f*/) {
-  VELOX_NYI();
+void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
+  // TODO(step 10): port listener invocation, CPU timing, adaptive
+  // sampling, tracer hooks.  Step 4 invokes the bare function.
+  VELOX_CHECK_NOT_NULL(f.expr.vectorFunction());
+  f.expr.vectorFunction()->apply(
+      f.remainingRows.rows(),
+      f.inputValues,
+      f.expr.type(),
+      f.ctx,
+      f.result);
 }
 
-void ExprEvaluatorV2::emitEmpty(EvalFrame& /*f*/) {
-  VELOX_NYI();
+void ExprEvaluatorV2::emitEmpty(EvalFrame& f) {
+  emitNullConstant(f.expr.type(), f.ctx.pool(), f.result);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprEvaluatorV2.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec {
+
+// Pipeline implementation lands incrementally across steps 4-10.  For
+// now every entry point is a no-op stub that fails loudly if reached.
+
+void ExprEvaluatorV2::evaluate(
+    EvalFrame& /*frame*/,
+    const ExprSetV2* /*parentSet*/) {
+  VELOX_NYI("ExprEvaluatorV2::evaluate lands in step 4 of the refactor.");
+}
+
+void ExprEvaluatorV2::evaluateFrame(
+    EvalFrame& /*f*/,
+    const ExprSetV2* /*parentSet*/) {
+  VELOX_NYI();
+}
+
+void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& /*f*/) {
+  VELOX_NYI("Field peeling lands in step 5.");
+}
+
+void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& /*f*/) {
+  VELOX_NYI("Null pruning lands in step 7.");
+}
+
+void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& /*f*/) {
+  VELOX_NYI("Shared-subexpr cache lands in step 8.");
+}
+
+void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& /*f*/) {
+  VELOX_NYI();
+}
+
+void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& /*f*/) {
+  VELOX_NYI("Function-call leaf lands in step 4 / 9 / 10.");
+}
+
+void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& /*f*/) {
+  VELOX_NYI("Special-form delegation lands in step 4.");
+}
+
+void ExprEvaluatorV2::applyFunction(EvalFrame& /*f*/) {
+  VELOX_NYI();
+}
+
+void ExprEvaluatorV2::emitEmpty(EvalFrame& /*f*/) {
+  VELOX_NYI();
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprEvaluatorV2.h
+++ b/velox/expression/ExprEvaluatorV2.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/EvalFrame.h"
+
+namespace facebook::velox::exec {
+
+class ExprSetV2;
+
+/// Drives the staged evaluation pipeline against an EvalFrame.  Owns no
+/// state; all per-call state lives on the frame, all cross-call state
+/// lives in ExprRuntimeState.  Safe to share across threads.
+///
+/// Pipeline order matches V1 semantics exactly:
+///
+///   evaluateFrame                  entry guards
+///     evaluateWithFieldPeeling     field peeling wrapper
+///       evaluateWithNullPruning    null pruning wrapper
+///         evaluateWithSharedSubexpr shared subexpr wrapper
+///           evaluateNodeBody       special-form vs function-call fork
+///             evaluateSpecialForm  (delegates to legacy Expr)
+///             evaluateFunctionCall arg eval + arg peeling + apply
+class ExprEvaluatorV2 {
+ public:
+  /// Public entry point.  Drives the pipeline against 'frame'.
+  /// 'parentSet' is forwarded to the top-level exception scope; null
+  /// for nested/non-top-level calls.
+  void evaluate(EvalFrame& frame, const ExprSetV2* parentSet);
+
+ private:
+  // Pipeline phases.  Each name describes what wrapper or fork this
+  // layer owns, not what the previous layer did.
+  void evaluateFrame(EvalFrame& f, const ExprSetV2* parentSet);
+  void evaluateWithFieldPeeling(EvalFrame& f);
+  void evaluateWithNullPruning(EvalFrame& f);
+  void evaluateWithSharedSubexpr(EvalFrame& f);
+  void evaluateNodeBody(EvalFrame& f);
+  void evaluateFunctionCall(EvalFrame& f);
+  void evaluateSpecialForm(EvalFrame& f);
+
+  // Leaf operations.
+  void applyFunction(EvalFrame& f);
+  void emitEmpty(EvalFrame& f);
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprRuntimeState.cpp
+++ b/velox/expression/ExprRuntimeState.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprRuntimeState.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/ExprV2.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+
+void collect(
+    const ExprV2& node,
+    folly::F14FastMap<const ExprV2*, size_t>& indexByNode) {
+  if (indexByNode.contains(&node)) {
+    return;
+  }
+  indexByNode.emplace(&node, indexByNode.size());
+  for (const auto& child : node.inputs()) {
+    if (child != nullptr) {
+      collect(*child, indexByNode);
+    }
+  }
+}
+
+} // namespace
+
+ExprRuntimeStateTree::ExprRuntimeStateTree(const ExprV2& root) {
+  collect(root, indexByNode_);
+  states_.resize(indexByNode_.size());
+}
+
+ExprRuntimeState& ExprRuntimeStateTree::at(const ExprV2& node) {
+  auto it = indexByNode_.find(&node);
+  VELOX_CHECK(
+      it != indexByNode_.end(),
+      "ExprV2 node not in this ExprRuntimeStateTree");
+  return states_[it->second];
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprRuntimeState.cpp
+++ b/velox/expression/ExprRuntimeState.cpp
@@ -39,8 +39,13 @@ void collect(
 
 } // namespace
 
-ExprRuntimeStateTree::ExprRuntimeStateTree(const ExprV2& root) {
-  collect(root, indexByNode_);
+ExprRuntimeStateTree::ExprRuntimeStateTree(
+    const std::vector<std::shared_ptr<ExprV2>>& roots) {
+  for (const auto& root : roots) {
+    if (root != nullptr) {
+      collect(*root, indexByNode_);
+    }
+  }
   states_.resize(indexByNode_.size());
 }
 

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+
+#include "velox/expression/ExprStats.h"
+
+namespace facebook::velox::exec {
+
+class ExprV2;
+
+/// Placeholder for shared-subexpression cache state.  Populated in step 8.
+struct SharedSubexprCacheState {};
+
+/// Placeholder for dictionary memoization state.  Populated in step 6.
+struct DictionaryMemoState {};
+
+/// Placeholder for adaptive CPU sampling state.  Populated in step 10.
+struct AdaptiveSamplingState {};
+
+/// Mutable per-Expr state that survives across evaluations.  One instance
+/// per ExprV2 per ExprSetV2.  Not thread-safe: concurrent evaluations of
+/// the same ExprSetV2 either need separate ExprRuntimeStateTrees or must
+/// guard a shared one with a mutex.  Decision deferred until M3.
+struct ExprRuntimeState {
+  SharedSubexprCacheState sharedCache;
+  DictionaryMemoState dictMemo;
+  ExprStats stats;
+  AdaptiveSamplingState adaptiveState;
+};
+
+/// Tree of runtime state parallel-indexed with an ExprV2 tree.  Look up
+/// runtime state for a node by pointer.  Implementation uses a flat
+/// vector for cache friendliness; lookups go through indexByNode_.
+class ExprRuntimeStateTree {
+ public:
+  /// Builds a runtime-state tree mirroring the shape of the ExprV2 tree
+  /// rooted at 'root'.  Each node in the tree gets one ExprRuntimeState.
+  explicit ExprRuntimeStateTree(const ExprV2& root);
+
+  /// Returns the runtime state for 'node'.  'node' must be a member of
+  /// the tree this object was built from.
+  ExprRuntimeState& at(const ExprV2& node);
+
+ private:
+  std::vector<ExprRuntimeState> states_;
+  folly::F14FastMap<const ExprV2*, size_t> indexByNode_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -47,18 +47,28 @@ struct ExprRuntimeState {
   AdaptiveSamplingState adaptiveState;
 };
 
-/// Tree of runtime state parallel-indexed with an ExprV2 tree.  Look up
-/// runtime state for a node by pointer.  Implementation uses a flat
-/// vector for cache friendliness; lookups go through indexByNode_.
+/// Tree of runtime state parallel-indexed with an ExprV2 forest.  Look
+/// up runtime state for a node by pointer.  Backed by a flat vector
+/// for cache friendliness; lookups go through indexByNode_.
+///
+/// Built from the roots of an ExprSetV2.  Nodes shared between roots
+/// (e.g. CSE subtrees) appear once in the tree and share state.
 class ExprRuntimeStateTree {
  public:
-  /// Builds a runtime-state tree mirroring the shape of the ExprV2 tree
-  /// rooted at 'root'.  Each node in the tree gets one ExprRuntimeState.
-  explicit ExprRuntimeStateTree(const ExprV2& root);
+  /// Builds a runtime-state tree covering 'roots' and all their
+  /// reachable descendants.  Each unique ExprV2 node gets exactly one
+  /// ExprRuntimeState.
+  explicit ExprRuntimeStateTree(
+      const std::vector<std::shared_ptr<ExprV2>>& roots);
 
-  /// Returns the runtime state for 'node'.  'node' must be a member of
-  /// the tree this object was built from.
+  /// Returns the runtime state for 'node'.  'node' must be reachable
+  /// from one of the roots this tree was built from.
   ExprRuntimeState& at(const ExprV2& node);
+
+  /// Number of nodes covered by this tree.
+  size_t size() const {
+    return states_.size();
+  }
 
  private:
   std::vector<ExprRuntimeState> states_;

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprSetV2.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec {
+
+ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> /*source*/) {
+  VELOX_NYI("ExprSetV2 construction lands in step 3 of the refactor.");
+}
+
+void ExprSetV2::eval(
+    const SelectivityVector& /*rows*/,
+    EvalCtx& /*ctx*/,
+    std::vector<VectorPtr>& /*results*/) {
+  VELOX_NYI("ExprSetV2::eval lands in step 4 of the refactor.");
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -34,10 +34,18 @@ ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> source)
 }
 
 void ExprSetV2::eval(
-    const SelectivityVector& /*rows*/,
-    EvalCtx& /*ctx*/,
-    std::vector<VectorPtr>& /*results*/) {
-  VELOX_NYI("ExprSetV2::eval lands in step 4 of the refactor.");
+    const SelectivityVector& rows,
+    EvalCtx& ctx,
+    std::vector<VectorPtr>& results) {
+  VELOX_CHECK_EQ(
+      results.size(),
+      roots_.size(),
+      "results vector must be sized to the number of expression roots");
+
+  for (size_t i = 0; i < roots_.size(); ++i) {
+    EvalFrame frame{*roots_[i], *runtimeStates_, ctx, rows, results[i]};
+    evaluator_.evaluate(frame, this);
+  }
 }
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -17,11 +17,20 @@
 #include "velox/expression/ExprSetV2.h"
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/expression/Expr.h"
 
 namespace facebook::velox::exec {
 
-ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> /*source*/) {
-  VELOX_NYI("ExprSetV2 construction lands in step 3 of the refactor.");
+ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> source)
+    : sourceSet_{std::move(source)} {
+  VELOX_CHECK_NOT_NULL(sourceSet_, "ExprSetV2 requires a non-null ExprSet");
+
+  roots_.reserve(sourceSet_->exprs().size());
+  for (const auto& root : sourceSet_->exprs()) {
+    roots_.push_back(ExprV2::from(root));
+  }
+
+  runtimeStates_ = std::make_unique<ExprRuntimeStateTree>(roots_);
 }
 
 void ExprSetV2::eval(

--- a/velox/expression/ExprSetV2.h
+++ b/velox/expression/ExprSetV2.h
@@ -56,6 +56,13 @@ class ExprSetV2 {
     return *runtimeStates_;
   }
 
+  /// The V1 ExprSet this V2 set was adapted from.  During the migration
+  /// period, callers pass this to EvalCtx so it can route exception
+  /// context, memo updates, and tracer hooks through V1's bookkeeping.
+  const std::shared_ptr<ExprSet>& sourceSet() const {
+    return sourceSet_;
+  }
+
  private:
   std::shared_ptr<ExprSet> sourceSet_;
   std::vector<std::shared_ptr<ExprV2>> roots_;

--- a/velox/expression/ExprSetV2.h
+++ b/velox/expression/ExprSetV2.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "velox/expression/ExprEvaluatorV2.h"
+#include "velox/expression/ExprRuntimeState.h"
+#include "velox/expression/ExprV2.h"
+
+namespace facebook::velox::exec {
+
+class ExprSet;
+
+/// Owner of a tree of immutable ExprV2 nodes plus the parallel runtime
+/// state tree and the stateless evaluator.  Mirrors ExprSet's public
+/// shape but routes evaluation through the V2 pipeline.
+///
+/// During the migration period, ExprSetV2 is constructed from an
+/// existing ExprSet (which already holds compiled Expr trees).  This
+/// avoids duplicating any compiler, parser, or registry logic.
+class ExprSetV2 {
+ public:
+  /// Adapts an existing compiled ExprSet to V2 by walking each root
+  /// Expr and producing a parallel ExprV2 tree.  The source ExprSet is
+  /// retained for lifetime of FieldReference pointers and for
+  /// delegated special-form evaluation.
+  explicit ExprSetV2(std::shared_ptr<ExprSet> source);
+
+  /// Evaluates all roots for 'rows' and writes outputs into 'results'.
+  void eval(
+      const SelectivityVector& rows,
+      EvalCtx& ctx,
+      std::vector<VectorPtr>& results);
+
+  const std::vector<std::shared_ptr<ExprV2>>& exprs() const {
+    return roots_;
+  }
+
+  ExprRuntimeStateTree& runtimeStates() {
+    return *runtimeStates_;
+  }
+
+ private:
+  std::shared_ptr<ExprSet> sourceSet_;
+  std::vector<std::shared_ptr<ExprV2>> roots_;
+  std::unique_ptr<ExprRuntimeStateTree> runtimeStates_;
+  ExprEvaluatorV2 evaluator_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprV2.cpp
+++ b/velox/expression/ExprV2.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprV2.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec {
+
+// Adapter implementation lands in step 3.  Until then, calling this is a
+// programmer error -- nothing should be constructing ExprV2 yet.
+std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& /*expr*/) {
+  VELOX_NYI("ExprV2::from is implemented in step 3 of the refactor.");
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ExprV2.cpp
+++ b/velox/expression/ExprV2.cpp
@@ -20,10 +20,35 @@
 
 namespace facebook::velox::exec {
 
-// Adapter implementation lands in step 3.  Until then, calling this is a
-// programmer error -- nothing should be constructing ExprV2 yet.
-std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& /*expr*/) {
-  VELOX_NYI("ExprV2::from is implemented in step 3 of the refactor.");
+std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& expr) {
+  VELOX_CHECK_NOT_NULL(expr, "ExprV2::from requires a non-null Expr");
+
+  std::vector<std::shared_ptr<ExprV2>> inputs;
+  inputs.reserve(expr->inputs().size());
+  for (const auto& child : expr->inputs()) {
+    inputs.push_back(ExprV2::from(child));
+  }
+
+  auto node = std::shared_ptr<ExprV2>(new ExprV2());
+  node->type_ = expr->type();
+  node->name_ = expr->name();
+  node->inputs_ = std::move(inputs);
+  node->vectorFunction_ = expr->vectorFunction();
+  node->metadata_ = expr->vectorFunctionMetadata();
+  node->listeners_ = expr->listeners();
+  if (expr->isSpecialForm()) {
+    node->specialFormKind_ = expr->specialFormKind();
+  }
+  node->deterministic_ = expr->isDeterministic();
+  node->propagatesNulls_ = expr->propagatesNulls();
+  node->supportsFlatNoNullsFastPath_ = expr->supportsFlatNoNullsFastPath();
+  node->hasConditionals_ = expr->hasConditionals();
+  node->trackCpuUsage_ = expr->trackCpuUsage();
+  node->distinctFields_ = expr->distinctFields();
+  node->multiplyReferencedFields_ = expr->multiplyReferencedFields();
+  node->sourceExpr_ = expr;
+
+  return node;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprV2.h
+++ b/velox/expression/ExprV2.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "velox/expression/Expr.h"
+#include "velox/expression/FunctionMetadata.h"
+#include "velox/expression/VectorFunctionListener.h"
+
+namespace facebook::velox::exec {
+
+class FieldReference;
+class VectorFunction;
+
+/// Immutable expression-tree node used by the V2 evaluator.
+///
+/// All fields are set at construction (from a compiled Expr via
+/// ExprV2::from()) and never mutated during evaluation.  Safe to share
+/// across threads.
+///
+/// Per-call evaluation state lives on EvalFrame.  Per-Expr cross-call
+/// state (memo, shared-subexpr cache, stats) lives on ExprRuntimeState,
+/// owned by ExprSetV2.
+///
+/// During the migration period, every ExprV2 holds a shared_ptr to the
+/// V1 Expr it was adapted from.  For special-form nodes, evaluation
+/// delegates to that Expr's evalSpecialForm().  For function-call nodes,
+/// the V1 Expr is kept alive only to ensure raw FieldReference* pointers
+/// in distinctFields_ remain valid.
+class ExprV2 {
+ public:
+  /// Builds a V2 tree from a compiled V1 Expr.  Recursively converts
+  /// children.
+  static std::shared_ptr<ExprV2> from(const std::shared_ptr<Expr>& expr);
+
+  const TypePtr& type() const {
+    return type_;
+  }
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  const std::vector<std::shared_ptr<ExprV2>>& inputs() const {
+    return inputs_;
+  }
+
+  /// Returns null for special-form nodes.  Function-call nodes return
+  /// the VectorFunction to invoke during applyFunction().
+  const std::shared_ptr<VectorFunction>& vectorFunction() const {
+    return vectorFunction_;
+  }
+
+  const VectorFunctionMetadata& metadata() const {
+    return metadata_;
+  }
+
+  const std::vector<VectorFunctionListeners>& listeners() const {
+    return listeners_;
+  }
+
+  bool isSpecialForm() const {
+    return specialFormKind_.has_value();
+  }
+
+  std::optional<SpecialFormKind> specialFormKind() const {
+    return specialFormKind_;
+  }
+
+  bool deterministic() const {
+    return deterministic_;
+  }
+
+  bool propagatesNulls() const {
+    return propagatesNulls_;
+  }
+
+  bool supportsFlatNoNullsFastPath() const {
+    return supportsFlatNoNullsFastPath_;
+  }
+
+  bool hasConditionals() const {
+    return hasConditionals_;
+  }
+
+  bool trackCpuUsage() const {
+    return trackCpuUsage_;
+  }
+
+  const std::vector<FieldReference*>& distinctFields() const {
+    return distinctFields_;
+  }
+
+  const std::unordered_set<FieldReference*>& multiplyReferencedFields() const {
+    return multiplyReferencedFields_;
+  }
+
+  /// The V1 Expr this node was adapted from.  Always non-null.  Kept
+  /// alive to ensure raw FieldReference* pointers remain valid and to
+  /// support delegated evaluation of special forms during the migration.
+  const std::shared_ptr<Expr>& sourceExpr() const {
+    return sourceExpr_;
+  }
+
+ private:
+  ExprV2() = default;
+
+  TypePtr type_;
+  std::string name_;
+  std::vector<std::shared_ptr<ExprV2>> inputs_;
+
+  // Null for special-form nodes.
+  std::shared_ptr<VectorFunction> vectorFunction_;
+  VectorFunctionMetadata metadata_;
+  std::vector<VectorFunctionListeners> listeners_;
+
+  std::optional<SpecialFormKind> specialFormKind_;
+
+  // Compile-time metadata copied from sourceExpr_ at construction.
+  bool deterministic_{true};
+  bool propagatesNulls_{false};
+  bool supportsFlatNoNullsFastPath_{false};
+  bool hasConditionals_{false};
+  bool trackCpuUsage_{false};
+
+  // Raw pointers into the V1 tree owned by sourceExpr_.  Valid as long
+  // as sourceExpr_ is held.
+  std::vector<FieldReference*> distinctFields_;
+  std::unordered_set<FieldReference*> multiplyReferencedFields_;
+
+  // Owning reference to the V1 Expr this V2 node was built from.  Kept
+  // alive for the lifetime of this ExprV2.
+  std::shared_ptr<Expr> sourceExpr_;
+
+  friend class ExprV2Builder;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
   ExprTest.cpp
   ExprToSubfieldFilterTest.cpp
   ExprV2AdapterTest.cpp
+  ExprV2ParityTest.cpp
   EvalCtxTest.cpp
   EvalErrorsTest.cpp
   EvalSimplifiedTest.cpp

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   ExprStatsTest.cpp
   ExprTest.cpp
   ExprToSubfieldFilterTest.cpp
+  ExprV2AdapterTest.cpp
   EvalCtxTest.cpp
   EvalErrorsTest.cpp
   EvalSimplifiedTest.cpp

--- a/velox/expression/tests/ExprV2AdapterTest.cpp
+++ b/velox/expression/tests/ExprV2AdapterTest.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ExprV2.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/core/Expressions.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprRuntimeState.h"
+#include "velox/expression/ExprSetV2.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class ExprV2AdapterTest : public testing::Test,
+                          public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
+  }
+
+  core::TypedExprPtr parseExpression(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr(text);
+    return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
+  }
+
+  std::shared_ptr<ExprSet> compile(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    return std::make_shared<ExprSet>(
+        std::vector<core::TypedExprPtr>{parseExpression(text, rowType)},
+        execCtx_.get());
+  }
+
+  std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
+  parse::ParseOptions options_;
+};
+
+// Adapter must produce a tree of the same shape as the source Expr,
+// with every node populated and sourceExpr pointing back to the source.
+TEST_F(ExprV2AdapterTest, functionCallShape) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  auto exprSet = compile("a + b * 2::bigint", rowType);
+  const auto& root = exprSet->exprs().front();
+
+  auto v2 = ExprV2::from(root);
+  ASSERT_NE(v2, nullptr);
+
+  // Root: plus(a, multiply(b, 2)).
+  EXPECT_EQ(v2->type()->toString(), root->type()->toString());
+  EXPECT_EQ(v2->name(), root->name());
+  EXPECT_EQ(v2->inputs().size(), root->inputs().size());
+  EXPECT_FALSE(v2->isSpecialForm());
+  EXPECT_EQ(v2->deterministic(), root->isDeterministic());
+  EXPECT_EQ(v2->propagatesNulls(), root->propagatesNulls());
+  EXPECT_EQ(
+      v2->supportsFlatNoNullsFastPath(), root->supportsFlatNoNullsFastPath());
+  EXPECT_EQ(v2->hasConditionals(), root->hasConditionals());
+  EXPECT_EQ(v2->sourceExpr().get(), root.get());
+
+  // Function pointer and metadata round-trip.
+  EXPECT_EQ(v2->vectorFunction().get(), root->vectorFunction().get());
+  EXPECT_EQ(
+      v2->metadata().defaultNullBehavior,
+      root->vectorFunctionMetadata().defaultNullBehavior);
+
+  // Recurse into children and verify the same.
+  for (size_t i = 0; i < v2->inputs().size(); ++i) {
+    const auto& childV2 = v2->inputs()[i];
+    const auto& childV1 = root->inputs()[i];
+    EXPECT_EQ(childV2->sourceExpr().get(), childV1.get());
+    EXPECT_EQ(childV2->inputs().size(), childV1->inputs().size());
+    EXPECT_EQ(childV2->name(), childV1->name());
+  }
+}
+
+// Adapter must tag special-form nodes with their SpecialFormKind.
+TEST_F(ExprV2AdapterTest, specialFormTag) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  // Switch is a special form.
+  auto exprSet = compile("case when a > 0 then b else 0::bigint end", rowType);
+  const auto& root = exprSet->exprs().front();
+
+  auto v2 = ExprV2::from(root);
+
+  EXPECT_TRUE(v2->isSpecialForm());
+  EXPECT_EQ(v2->specialFormKind(), root->specialFormKind());
+
+  // Special-form nodes still retain sourceExpr for delegation.
+  EXPECT_EQ(v2->sourceExpr().get(), root.get());
+}
+
+// distinctFields and multiplyReferencedFields raw pointers must remain
+// valid after adaptation -- they still point into the V1 tree, which
+// is kept alive via sourceExpr.
+TEST_F(ExprV2AdapterTest, fieldReferencePointersPreserved) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  auto exprSet = compile("a + a + b", rowType);
+  const auto& root = exprSet->exprs().front();
+
+  auto v2 = ExprV2::from(root);
+
+  EXPECT_EQ(v2->distinctFields().size(), root->distinctFields().size());
+  for (size_t i = 0; i < v2->distinctFields().size(); ++i) {
+    // Raw pointers should be bit-identical to the V1 set.
+    EXPECT_EQ(v2->distinctFields()[i], root->distinctFields()[i]);
+  }
+  EXPECT_EQ(
+      v2->multiplyReferencedFields().size(),
+      root->multiplyReferencedFields().size());
+}
+
+// ExprSetV2 should adapt every root from the source ExprSet and build a
+// runtime-state tree covering all unique nodes.
+TEST_F(ExprV2AdapterTest, exprSetV2Construction) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  parse::ParseOptions options;
+  std::vector<core::TypedExprPtr> typed{
+      parseExpression("a + b", rowType),
+      parseExpression("a * b", rowType),
+  };
+  auto exprSet = std::make_shared<ExprSet>(std::move(typed), execCtx_.get());
+
+  ExprSetV2 v2{exprSet};
+
+  ASSERT_EQ(v2.exprs().size(), 2);
+  EXPECT_EQ(v2.exprs()[0]->sourceExpr().get(), exprSet->exprs()[0].get());
+  EXPECT_EQ(v2.exprs()[1]->sourceExpr().get(), exprSet->exprs()[1].get());
+
+  // Runtime-state tree should cover at least the 2 roots + their unique
+  // descendants.  Each root is binary so total >= 2 (roots) + 4
+  // (FieldReferences) = 6.  Use >= to keep the test robust to minor
+  // tree-shape variation.
+  EXPECT_GE(v2.runtimeStates().size(), 6u);
+
+  // at() returns distinct state instances per node.
+  auto& s0 = v2.runtimeStates().at(*v2.exprs()[0]);
+  auto& s1 = v2.runtimeStates().at(*v2.exprs()[1]);
+  EXPECT_NE(&s0, &s1);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -66,7 +66,7 @@ class ExprV2ParityTest : public testing::Test,
 
     // V2 path -- adapt the same compiled ExprSet.
     ExprSetV2 v2Set{v1Set};
-    EvalCtx v2Ctx{execCtx_.get(), nullptr, input.get()};
+    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
     std::vector<VectorPtr> v2Results(1);
     v2Set.eval(rows, v2Ctx, v2Results);
 
@@ -143,7 +143,7 @@ TEST_F(ExprV2ParityTest, emptyRows) {
   v1Set->eval(rows, v1Ctx, v1Results);
 
   ExprSetV2 v2Set{v1Set};
-  EvalCtx v2Ctx{execCtx_.get(), nullptr, input.get()};
+  EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
   std::vector<VectorPtr> v2Results(1);
   v2Set.eval(rows, v2Ctx, v2Results);
 

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/core/Expressions.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprSetV2.h"
+#include "velox/expression/ExprV2.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+/// Compares V1 (ExprSet) and V2 (ExprSetV2) on a restricted subset of
+/// queries that V2 supports as of step 4: no-null inputs, no lazy
+/// vectors, no shared sub-expressions, no encodings, no special forms
+/// requiring conditional row evaluation.
+class ExprV2ParityTest : public testing::Test,
+                         public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
+  }
+
+  void assertParity(
+      const std::string& exprText,
+      const RowVectorPtr& input) {
+    auto rowType = std::dynamic_pointer_cast<const RowType>(input->type());
+    ASSERT_NE(rowType, nullptr);
+
+    auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr(exprText);
+    auto typed = core::Expressions::inferTypes(
+        untyped, rowType, execCtx_->pool());
+
+    // V1 path.
+    auto v1Set = std::make_shared<ExprSet>(
+        std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
+    SelectivityVector rows{input->size()};
+    EvalCtx v1Ctx{execCtx_.get(), v1Set.get(), input.get()};
+    std::vector<VectorPtr> v1Results(1);
+    v1Set->eval(rows, v1Ctx, v1Results);
+
+    // V2 path -- adapt the same compiled ExprSet.
+    ExprSetV2 v2Set{v1Set};
+    EvalCtx v2Ctx{execCtx_.get(), nullptr, input.get()};
+    std::vector<VectorPtr> v2Results(1);
+    v2Set.eval(rows, v2Ctx, v2Results);
+
+    velox::test::assertEqualVectors(v1Results[0], v2Results[0]);
+  }
+
+  std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
+  parse::ParseOptions options_;
+};
+
+// Bare field reference: a -> a.  Goes through special-form delegation
+// (FieldAccess).
+TEST_F(ExprV2ParityTest, fieldReference) {
+  auto input = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5})});
+  assertParity("a", input);
+}
+
+// Two-arg deterministic function on no-null flat inputs.
+TEST_F(ExprV2ParityTest, simplePlus) {
+  auto input = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<int64_t>({10, 20, 30, 40, 50})});
+  assertParity("a + b", input);
+}
+
+// Nested function calls on no-null flat inputs.
+TEST_F(ExprV2ParityTest, nestedArith) {
+  auto input = makeRowVector(
+      {"a", "b", "c"},
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+       makeFlatVector<int64_t>({100, 200, 300, 400, 500})});
+  assertParity("a + b * c", input);
+}
+
+// Constant inputs in the expression tree (special-form delegation).
+TEST_F(ExprV2ParityTest, constantInExpr) {
+  auto input = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5})});
+  assertParity("a + 100::bigint", input);
+}
+
+// Boolean function on no-null flat inputs.
+TEST_F(ExprV2ParityTest, comparison) {
+  auto input = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>({1, 5, 3, 2, 4}),
+       makeFlatVector<int64_t>({4, 4, 4, 4, 4})});
+  assertParity("a < b", input);
+}
+
+// Empty selectivity vector -- emitEmpty path.
+TEST_F(ExprV2ParityTest, emptyRows) {
+  auto input = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int64_t>({10, 20, 30})});
+  auto rowType = std::dynamic_pointer_cast<const RowType>(input->type());
+  auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr("a + b");
+  auto typed = core::Expressions::inferTypes(
+      untyped, rowType, execCtx_->pool());
+
+  auto v1Set = std::make_shared<ExprSet>(
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
+  SelectivityVector rows{input->size()};
+  rows.clearAll();
+
+  EvalCtx v1Ctx{execCtx_.get(), v1Set.get(), input.get()};
+  std::vector<VectorPtr> v1Results(1);
+  v1Set->eval(rows, v1Ctx, v1Results);
+
+  ExprSetV2 v2Set{v1Set};
+  EvalCtx v2Ctx{execCtx_.get(), nullptr, input.get()};
+  std::vector<VectorPtr> v2Results(1);
+  v2Set.eval(rows, v2Ctx, v2Results);
+
+  // Both should produce a 0-size constant; just check sizes match.
+  EXPECT_EQ(v1Results[0]->size(), v2Results[0]->size());
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
## Summary

Adds the V2 evaluator skeleton, the ExprV2::from() adapter that
mirrors V1's compiled Expr tree into an immutable ExprV2 tree, a
trivial V2 pipeline capable of evaluating function calls and constants
end-to-end, and an A/B test harness that runs V2 alongside V1 for
parity.

Commits:
- `refactor(expression): Add V2 evaluator skeleton (step 2)` — new
  ExprV2 / ExprSetV2 / ExprEvaluatorV2 / ExprRuntimeState / EvalFrame /
  DebugGuards headers and skeleton implementations.
- `refactor(expression): ExprV2::from() adapter (step 3)` — walks a
  V1 Expr tree and produces the mirrored ExprV2 tree; keeps V1 alive
  so raw `FieldReference*` pointers stay valid.
- `refactor(expression): Trivial V2 pipeline + A/B harness (step 4)` —
  minimal V2 eval loop for function calls / constants and an A/B
  parity harness.
- `refactor(expression): Expose ExprSetV2::sourceSet() for EvalCtx` —
  small accessor needed by the eval path.

## Dependencies

Depends on **1/7 — Design doc (#2232)** (must merge first).

Follows in the stack:
- 3/7 — FieldPeeling + DictionaryMemo (#2234)
- 4/7 — NullPruning + SharedSubexprCache (#2235)
- 5/7 — ArgEval + ArgPeeling (#2236)
- 6/7 — Output tracer + listeners + CPU timing (#2237)
- 7/7 — Wire V2 evaluator + flag + fuzzer parity (#2238)

## Test plan

- [ ] `velox_expression_test --gtest_filter='ExprV2*'` passes.
- [ ] A/B harness runs the same expressions through V1 and V2 and
      confirms identical output.
- [ ] No V1 code path is modified beyond what's needed to expose
      `sourceSet()`.
