### PR TITLE
[ExprV2 4/7] NullPruning + SharedSubexprCache phases

### DIFF
--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -441,10 +441,106 @@ void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
 
 void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& f) {
   DebugRemainingRowsGuard guard{f};
-  // TODO(step 8): port SharedSubexprCache::tryReuse from
-  // Expr::evaluateSharedSubexpr.  For step 4 this layer is a
-  // pass-through.
-  evaluateNodeBody(f);
+
+  // Mirrors the wrapper in Expr::evalAll (Expr.cpp:1459): only invoke
+  // the shared-subexpr cache when the expression is a CSE candidate.
+  if (!f.deterministic || !f.expr.isMultiplyReferenced() ||
+      f.expr.inputs().empty() || !f.ctx.sharedSubExpressionReuseEnabled()) {
+    evaluateNodeBody(f);
+    return;
+  }
+
+  // Mirrors Expr::evaluateSharedSubexpr (Expr.cpp:899).  Cache keyed
+  // by the identity of all distinct input field vectors.
+  auto& cache = f.nodeRuntime.sharedCache.entries;
+
+  InputForSharedResults key;
+  for (auto* field : f.expr.distinctFields()) {
+    key.addInput(f.ctx.getField(field->index(f.ctx)));
+  }
+
+  auto it = cache.find(key);
+  if (it != cache.end() && it->first.isExpired()) {
+    cache.erase(it);
+    it = cache.end();
+  }
+
+  if (it == cache.end()) {
+    auto max = f.ctx.maxSharedSubexprResultsCached();
+    if (cache.size() < max) {
+      it = cache.insert({std::move(key), SharedResults{}}).first;
+    } else {
+      // Cache full: evaluate without caching.
+      evaluateNodeBody(f);
+      return;
+    }
+  }
+
+  auto& sharedRows = it->second.sharedSubexprRows;
+  auto& sharedValues = it->second.sharedSubexprValues;
+
+  // First observation under this key: compute, store, return.
+  if (sharedValues == nullptr) {
+    evaluateNodeBody(f);
+    if (!sharedRows) {
+      sharedRows = f.ctx.execCtx()->getSelectivityVector(
+          f.remainingRows.rows().end());
+    }
+    *sharedRows = f.remainingRows.rows();
+    if (f.ctx.errors()) {
+      f.ctx.deselectErrors(*sharedRows);
+      if (!sharedRows->hasSelections()) {
+        // No usable rows; don't cache.
+        return;
+      }
+    }
+    sharedValues = f.result;
+    return;
+  }
+
+  // Full hit: every requested row is already cached.
+  if (f.remainingRows.rows().isSubset(*sharedRows)) {
+    f.ctx.moveOrCopyResult(sharedValues, f.remainingRows.rows(), f.result);
+    return;
+  }
+
+  // Partial hit: compute the missing rows on top of cached results.
+  LocalSelectivityVector missingHolder(f.ctx, f.remainingRows.rows());
+  auto* missing = missingHolder.get();
+  missing->deselect(*sharedRows);
+  VELOX_DCHECK(missing->hasSelections());
+
+  // Final selection must cover sharedRows ∪ missing ∪ existing
+  // finalSelection so values outside 'missing' aren't lost when the
+  // child writes into sharedValues.
+  LocalSelectivityVector newFinalSelHolder(f.ctx, *sharedRows);
+  auto* newFinalSel = newFinalSelHolder.get();
+  newFinalSel->select(*missing);
+  if (!f.ctx.isFinalSelection()) {
+    newFinalSel->select(*f.ctx.finalSelection());
+  }
+  ScopedFinalSelectionSetter finalSetter(
+      f.ctx,
+      newFinalSel,
+      /*checkCondition=*/true,
+      /*override=*/true);
+
+  EvalFrame missingFrame{
+      f.expr, f.runtimeStates, f.ctx, *missing, sharedValues};
+  evaluateNodeBody(missingFrame);
+
+  f.ctx.deselectErrors(*missing);
+  sharedRows->select(*missing);
+
+  if (f.ctx.errors()) {
+    LocalSelectivityVector rowsWithoutErrorsHolder(
+        f.ctx, f.remainingRows.rows());
+    auto* rowsWithoutErrors = rowsWithoutErrorsHolder.get();
+    f.ctx.deselectErrors(*rowsWithoutErrors);
+    f.ctx.moveOrCopyResult(sharedValues, *rowsWithoutErrors, f.result);
+  } else {
+    f.ctx.moveOrCopyResult(sharedValues, f.remainingRows.rows(), f.result);
+  }
 }
 
 void ExprEvaluatorV2::evaluateNodeBody(EvalFrame& f) {

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -22,6 +22,7 @@
 #include "velox/expression/DebugGuards.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/PeeledEncoding.h"
+#include "velox/expression/ScopedVarSetter.h"
 #include "velox/vector/LazyVector.h"
 
 namespace facebook::velox::exec {
@@ -341,11 +342,101 @@ void ExprEvaluatorV2::evaluateDictionaryMemo(EvalFrame& f) {
   f.ctx.releaseVector(base);
 }
 
+namespace {
+
+// Mirrors Expr::removeSureNulls (Expr.cpp:1157).  Computes the
+// non-null subset of 'rows' across all distinct input fields.  Returns
+// true if any sure-null row was removed; in that case 'nullHolder'
+// owns the non-null SelectivityVector.
+bool removeSureNulls(
+    const ExprV2& expr,
+    EvalCtx& context,
+    const SelectivityVector& rows,
+    LocalSelectivityVector& nullHolder) {
+  SelectivityVector* result = nullptr;
+  for (auto* field : expr.distinctFields()) {
+    VectorPtr values;
+    field->evalSpecialForm(rows, context, values);
+
+    if (isLazyNotLoaded(*values)) {
+      continue;
+    }
+
+    if (values->mayHaveNulls()) {
+      LocalDecodedVector decoded(context, *values, rows);
+      if (auto* rawNulls = decoded->nulls(&rows)) {
+        if (!result) {
+          result = nullHolder.get(rows);
+        }
+        auto* bits = result->asMutableRange().bits();
+        bits::andBits(bits, rawNulls, rows.begin(), rows.end());
+      }
+    }
+  }
+  if (result == nullptr) {
+    return false;
+  }
+  result->updateBounds();
+  return result->countSelected() < rows.countSelected();
+}
+
+} // namespace
+
 void ExprEvaluatorV2::evaluateWithNullPruning(EvalFrame& f) {
   DebugRemainingRowsGuard guard{f};
-  // TODO(step 7): port NullPruning::tryPrune from Expr::evalWithNulls.
-  // For now this layer is a pass-through.
-  evaluateWithSharedSubexpr(f);
+
+  // Mirrors Expr::evalWithNulls (Expr.cpp:1201).  Only attempts null
+  // pruning when the expression propagates nulls and field-dependent
+  // optimizations are not skipped.
+  if (!f.propagatesNulls || f.skipFieldDependentOptimizations) {
+    evaluateWithSharedSubexpr(f);
+    return;
+  }
+
+  // Quick reject: if no distinct field may have nulls, skip the
+  // expensive removeSureNulls work.
+  bool mayHaveNulls = false;
+  for (auto* field : f.expr.distinctFields()) {
+    const auto& vector = f.ctx.getField(field->index(f.ctx));
+    if (isLazyNotLoaded(*vector)) {
+      continue;
+    }
+    if (vector->mayHaveNulls()) {
+      mayHaveNulls = true;
+      break;
+    }
+  }
+  if (!mayHaveNulls) {
+    evaluateWithSharedSubexpr(f);
+    return;
+  }
+
+  LocalSelectivityVector nonNullHolder(f.ctx);
+  if (!removeSureNulls(
+          f.expr, f.ctx, f.remainingRows.rows(), nonNullHolder)) {
+    evaluateWithSharedSubexpr(f);
+    return;
+  }
+
+  // Default-null pruning fired.  Recurse on the non-null subset under
+  // a scoped nullsPruned flag, then null-fill the rows we removed.
+  ScopedVarSetter noMoreNulls(f.ctx.mutableNullsPruned(), true);
+  auto* nonNullRows = nonNullHolder.get();
+
+  if (nonNullRows->hasSelections()) {
+    EvalFrame innerFrame{
+        f.expr, f.runtimeStates, f.ctx, *nonNullRows, f.result};
+    evaluateWithSharedSubexpr(innerFrame);
+  }
+
+  // addNulls writes nulls into 'result' for rows in originalRows but
+  // not in nonNullRows.
+  EvalCtx::addNulls(
+      f.remainingRows.rows(),
+      nonNullRows->asRange().bits(),
+      f.ctx,
+      f.expr.type(),
+      f.result);
 }
 
 void ExprEvaluatorV2::evaluateWithSharedSubexpr(EvalFrame& f) {

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -29,8 +30,52 @@ namespace facebook::velox::exec {
 
 class ExprV2;
 
-/// Placeholder for shared-subexpression cache state.  Populated in step 8.
-struct SharedSubexprCacheState {};
+/// Identity of the input vectors a shared sub-expression was computed
+/// over.  Used as a key in the per-Expr SharedSubexprCacheState.
+/// Mirrors Expr::InputForSharedResults (Expr.h:738).
+class InputForSharedResults {
+ public:
+  void addInput(const std::shared_ptr<BaseVector>& input) {
+    inputVectors_.push_back(input.get());
+    inputWeakVectors_.push_back(input);
+  }
+
+  bool operator<(const InputForSharedResults& other) const {
+    return inputVectors_ < other.inputVectors_;
+  }
+
+  // True if any captured input has been freed since the entry was
+  // inserted.  Stale entries are evicted on lookup.
+  bool isExpired() const {
+    for (const auto& input : inputWeakVectors_) {
+      if (input.expired()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  // Raw pointers used for ordering only; lifetime checked via the
+  // parallel weak_ptr vector.
+  std::vector<const BaseVector*> inputVectors_;
+  std::vector<std::weak_ptr<BaseVector>> inputWeakVectors_;
+};
+
+/// Cached output for a previously-seen set of input identities.
+/// Mirrors Expr::SharedResults (Expr.h:765).
+struct SharedResults {
+  // Rows for which 'sharedSubexprValues' has a valid value.
+  std::unique_ptr<SelectivityVector> sharedSubexprRows;
+  // The cached output, indexed alongside sharedSubexprRows.
+  VectorPtr sharedSubexprValues;
+};
+
+/// Shared sub-expression result cache, indexed by the identity of the
+/// captured input vectors.  Populated by the SharedSubexprCache phase.
+struct SharedSubexprCacheState {
+  std::map<InputForSharedResults, SharedResults> entries;
+};
 
 /// Per-Expr dictionary memoization state.  Mirrors the cluster of
 /// member variables on Expr (baseOfDictionary*, dictionaryCache_,

--- a/velox/expression/ExprV2.cpp
+++ b/velox/expression/ExprV2.cpp
@@ -45,6 +45,7 @@ std::shared_ptr<ExprV2> ExprV2::from(const std::shared_ptr<Expr>& expr) {
   node->hasConditionals_ = expr->hasConditionals();
   node->skipFieldDependentOptimizations_ =
       expr->skipFieldDependentOptimizations();
+  node->isMultiplyReferenced_ = expr->isMultiplyReferenced();
   node->trackCpuUsage_ = expr->trackCpuUsage();
   node->distinctFields_ = expr->distinctFields();
   node->multiplyReferencedFields_ = expr->multiplyReferencedFields();

--- a/velox/expression/ExprV2.h
+++ b/velox/expression/ExprV2.h
@@ -106,6 +106,13 @@ class ExprV2 {
     return skipFieldDependentOptimizations_;
   }
 
+  /// True if this expression appears in more than one place in the
+  /// containing ExprSet (CSE candidate).  Set during compilation of
+  /// the source Expr; mirrored here for the SharedSubexprCache phase.
+  bool isMultiplyReferenced() const {
+    return isMultiplyReferenced_;
+  }
+
   bool trackCpuUsage() const {
     return trackCpuUsage_;
   }
@@ -145,6 +152,7 @@ class ExprV2 {
   bool supportsFlatNoNullsFastPath_{false};
   bool hasConditionals_{false};
   bool skipFieldDependentOptimizations_{false};
+  bool isMultiplyReferenced_{false};
   bool trackCpuUsage_{false};
 
   // Raw pointers into the V1 tree owned by sourceExpr_.  Valid as long

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -139,6 +139,35 @@ TEST_F(ExprV2ParityTest, constantEncodedInput) {
   assertParity("a + 1::bigint", input);
 }
 
+// Null-containing input on a propagatesNulls expression -- exercises
+// NullPruning::removeSureNulls.
+TEST_F(ExprV2ParityTest, propagatesNullsWithNullInput) {
+  auto a = makeNullableFlatVector<int64_t>(
+      {1, std::nullopt, 3, std::nullopt, 5});
+  auto b = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  auto input = makeRowVector({"a", "b"}, {a, b});
+  assertParity("a + b", input);
+}
+
+// Both inputs may have nulls -- exercises multi-field null pruning.
+TEST_F(ExprV2ParityTest, propagatesNullsBothInputs) {
+  auto a = makeNullableFlatVector<int64_t>(
+      {1, std::nullopt, 3, std::nullopt, 5});
+  auto b = makeNullableFlatVector<int64_t>(
+      {10, 20, std::nullopt, 40, std::nullopt});
+  auto input = makeRowVector({"a", "b"}, {a, b});
+  assertParity("a + b", input);
+}
+
+// All-null input -- pruning should produce all-null result.
+TEST_F(ExprV2ParityTest, allNullInput) {
+  auto a = makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  auto b = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  auto input = makeRowVector({"a", "b"}, {a, b});
+  assertParity("a + b", input);
+}
+
 // Multi-batch dictionary input with the same base -- exercises the
 // DictionaryMemo phase, including the "first repeat" cache fill and
 // the subsequent cache-hit / cache-miss merge paths.

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -220,6 +220,50 @@ TEST_F(ExprV2ParityTest, twoDictionariesSameBase) {
   assertParity("a + b", input);
 }
 
+// Repeated sub-expression (a + b) -- the compiler may identify this as
+// a shared sub-expression and mark it isMultiplyReferenced, exercising
+// SharedSubexprCache.  Even if the compiler doesn't dedupe, V2 falls
+// back to evaluateNodeBody and still matches V1.
+TEST_F(ExprV2ParityTest, repeatedSubexpression) {
+  auto a = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto b = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+  auto input = makeRowVector({"a", "b"}, {a, b});
+  assertParity("(a + b) * (a + b)", input);
+}
+
+// Same shared sub-expression evaluated across multiple batches.  If
+// the compiler shares the AST node, the second batch will hit the
+// cache; if not, V2 still matches V1.
+TEST_F(ExprV2ParityTest, sharedSubexprAcrossBatches) {
+  auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
+  auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr(
+      "(a + b) + (a + b) + (a + b)");
+  auto typed =
+      core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
+
+  auto v1Set = std::make_shared<ExprSet>(
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
+  ExprSetV2 v2Set{v1Set};
+
+  for (int batch = 0; batch < 2; ++batch) {
+    auto input = makeRowVector(
+        {"a", "b"},
+        {makeFlatVector<int64_t>({1 + batch, 2 + batch, 3 + batch}),
+         makeFlatVector<int64_t>({10 + batch, 20 + batch, 30 + batch})});
+    SelectivityVector rows{input->size()};
+
+    EvalCtx v1Ctx{execCtx_.get(), v1Set.get(), input.get()};
+    std::vector<VectorPtr> v1Results(1);
+    v1Set->eval(rows, v1Ctx, v1Results);
+
+    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    std::vector<VectorPtr> v2Results(1);
+    v2Set.eval(rows, v2Ctx, v2Results);
+
+    velox::test::assertEqualVectors(v1Results[0], v2Results[0]);
+  }
+}
+
 // Empty selectivity vector -- emitEmpty path.
 TEST_F(ExprV2ParityTest, emptyRows) {
   auto input = makeRowVector(


### PR DESCRIPTION
## Summary

Adds the NullPruning and SharedSubexprCache phases to the V2 evaluator.

Commits:
- `refactor(expression): NullPruning phase (step 7)` — removes rows
  whose input columns are null before running the function-call
  kernel, matching V1's null-propagation semantics.
- `refactor(expression): SharedSubexprCache phase (step 8)` — caches
  results of subexpressions that appear more than once in the same
  ExprSet.

## Dependencies

Depends on:
- 1/7 — Design doc (#2232)
- 2/7 — V2 evaluator skeleton (#2233)
- **3/7 — FieldPeeling + DictionaryMemo (#2234)** (immediate parent —
  must merge first)

Follows in the stack:
- 5/7 — ArgEval + ArgPeeling (#2236)
- 6/7 — Output tracer + listeners + CPU timing (#2237)
- 7/7 — Wire V2 evaluator + flag + fuzzer parity (#2238)

## Test plan

- [ ] `velox_expression_test --gtest_filter='ExprV2*'` passes.
- [ ] A/B parity harness exercises null-propagation and CSE paths.
