### PR TITLE
[ExprV2 3/7] FieldPeeling + DictionaryMemo phases

### DIFF
--- a/velox/expression/EvalFrame.h
+++ b/velox/expression/EvalFrame.h
@@ -59,7 +59,9 @@ struct EvalFrame {
         deterministic{exprIn.deterministic()},
         isSpecialForm{exprIn.isSpecialForm()},
         supportsFlatNoNullsFastPath{exprIn.supportsFlatNoNullsFastPath()},
-        hasConditionals{exprIn.hasConditionals()} {}
+        hasConditionals{exprIn.hasConditionals()},
+        skipFieldDependentOptimizations{
+            exprIn.skipFieldDependentOptimizations()} {}
 
   // === Bindings (constant after construction) ===
 
@@ -95,6 +97,7 @@ struct EvalFrame {
   bool isSpecialForm;
   bool supportsFlatNoNullsFastPath;
   bool hasConditionals;
+  bool skipFieldDependentOptimizations;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -20,6 +20,9 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/DebugGuards.h"
+#include "velox/expression/FieldReference.h"
+#include "velox/expression/PeeledEncoding.h"
+#include "velox/vector/LazyVector.h"
 
 namespace facebook::velox::exec {
 
@@ -32,6 +35,102 @@ void emitNullConstant(
   if (result == nullptr) {
     result = BaseVector::createNullConstant(type, 0, pool);
   }
+}
+
+// Mirrors the file-private isFlat() in Expr.cpp (line 355).
+bool isFlat(const BaseVector& vector) {
+  auto encoding = vector.encoding();
+  if (encoding == VectorEncoding::Simple::LAZY) {
+    if (!vector.asUnchecked<LazyVector>()->isLoaded()) {
+      return true;
+    }
+    encoding = vector.loadedVector()->encoding();
+  }
+  return !(
+      encoding == VectorEncoding::Simple::DICTIONARY ||
+      encoding == VectorEncoding::Simple::CONSTANT);
+}
+
+// Result of attempting to peel the input field encodings.  Mirrors
+// Expr::PeelEncodingsResult (Expr.cpp:1025).
+struct FieldPeelResult {
+  // Inner-row selection in the peeled row space.  nullptr if peel failed.
+  SelectivityVector* newRows{nullptr};
+  // True if the peel result is cacheable by base dictionary.  Triggers
+  // the DictionaryMemo phase in step 6.
+  bool mayCache{false};
+};
+
+// Peels input field encodings for the whole subtree rooted at expr.
+// Mirrors Expr::peelEncodings (Expr.cpp:1025).  On success, mutates
+// 'context' to install the peeled encoding and peeled vectors via
+// 'saver'.
+FieldPeelResult tryPeelFields(
+    const ExprV2& expr,
+    EvalCtx& context,
+    ContextSaver& saver,
+    const SelectivityVector& rows,
+    LocalDecodedVector& localDecoded,
+    LocalSelectivityVector& newRowsHolder,
+    LocalSelectivityVector& finalRowsHolder) {
+  if (context.wrapEncoding() == VectorEncoding::Simple::CONSTANT) {
+    return {};
+  }
+
+  // Use finalSelection to generate peel to ensure those rows can be
+  // translated and to ensure consistent peeling across multiple calls
+  // for a shared sub-expression.
+  const auto& rowsToPeel =
+      context.isFinalSelection() ? rows : *context.finalSelection();
+
+  std::vector<VectorPtr> vectorsToPeel;
+  vectorsToPeel.reserve(expr.distinctFields().size());
+  for (auto* field : expr.distinctFields()) {
+    auto fieldIndex = field->index(context);
+    auto fieldVector = context.getField(fieldIndex);
+    if (fieldVector->isConstantEncoding()) {
+      fieldVector = context.ensureFieldLoaded(fieldIndex, rowsToPeel);
+    }
+    vectorsToPeel.push_back(fieldVector);
+  }
+
+  VELOX_CHECK(!vectorsToPeel.empty());
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::peel(
+      vectorsToPeel,
+      rowsToPeel,
+      localDecoded,
+      expr.propagatesNulls(),
+      peeledVectors);
+  if (!peeledEncoding) {
+    return {};
+  }
+
+  SelectivityVector* newFinalSelection = nullptr;
+  if (!context.isFinalSelection()) {
+    newFinalSelection = peeledEncoding->translateToInnerRows(
+        *context.finalSelection(), finalRowsHolder);
+  }
+  auto* newRows = peeledEncoding->translateToInnerRows(rows, newRowsHolder);
+
+  context.saveAndReset(saver, rows);
+  context.setPeeledEncoding(peeledEncoding);
+  if (newFinalSelection) {
+    *context.mutableFinalSelection() = newFinalSelection;
+  }
+  VELOX_DCHECK_EQ(peeledVectors.size(), expr.distinctFields().size());
+  for (size_t i = 0; i < peeledVectors.size(); ++i) {
+    auto fieldIndex = expr.distinctFields()[i]->index(context);
+    context.setPeeled(fieldIndex, peeledVectors[i]);
+  }
+
+  bool mayCache = false;
+  if (context.dictionaryMemoizationEnabled()) {
+    mayCache = expr.distinctFields().size() == 1 &&
+        VectorEncoding::isDictionary(context.wrapEncoding()) &&
+        !peeledVectors[0]->memoDisabled();
+  }
+  return {newRows, mayCache};
 }
 
 } // namespace
@@ -79,8 +178,62 @@ void ExprEvaluatorV2::evaluateFrame(
 
 void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
   DebugRemainingRowsGuard guard{f};
-  // TODO(step 5): port FieldPeeling::tryPeel from Expr::evalEncodings.
-  // For step 4 this layer is a pass-through.
+
+  // Mirrors Expr::evalEncodings (Expr.cpp:1101).  Gating identical to
+  // V1: must be deterministic, must not skip field-dependent
+  // optimizations, peeling must be enabled, and no input field is
+  // already flat (in which case peeling can't help).
+  if (!f.deterministic || f.skipFieldDependentOptimizations ||
+      !f.ctx.peelingEnabled(f.remainingRows.rows())) {
+    evaluateWithNullPruning(f);
+    return;
+  }
+  for (auto* field : f.expr.distinctFields()) {
+    if (isFlat(*f.ctx.getField(field->index(f.ctx)))) {
+      evaluateWithNullPruning(f);
+      return;
+    }
+  }
+
+  VectorPtr wrappedResult;
+  withContextSaver([&](ContextSaver& saver) {
+    LocalSelectivityVector newRowsHolder(f.ctx);
+    LocalSelectivityVector finalRowsHolder(f.ctx);
+    LocalDecodedVector decodedHolder(f.ctx);
+
+    auto peel = tryPeelFields(
+        f.expr,
+        f.ctx,
+        saver,
+        f.remainingRows.rows(),
+        decodedHolder,
+        newRowsHolder,
+        finalRowsHolder);
+    if (peel.newRows == nullptr) {
+      return;
+    }
+
+    VectorPtr peeledResult;
+    if (peel.newRows->hasSelections()) {
+      // Construct an inner frame on the peeled inner row space and
+      // skip past evaluateWithFieldPeeling -- we've already peeled.
+      // TODO(step 6): when peel.mayCache, route through
+      // DictionaryMemo::evaluate before reaching null pruning.
+      EvalFrame innerFrame{
+          f.expr, f.runtimeStates, f.ctx, *peel.newRows, peeledResult};
+      evaluateWithNullPruning(innerFrame);
+    }
+
+    wrappedResult = f.ctx.getPeeledEncoding()->wrap(
+        f.expr.type(), f.ctx.pool(), peeledResult, f.remainingRows.rows());
+  });
+
+  if (wrappedResult != nullptr) {
+    f.ctx.moveOrCopyResult(wrappedResult, f.remainingRows.rows(), f.result);
+    return;
+  }
+  // Peeling did not produce a result (e.g. no peel possible) -- fall
+  // through to null pruning on the original row space.
   evaluateWithNullPruning(f);
 }
 

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -215,13 +215,13 @@ void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
 
     VectorPtr peeledResult;
     if (peel.newRows->hasSelections()) {
-      // Construct an inner frame on the peeled inner row space and
-      // skip past evaluateWithFieldPeeling -- we've already peeled.
-      // TODO(step 6): when peel.mayCache, route through
-      // DictionaryMemo::evaluate before reaching null pruning.
       EvalFrame innerFrame{
           f.expr, f.runtimeStates, f.ctx, *peel.newRows, peeledResult};
-      evaluateWithNullPruning(innerFrame);
+      if (peel.mayCache) {
+        evaluateDictionaryMemo(innerFrame);
+      } else {
+        evaluateWithNullPruning(innerFrame);
+      }
     }
 
     wrappedResult = f.ctx.getPeeledEncoding()->wrap(
@@ -237,10 +237,114 @@ void ExprEvaluatorV2::evaluateWithFieldPeeling(EvalFrame& f) {
   evaluateWithNullPruning(f);
 }
 
+void ExprEvaluatorV2::evaluateDictionaryMemo(EvalFrame& f) {
+  // Mirrors Expr::evalWithMemo (Expr.cpp:1246).  Reached only from
+  // FieldPeeling when peel.mayCache is true.
+  auto& memo = f.nodeRuntime.dictMemo;
+
+  VectorPtr base;
+  f.expr.distinctFields()[0]->evalSpecialForm(
+      f.remainingRows.rows(), f.ctx, base);
+
+  // Cache miss: the base vector identity has changed or the previous
+  // weak reference expired.  Reset cache state and recompute.
+  if (base.get() != memo.baseOfDictionaryRawPtr ||
+      memo.baseOfDictionaryWeakPtr.expired()) {
+    memo.baseOfDictionaryRepeats = 0;
+    memo.baseOfDictionaryWeakPtr.reset();
+    memo.baseOfDictionaryRawPtr = nullptr;
+    f.ctx.releaseVector(memo.baseOfDictionary);
+    f.ctx.releaseVector(memo.dictionaryCache);
+
+    evaluateWithNullPruning(f);
+    memo.baseOfDictionaryWeakPtr = base;
+    memo.baseOfDictionaryRawPtr = base.get();
+    return;
+  }
+
+  // First repeat of the same base: start caching.
+  if (memo.baseOfDictionaryRepeats == 0) {
+    evaluateWithNullPruning(f);
+    ++memo.baseOfDictionaryRepeats;
+    memo.baseOfDictionary = base;
+    memo.dictionaryCache = f.result;
+    if (!memo.cachedDictionaryIndices) {
+      memo.cachedDictionaryIndices = f.ctx.execCtx()->getSelectivityVector(
+          f.remainingRows.rows().end());
+    }
+    *memo.cachedDictionaryIndices = f.remainingRows.rows();
+    f.ctx.deselectErrors(*memo.cachedDictionaryIndices);
+    return;
+  }
+
+  ++memo.baseOfDictionaryRepeats;
+
+  // Copy cached values into the result for cached rows.
+  if (memo.cachedDictionaryIndices) {
+    LocalSelectivityVector cachedHolder(f.ctx, f.remainingRows.rows());
+    auto* cached = cachedHolder.get();
+    VELOX_DCHECK(cached != nullptr);
+    cached->intersect(*memo.cachedDictionaryIndices);
+    if (cached->hasSelections()) {
+      f.ctx.ensureWritable(
+          f.remainingRows.rows(), f.expr.type(), f.result);
+      f.result->copy(memo.dictionaryCache.get(), *cached, nullptr);
+    }
+  }
+
+  // Compute uncached rows by recursing on a child frame.
+  LocalSelectivityVector uncachedHolder(f.ctx, f.remainingRows.rows());
+  auto* uncached = uncachedHolder.get();
+  VELOX_DCHECK(uncached != nullptr);
+  if (memo.cachedDictionaryIndices) {
+    uncached->deselect(*memo.cachedDictionaryIndices);
+  }
+
+  if (uncached->hasSelections()) {
+    // Fix finalSelection at the outer rows if uncached is a strict
+    // subset, to avoid losing values not in uncached that were copied
+    // earlier into 'result' from cached rows.
+    ScopedFinalSelectionSetter finalSelectionSetter(
+        f.ctx,
+        &f.remainingRows.rows(),
+        uncached->countSelected() < f.remainingRows.rows().countSelected());
+
+    EvalFrame uncachedFrame{
+        f.expr, f.runtimeStates, f.ctx, *uncached, f.result};
+    evaluateWithNullPruning(uncachedFrame);
+    f.ctx.deselectErrors(*uncached);
+
+    if (uncached->hasSelections()) {
+      // TODO(step 14): register with V2's memo invalidation registry so
+      // ExprSet::clearMemo / clearCache also clears V2 state.  V1 calls
+      // context.exprSet()->addToMemo(this) here; equivalent V2 plumbing
+      // is deferred to the cutover step.
+      auto newCacheSize = uncached->end();
+
+      LocalSelectivityVector allUncached(f.ctx, memo.dictionaryCache->size());
+      allUncached.get()->setAll();
+      allUncached.get()->deselect(*memo.cachedDictionaryIndices);
+      f.ctx.ensureWritable(
+          *allUncached.get(), f.expr.type(), memo.dictionaryCache);
+
+      if (memo.cachedDictionaryIndices->size() < newCacheSize) {
+        memo.cachedDictionaryIndices->resize(newCacheSize, false);
+      }
+      memo.cachedDictionaryIndices->select(*uncached);
+
+      if (memo.dictionaryCache->size() < uncached->end()) {
+        memo.dictionaryCache->resize(uncached->end());
+      }
+      memo.dictionaryCache->copy(f.result.get(), *uncached, nullptr);
+    }
+  }
+  f.ctx.releaseVector(base);
+}
+
 void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
   DebugRemainingRowsGuard guard{f};
   // TODO(step 7): port NullPruning::tryPrune from Expr::evalWithNulls.
-  // For step 4 this layer is a pass-through.
+  // For now this layer is a pass-through.
   evaluateWithSharedSubexpr(f);
 }
 

--- a/velox/expression/ExprEvaluatorV2.h
+++ b/velox/expression/ExprEvaluatorV2.h
@@ -47,6 +47,7 @@ class ExprEvaluatorV2 {
   // layer owns, not what the previous layer did.
   void evaluateFrame(EvalFrame& f, const ExprSetV2* parentSet);
   void evaluateWithFieldPeeling(EvalFrame& f);
+  void evaluateDictionaryMemo(EvalFrame& f);
   void evaluateWithNullPruning(EvalFrame& f);
   void evaluateWithSharedSubexpr(EvalFrame& f);
   void evaluateNodeBody(EvalFrame& f);

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -22,6 +22,8 @@
 #include <folly/container/F14Map.h>
 
 #include "velox/expression/ExprStats.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::exec {
 
@@ -30,8 +32,33 @@ class ExprV2;
 /// Placeholder for shared-subexpression cache state.  Populated in step 8.
 struct SharedSubexprCacheState {};
 
-/// Placeholder for dictionary memoization state.  Populated in step 6.
-struct DictionaryMemoState {};
+/// Per-Expr dictionary memoization state.  Mirrors the cluster of
+/// member variables on Expr (baseOfDictionary*, dictionaryCache_,
+/// cachedDictionaryIndices_, baseOfDictionaryRepeats_).  Populated by
+/// the DictionaryMemo phase only on the peeled+mayCache path.
+struct DictionaryMemoState {
+  // Weak/raw pointers to the last cached base vector.  The weak_ptr is
+  // checked for expiration to invalidate when inputs die between
+  // batches; the raw pointer is the fast-path identity check.
+  std::weak_ptr<BaseVector> baseOfDictionaryWeakPtr;
+  BaseVector* baseOfDictionaryRawPtr{nullptr};
+
+  // Strong reference taken on the second observation of the same base
+  // (i.e. once baseOfDictionaryRepeats >= 1).  Pinning the base ensures
+  // the dictionary indices remain valid.
+  VectorPtr baseOfDictionary;
+
+  // Number of consecutive batches that have used the same base.  0 on
+  // first observation; caching begins on the transition 0 -> 1.
+  int baseOfDictionaryRepeats{0};
+
+  // Cached output values, indexed in the base dictionary's row space.
+  VectorPtr dictionaryCache;
+
+  // Set of rows in 'dictionaryCache' that are valid (have been computed
+  // successfully).
+  std::unique_ptr<SelectivityVector> cachedDictionaryIndices;
+};
 
 /// Placeholder for adaptive CPU sampling state.  Populated in step 10.
 struct AdaptiveSamplingState {};

--- a/velox/expression/ExprV2.cpp
+++ b/velox/expression/ExprV2.cpp
@@ -43,6 +43,8 @@ std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& expr) {
   node->propagatesNulls_ = expr->propagatesNulls();
   node->supportsFlatNoNullsFastPath_ = expr->supportsFlatNoNullsFastPath();
   node->hasConditionals_ = expr->hasConditionals();
+  node->skipFieldDependentOptimizations_ =
+      expr->skipFieldDependentOptimizations();
   node->trackCpuUsage_ = expr->trackCpuUsage();
   node->distinctFields_ = expr->distinctFields();
   node->multiplyReferencedFields_ = expr->multiplyReferencedFields();

--- a/velox/expression/ExprV2.h
+++ b/velox/expression/ExprV2.h
@@ -102,6 +102,10 @@ class ExprV2 {
     return hasConditionals_;
   }
 
+  bool skipFieldDependentOptimizations() const {
+    return skipFieldDependentOptimizations_;
+  }
+
   bool trackCpuUsage() const {
     return trackCpuUsage_;
   }
@@ -140,6 +144,7 @@ class ExprV2 {
   bool propagatesNulls_{false};
   bool supportsFlatNoNullsFastPath_{false};
   bool hasConditionals_{false};
+  bool skipFieldDependentOptimizations_{false};
   bool trackCpuUsage_{false};
 
   // Raw pointers into the V1 tree owned by sourceExpr_.  Valid as long

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -122,6 +122,35 @@ TEST_F(ExprV2ParityTest, comparison) {
   assertParity("a < b", input);
 }
 
+// Dictionary-encoded input -- exercises FieldPeeling.
+TEST_F(ExprV2ParityTest, dictionaryEncodedInput) {
+  auto flatA = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  // Dictionary that reverses the input.
+  auto indices = makeIndicesInReverse(5);
+  auto dictA = BaseVector::wrapInDictionary(nullptr, indices, 5, flatA);
+  auto input = makeRowVector({"a"}, {dictA});
+  assertParity("a + 1::bigint", input);
+}
+
+// Constant-encoded input -- exercises FieldPeeling's constant path.
+TEST_F(ExprV2ParityTest, constantEncodedInput) {
+  auto constA = BaseVector::createConstant(BIGINT(), int64_t(7), 5, pool_.get());
+  auto input = makeRowVector({"a"}, {constA});
+  assertParity("a + 1::bigint", input);
+}
+
+// Two dictionary inputs over the same base -- exercises peeling of
+// multiple field references.
+TEST_F(ExprV2ParityTest, twoDictionariesSameBase) {
+  auto flatA = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto flatB = makeFlatVector<int64_t>({100, 200, 300, 400, 500});
+  auto indices = makeIndicesInReverse(5);
+  auto dictA = BaseVector::wrapInDictionary(nullptr, indices, 5, flatA);
+  auto dictB = BaseVector::wrapInDictionary(nullptr, indices, 5, flatB);
+  auto input = makeRowVector({"a", "b"}, {dictA, dictB});
+  assertParity("a + b", input);
+}
+
 // Empty selectivity vector -- emitEmpty path.
 TEST_F(ExprV2ParityTest, emptyRows) {
   auto input = makeRowVector(

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -139,6 +139,46 @@ TEST_F(ExprV2ParityTest, constantEncodedInput) {
   assertParity("a + 1::bigint", input);
 }
 
+// Multi-batch dictionary input with the same base -- exercises the
+// DictionaryMemo phase, including the "first repeat" cache fill and
+// the subsequent cache-hit / cache-miss merge paths.
+TEST_F(ExprV2ParityTest, dictionaryMemoAcrossBatches) {
+  auto base = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  // Three batches all using the same base dictionary but different
+  // index permutations.  V2's DictionaryMemo should cache after batch 1
+  // and reuse on subsequent batches.
+  std::vector<RowVectorPtr> inputs;
+  for (int batch = 0; batch < 3; ++batch) {
+    auto indices = makeIndicesInReverse(5);
+    auto dict = BaseVector::wrapInDictionary(nullptr, indices, 5, base);
+    inputs.push_back(makeRowVector({"a"}, {dict}));
+  }
+
+  auto rowType = std::dynamic_pointer_cast<const RowType>(inputs[0]->type());
+  auto untyped =
+      parse::DuckSqlExpressionsParser(options_).parseExpr("a + 1::bigint");
+  auto typed =
+      core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
+
+  auto v1Set = std::make_shared<ExprSet>(
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
+  ExprSetV2 v2Set{v1Set};
+
+  for (const auto& input : inputs) {
+    SelectivityVector rows{input->size()};
+
+    EvalCtx v1Ctx{execCtx_.get(), v1Set.get(), input.get()};
+    std::vector<VectorPtr> v1Results(1);
+    v1Set->eval(rows, v1Ctx, v1Results);
+
+    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    std::vector<VectorPtr> v2Results(1);
+    v2Set.eval(rows, v2Ctx, v2Results);
+
+    velox::test::assertEqualVectors(v1Results[0], v2Results[0]);
+  }
+}
+
 // Two dictionary inputs over the same base -- exercises peeling of
 // multiple field references.
 TEST_F(ExprV2ParityTest, twoDictionariesSameBase) {


### PR DESCRIPTION
## Summary

Adds the FieldPeeling and DictionaryMemo phases to the V2 evaluator,
mirroring V1's dictionary-encoded fast paths for shared column
references.

Commits:
- `refactor(expression): FieldPeeling phase (step 5)` — peels
  dictionary encodings off shared FieldReferences before the
  function-call kernel runs.
- `refactor(expression): DictionaryMemo phase (step 6)` — memoizes
  results per (base, indices) so repeated batches over the same
  dictionary base skip recomputation.

## Dependencies

Depends on:
- 1/7 — Design doc (#2232)
- **2/7 — V2 evaluator skeleton (#2233)** (immediate parent — must
  merge first)

Follows in the stack:
- 4/7 — NullPruning + SharedSubexprCache (#2235)
- 5/7 — ArgEval + ArgPeeling (#2236)
- 6/7 — Output tracer + listeners + CPU timing (#2237)
- 7/7 — Wire V2 evaluator + flag + fuzzer parity (#2238)

## Test plan

- [ ] `velox_expression_test --gtest_filter='ExprV2*'` passes.
- [ ] A/B parity harness (dictionary-encoded inputs) matches V1
      row-for-row.
