### PR TITLE
[ExprV2 5/7] ArgEval + ArgPeeling

### DIFF
--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -770,25 +770,14 @@ bool ExprEvaluatorV2::tryApplyWithPeeling(EvalFrame& f) {
     f.ctx.setPeeledEncoding(peeledEncoding);
 
     VectorPtr peeledResult;
-    // Apply on the inner row space against the peeled inputs.  We
-    // temporarily swap result so applyFunction writes into peeledResult.
-    auto savedResult = std::move(f.result);
-    f.result = std::move(peeledResult);
-    // Temporarily redirect remainingRows to newRows for the apply.
-    // We can't construct a new frame because applyFunction reads from
-    // 'f' directly; instead, mutate and restore.
-    // Simpler: bypass MutableRemainingRows here by calling
-    // vectorFunction->apply directly.
     f.expr.vectorFunction()->apply(
-        *newRows, f.inputValues, f.expr.type(), f.ctx, f.result);
+        *newRows, f.inputValues, f.expr.type(), f.ctx, peeledResult);
 
     VectorPtr wrappedResult = f.ctx.getPeeledEncoding()->wrap(
-        f.expr.type(), f.ctx.pool(), f.result, applyRows);
-    auto innerResult = std::move(f.result);
-    f.result = std::move(savedResult);
+        f.expr.type(), f.ctx.pool(), peeledResult, applyRows);
     f.ctx.moveOrCopyResult(wrappedResult, applyRows, f.result);
 
-    f.ctx.releaseVector(innerResult);
+    f.ctx.releaseVector(peeledResult);
   });
 
   return true;

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -38,6 +38,34 @@ void emitNullConstant(
   }
 }
 
+// Mirrors Expr.cpp:1438.
+bool isPeelable(VectorEncoding::Simple encoding) {
+  return encoding == VectorEncoding::Simple::CONSTANT ||
+      encoding == VectorEncoding::Simple::DICTIONARY;
+}
+
+// Mirrors Expr::throwArgumentErrors (Expr.cpp:1472).
+bool throwArgumentErrors(const EvalFrame& f) {
+  return f.ctx.throwOnError() &&
+      (!f.defaultNulls ||
+       (f.supportsFlatNoNullsFastPath && f.ctx.inputFlatNoNulls()));
+}
+
+// Mirrors mergeOrThrowArgumentErrors (Expr.cpp:339).
+void mergeOrThrowArgumentErrors(
+    const SelectivityVector& rows,
+    EvalErrorsPtr& originalErrors,
+    EvalErrorsPtr& argumentErrors,
+    EvalCtx& context) {
+  if (argumentErrors) {
+    if (context.throwOnError()) {
+      argumentErrors->throwFirstError(rows);
+    }
+    context.addErrors(rows, argumentErrors, originalErrors);
+  }
+  context.swapErrors(originalErrors);
+}
+
 // Mirrors the file-private isFlat() in Expr.cpp (line 355).
 bool isFlat(const BaseVector& vector) {
   auto encoding = vector.encoding();
@@ -558,10 +586,109 @@ void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& f) {
     f.inputValues.clear();
   });
 
-  // TODO(step 9): port ArgEval::evaluate (default-null vs
-  // preserve-null strategies, error swapping).  For step 4 the
-  // harness restricts to expressions with no-null inputs, where
-  // preserve-null and default-null are equivalent.
+  // Reset before each arg-eval attempt; the strategies populate
+  // inputValues, and ArgPeeling reads tryPeelArgs.
+  f.tryPeelArgs = f.deterministic;
+
+  bool argsOk = f.defaultNulls ? evalArgsDefaultNull(f) : evalArgsPreserveNull(f);
+  if (!argsOk) {
+    // setAllNulls already applied to originalRows.
+    return;
+  }
+
+  if (!f.tryPeelArgs || !tryApplyWithPeeling(f)) {
+    applyFunction(f);
+  }
+
+  // Write nulls for any rows that ArgEval pruned (default-null path).
+  if (f.remainingRows.hasChanged()) {
+    EvalCtx::addNulls(
+        f.originalRows,
+        f.remainingRows.rows().asRange().bits(),
+        f.ctx,
+        f.expr.type(),
+        f.result);
+  }
+}
+
+bool ExprEvaluatorV2::evalArgsDefaultNull(EvalFrame& f) {
+  // Mirrors Expr::evalArgsDefaultNulls (Expr.cpp:380).  For each child:
+  // evaluate, then deselect rows that are null and have no error.
+  EvalErrorsPtr argumentErrors;
+  EvalErrorsPtr originalErrors;
+  LocalDecodedVector decoded(f.ctx);
+
+  // Set aside pre-existing errors so we can distinguish argument errors.
+  if (f.ctx.errors()) {
+    f.ctx.swapErrors(originalErrors);
+  }
+
+  f.inputValues.resize(f.expr.inputs().size());
+  {
+    ScopedVarSetter throwErrors(
+        f.ctx.mutableThrowOnError(), throwArgumentErrors(f));
+
+    for (size_t i = 0; i < f.expr.inputs().size(); ++i) {
+      auto& childExpr = *f.expr.inputs()[i];
+      EvalFrame childFrame{
+          childExpr,
+          f.runtimeStates,
+          f.ctx,
+          f.remainingRows.rows(),
+          f.inputValues[i]};
+      evaluate(childFrame, /*parentSet=*/nullptr);
+      f.tryPeelArgs =
+          f.tryPeelArgs && isPeelable(f.inputValues[i]->encoding());
+
+      const uint64_t* flatNulls = nullptr;
+      auto& arg = f.inputValues[i];
+      if (arg->mayHaveNulls()) {
+        decoded.get()->decode(*arg, f.remainingRows.rows());
+        flatNulls = decoded.get()->nulls(&f.remainingRows.rows());
+      }
+
+      if (f.ctx.errors()) {
+        f.ctx.ensureErrorsVectorSize(f.remainingRows.rows().end());
+        auto* newErrors = f.ctx.errors();
+        if (flatNulls) {
+          // Null without error removes the row; null with error keeps
+          // the error.
+          auto errorNulls = newErrors->errorFlags();
+          auto* rowBits = f.remainingRows.mutableRows().asMutableRange().bits();
+          auto nwords = bits::nwords(f.remainingRows.rows().end());
+          for (size_t w = 0; w < nwords; ++w) {
+            auto nullNoError =
+                errorNulls ? flatNulls[w] | errorNulls[w] : flatNulls[w];
+            rowBits[w] &= nullNoError;
+          }
+          f.remainingRows.mutableRows().updateBounds();
+        }
+        f.ctx.moveAppendErrors(argumentErrors);
+      } else if (flatNulls) {
+        f.remainingRows.deselectNulls(flatNulls);
+      }
+
+      if (!f.remainingRows.rows().hasSelections()) {
+        break;
+      }
+    }
+  }
+
+  mergeOrThrowArgumentErrors(
+      f.remainingRows.rows(), originalErrors, argumentErrors, f.ctx);
+
+  if (!f.remainingRows.deselectErrors()) {
+    f.ctx.releaseVectors(f.inputValues);
+    f.inputValues.clear();
+    setAllNulls(f, f.remainingRows.originalRows());
+    return false;
+  }
+  return true;
+}
+
+bool ExprEvaluatorV2::evalArgsPreserveNull(EvalFrame& f) {
+  // Mirrors Expr::evalArgsWithNulls (Expr.cpp:455).  Nulls are not
+  // pruned; only error rows are removed.
   f.inputValues.resize(f.expr.inputs().size());
   for (size_t i = 0; i < f.expr.inputs().size(); ++i) {
     auto& childExpr = *f.expr.inputs()[i];
@@ -572,16 +699,115 @@ void ExprEvaluatorV2::evaluateFunctionCall(EvalFrame& f) {
         f.remainingRows.rows(),
         f.inputValues[i]};
     evaluate(childFrame, /*parentSet=*/nullptr);
+    f.tryPeelArgs =
+        f.tryPeelArgs && isPeelable(f.inputValues[i]->encoding());
+
+    if (!f.remainingRows.deselectErrors()) {
+      break;
+    }
+  }
+  if (!f.remainingRows.rows().hasSelections()) {
+    f.ctx.releaseVectors(f.inputValues);
+    f.inputValues.clear();
+    setAllNulls(f, f.remainingRows.originalRows());
+    return false;
+  }
+  return true;
+}
+
+bool ExprEvaluatorV2::tryApplyWithPeeling(EvalFrame& f) {
+  // Mirrors Expr::applyFunctionWithPeeling (Expr.cpp:1534).
+  const auto& applyRows = f.remainingRows.rows();
+  LocalDecodedVector localDecoded(f.ctx);
+  LocalSelectivityVector newRowsHolder(f.ctx);
+
+  // Peeling-suppressed path (small batches): handle the
+  // single-dictionary and single-constant cases explicitly to preserve
+  // the "flat-or-constant inputs" guarantee that vector functions rely
+  // on.
+  if (!f.ctx.peelingEnabled(applyRows) &&
+      !(f.inputValues.size() == 1 &&
+        f.inputValues[0]->encoding() == VectorEncoding::Simple::CONSTANT)) {
+    int dictIndex = -1;
+    bool canFlatten = true;
+
+    for (int i = 0; i < static_cast<int>(f.inputValues.size()); ++i) {
+      auto encoding = f.inputValues[i]->encoding();
+      if (encoding == VectorEncoding::Simple::DICTIONARY) {
+        if (dictIndex != -1) {
+          canFlatten = false;
+          break;
+        }
+        dictIndex = i;
+      }
+    }
+    if (canFlatten && dictIndex != -1) {
+      BaseVector::flattenVector(f.inputValues[dictIndex]);
+      applyFunction(f);
+      return true;
+    }
+    return false;
   }
 
-  // TODO(step 5): port ArgPeeling::tryApply.  For step 4 we always
-  // apply on un-peeled args.
-  applyFunction(f);
+  // Attempt peeling on the evaluated input vectors.
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::peel(
+      f.inputValues,
+      applyRows,
+      localDecoded,
+      f.expr.metadata().defaultNullBehavior,
+      peeledVectors);
+  if (!peeledEncoding) {
+    return false;
+  }
+  f.inputValues = std::move(peeledVectors);
+  peeledVectors.clear();
 
-  // TODO(step 9): write nulls for any rows that ArgEval pruned.  For
-  // step 4 ArgEval never prunes, so remainingRows.hasChanged() is
-  // always false.
-  VELOX_DCHECK(!f.remainingRows.hasChanged());
+  auto* newRows = peeledEncoding->translateToInnerRows(applyRows, newRowsHolder);
+
+  withContextSaver([&](ContextSaver& saver) {
+    f.ctx.saveAndReset(saver, applyRows);
+    f.ctx.setPeeledEncoding(peeledEncoding);
+
+    VectorPtr peeledResult;
+    // Apply on the inner row space against the peeled inputs.  We
+    // temporarily swap result so applyFunction writes into peeledResult.
+    auto savedResult = std::move(f.result);
+    f.result = std::move(peeledResult);
+    // Temporarily redirect remainingRows to newRows for the apply.
+    // We can't construct a new frame because applyFunction reads from
+    // 'f' directly; instead, mutate and restore.
+    // Simpler: bypass MutableRemainingRows here by calling
+    // vectorFunction->apply directly.
+    f.expr.vectorFunction()->apply(
+        *newRows, f.inputValues, f.expr.type(), f.ctx, f.result);
+
+    VectorPtr wrappedResult = f.ctx.getPeeledEncoding()->wrap(
+        f.expr.type(), f.ctx.pool(), f.result, applyRows);
+    auto innerResult = std::move(f.result);
+    f.result = std::move(savedResult);
+    f.ctx.moveOrCopyResult(wrappedResult, applyRows, f.result);
+
+    f.ctx.releaseVector(innerResult);
+  });
+
+  return true;
+}
+
+void ExprEvaluatorV2::setAllNulls(
+    EvalFrame& f,
+    const SelectivityVector& rows) {
+  // Mirrors Expr::setAllNulls (Expr.cpp:1353).
+  if (f.result) {
+    BaseVector::ensureWritable(rows, f.expr.type(), f.ctx.pool(), f.result);
+    LocalSelectivityVector notNulls(f.ctx, rows.end());
+    notNulls.get()->setAll();
+    notNulls.get()->deselect(rows);
+    f.result->addNulls(notNulls.get()->asRange().bits(), rows);
+    return;
+  }
+  f.result =
+      BaseVector::createNullConstant(f.expr.type(), rows.end(), f.ctx.pool());
 }
 
 void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {

--- a/velox/expression/ExprEvaluatorV2.h
+++ b/velox/expression/ExprEvaluatorV2.h
@@ -54,9 +54,17 @@ class ExprEvaluatorV2 {
   void evaluateFunctionCall(EvalFrame& f);
   void evaluateSpecialForm(EvalFrame& f);
 
+  // Argument-evaluation strategies (Expr.cpp:380, 455).  Each populates
+  // f.inputValues, may shrink f.remainingRows, and returns true if at
+  // least one row survived (false means setAllNulls already applied).
+  bool evalArgsDefaultNull(EvalFrame& f);
+  bool evalArgsPreserveNull(EvalFrame& f);
+
   // Leaf operations.
   void applyFunction(EvalFrame& f);
+  bool tryApplyWithPeeling(EvalFrame& f);
   void emitEmpty(EvalFrame& f);
+  void setAllNulls(EvalFrame& f, const SelectivityVector& rows);
 };
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
## Summary

Adds argument evaluation + argument peeling to the V2 evaluator, and
simplifies the tryApplyWithPeeling result-handling path.

Commits:
- `refactor(expression): ArgEval + ArgPeeling (step 9)` — recursive
  evaluation of function-call arguments with per-arg peeling.
- `refactor(expression): Simplify tryApplyWithPeeling result handling` —
  narrow cleanup of the code path introduced above.

## Dependencies

Depends on:
- 1/7 — Design doc (#2232)
- 2/7 — V2 evaluator skeleton (#2233)
- 3/7 — FieldPeeling + DictionaryMemo (#2234)
- **4/7 — NullPruning + SharedSubexprCache (#2235)** (immediate parent —
  must merge first)

Follows in the stack:
- 6/7 — Output tracer + listeners + CPU timing (#2237)
- 7/7 — Wire V2 evaluator + flag + fuzzer parity (#2238)

## Test plan

- [ ] `velox_expression_test --gtest_filter='ExprV2*'` passes.
- [ ] A/B parity harness exercises nested function calls.
