### PR TITLE
[ExprV2 6/7] Output tracer + listeners + CPU timing

### DIFF
--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -18,6 +18,8 @@
 
 #include <folly/ScopeGuard.h>
 
+#include <cmath>
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/exec/trace/TraceWriter.h"
 #include "velox/expression/DebugGuards.h"
@@ -65,6 +67,62 @@ void mergeOrThrowArgumentErrors(
     context.addErrors(rows, argumentErrors, originalErrors);
   }
   context.swapErrors(originalErrors);
+}
+
+// Mirrors the file-private computeIsAsciiForInputs in Expr.cpp:1369.
+void computeIsAsciiForInputs(
+    const VectorFunction* vectorFunction,
+    const std::vector<VectorPtr>& inputValues,
+    const SelectivityVector& rows) {
+  std::vector<size_t> indices;
+  if (vectorFunction->ensureStringEncodingSetAtAllInputs()) {
+    for (size_t i = 0; i < inputValues.size(); ++i) {
+      indices.push_back(i);
+    }
+  }
+  for (auto& index : vectorFunction->ensureStringEncodingSetAt()) {
+    indices.push_back(index);
+  }
+  for (auto& index : indices) {
+    if (index < inputValues.size() &&
+        inputValues[index]->type()->kind() == TypeKind::VARCHAR) {
+      auto* vector = inputValues[index]->template as<SimpleVector<StringView>>();
+      VELOX_CHECK(vector, inputValues[index]->toString());
+      vector->computeAndSetIsAscii(rows);
+    }
+  }
+}
+
+// Mirrors the file-private computeIsAsciiForResult in Expr.cpp:1400.
+std::optional<bool> computeIsAsciiForResult(
+    const VectorFunction* vectorFunction,
+    const std::vector<VectorPtr>& inputValues,
+    const SelectivityVector& rows) {
+  std::vector<size_t> indices;
+  if (vectorFunction->propagateStringEncodingFromAllInputs()) {
+    for (size_t i = 0; i < inputValues.size(); ++i) {
+      indices.push_back(i);
+    }
+  } else if (vectorFunction->propagateStringEncodingFrom().has_value()) {
+    indices = vectorFunction->propagateStringEncodingFrom().value();
+  }
+  if (indices.empty()) {
+    return std::nullopt;
+  }
+  bool isAsciiSet = true;
+  for (auto& index : indices) {
+    if (index < inputValues.size() &&
+        inputValues[index]->type()->kind() == TypeKind::VARCHAR) {
+      auto* vector = inputValues[index]->template as<SimpleVector<StringView>>();
+      auto isAscii = vector->isAscii(rows);
+      if (!isAscii.has_value()) {
+        isAsciiSet = false;
+      } else if (!isAscii.value()) {
+        return false;
+      }
+    }
+  }
+  return isAsciiSet ? std::optional(true) : std::nullopt;
 }
 
 // Mirrors the file-private isFlat() in Expr.cpp (line 355).
@@ -809,15 +867,77 @@ void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {
 }
 
 void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
-  // TODO(step 10b): listener invocation, CPU timing, adaptive
-  // sampling, empty-result handling.
+  // Mirrors Expr::applyFunction (Expr.cpp:1753).
   VELOX_CHECK_NOT_NULL(f.expr.vectorFunction());
-  f.expr.vectorFunction()->apply(
-      f.remainingRows.rows(),
-      f.inputValues,
-      f.expr.type(),
-      f.ctx,
-      f.result);
+  const auto* vectorFunction = f.expr.vectorFunction().get();
+  const auto& rows = f.remainingRows.rows();
+  auto& stats = f.nodeRuntime.stats;
+
+  stats.numProcessedVectors += 1;
+  stats.numProcessedRows += rows.countSelected();
+  auto timer = cpuWallTimer(f);
+
+  computeIsAsciiForInputs(vectorFunction, f.inputValues, rows);
+  auto isAscii = f.expr.type()->isVarchar()
+      ? computeIsAsciiForResult(vectorFunction, f.inputValues, rows)
+      : std::nullopt;
+
+  // Invoke listeners pre/post around apply.  Mirrors
+  // Expr::invokeApplyWithListeners (Expr.cpp:1700).
+  const auto& listeners = f.expr.listeners();
+  bool hasPostListeners = false;
+  for (const auto& listener : listeners) {
+    if (listener.pre) {
+      (*listener.pre)(f.expr.name(), rows, f.inputValues, f.expr.type(), f.ctx);
+    }
+    hasPostListeners |= (listener.post != nullptr);
+  }
+
+  std::exception_ptr applyError;
+  if (!hasPostListeners) {
+    try {
+      vectorFunction->apply(
+          rows, f.inputValues, f.expr.type(), f.ctx, f.result);
+    } catch (const VeloxException&) {
+      throw;
+    } catch (const std::exception& e) {
+      VELOX_USER_FAIL(e.what());
+    }
+  } else {
+    try {
+      vectorFunction->apply(
+          rows, f.inputValues, f.expr.type(), f.ctx, f.result);
+    } catch (const VeloxException&) {
+      applyError = std::current_exception();
+    } catch (const std::exception& e) {
+      try {
+        VELOX_USER_FAIL(e.what());
+      } catch (...) {
+        applyError = std::current_exception();
+      }
+    }
+    for (const auto& listener : listeners) {
+      if (listener.post) {
+        try {
+          (*listener.post)(
+              f.expr.name(),
+              rows,
+              f.inputValues,
+              f.expr.type(),
+              f.ctx,
+              f.result,
+              applyError);
+        } catch (const std::exception& e) {
+          FB_LOG_EVERY_MS(ERROR, 5000)
+              << "Post-apply listener threw for function '" << f.expr.name()
+              << "': " << e.what();
+        }
+      }
+    }
+    if (applyError) {
+      std::rethrow_exception(applyError);
+    }
+  }
 
   // Tracer hook.  Mirrors Expr::traceOutput (Expr.cpp:2131).
   auto& tracer = f.nodeRuntime.outputTracer;
@@ -827,6 +947,120 @@ void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
     } catch (const std::exception& e) {
       LOG(ERROR) << "Failed to trace expression output: " << e.what();
     }
+  }
+
+  // Empty-result handling.  Mirrors Expr.cpp:1770-1789: if the function
+  // returned no result and no error, it's a bug in the function; record
+  // an error and null-fill so downstream callers don't crash.
+  if (!f.result) {
+    MutableRemainingRows remaining(rows, f.ctx);
+    if (remaining.deselectErrors()) {
+      try {
+        VELOX_USER_FAIL(
+            "Function neither returned results nor threw exception.");
+      } catch (const std::exception&) {
+        f.ctx.setErrors(remaining.rows(), std::current_exception());
+      }
+    }
+    f.result =
+        BaseVector::createNullConstant(f.expr.type(), rows.end(), f.ctx.pool());
+  }
+
+  if (isAscii.has_value()) {
+    f.result->asUnchecked<SimpleVector<StringView>>()->setIsAscii(
+        isAscii.value(), rows);
+  }
+
+  // Advance adaptive calibration if we're still measuring.  After
+  // kCalibrating completes, no further calls do anything.
+  using Phase = AdaptiveSamplingState::Phase;
+  if (f.ctx.adaptiveCpuSamplingEnabled() &&
+      (f.nodeRuntime.adaptiveState.phase == Phase::kWarmup ||
+       f.nodeRuntime.adaptiveState.phase == Phase::kCalibrating)) {
+    finalizeAdaptiveCalibration(
+        f,
+        f.ctx.adaptiveCpuSamplingMaxOverheadPct(),
+        f.ctx.timerOverheadNanos());
+  }
+}
+
+std::unique_ptr<CpuWallTimer> ExprEvaluatorV2::cpuWallTimer(EvalFrame& f) {
+  auto& adaptive = f.nodeRuntime.adaptiveState;
+
+  // Compile-time tracking always wins.
+  if (f.expr.trackCpuUsage()) {
+    return std::make_unique<CpuWallTimer>(f.nodeRuntime.stats.timing);
+  }
+
+  if (f.ctx.adaptiveCpuSamplingEnabled()) {
+    using Phase = AdaptiveSamplingState::Phase;
+    switch (adaptive.phase) {
+      case Phase::kWarmup:
+        return nullptr;
+      case Phase::kCalibrating:
+        adaptive.calibrationStopWatch.emplace();
+        return nullptr;
+      case Phase::kAlwaysTrack:
+        return std::make_unique<CpuWallTimer>(f.nodeRuntime.stats.timing);
+      case Phase::kSampling:
+        if (++adaptive.samplingCounter % adaptive.samplingRate == 0) {
+          return std::make_unique<CpuWallTimer>(f.nodeRuntime.stats.timing);
+        }
+        return nullptr;
+    }
+  }
+  return nullptr;
+}
+
+void ExprEvaluatorV2::finalizeAdaptiveCalibration(
+    EvalFrame& f,
+    double maxOverheadPct,
+    uint64_t timerOverheadNanos) {
+  auto& adaptive = f.nodeRuntime.adaptiveState;
+  using Phase = AdaptiveSamplingState::Phase;
+
+  switch (adaptive.phase) {
+    case Phase::kWarmup:
+      adaptive.phase = Phase::kCalibrating;
+      break;
+    case Phase::kCalibrating: {
+      adaptive.calibrationFunctionWallNanos +=
+          adaptive.calibrationStopWatch->elapsed().wallNanos;
+      adaptive.calibrationStopWatch.reset();
+
+      if (++adaptive.calibrationBatchCount <
+          AdaptiveSamplingState::kCalibrationBatches) {
+        break;
+      }
+
+      auto totalTimerOverhead =
+          timerOverheadNanos * adaptive.calibrationBatchCount;
+
+      if (adaptive.calibrationFunctionWallNanos > 0 && maxOverheadPct > 0) {
+        double overheadPct = 100.0 *
+            static_cast<double>(totalTimerOverhead) /
+            static_cast<double>(adaptive.calibrationFunctionWallNanos);
+
+        if (overheadPct > maxOverheadPct) {
+          adaptive.samplingRate =
+              static_cast<uint32_t>(std::ceil(overheadPct / maxOverheadPct));
+          // Start counter at rate-1 so first post-calibration batch is timed.
+          adaptive.samplingCounter = adaptive.samplingRate - 1;
+          adaptive.phase = Phase::kSampling;
+        } else {
+          adaptive.phase = Phase::kAlwaysTrack;
+        }
+      } else {
+        // Function ~0ns -- timer dominates.  Aggressive sampling.
+        adaptive.samplingRate = 100;
+        adaptive.samplingCounter = adaptive.samplingRate - 1;
+        adaptive.phase = Phase::kSampling;
+      }
+      break;
+    }
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected adaptive sampling phase in finalizeAdaptiveCalibration");
   }
 }
 

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -19,6 +19,7 @@
 #include <folly/ScopeGuard.h>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/exec/trace/TraceWriter.h"
 #include "velox/expression/DebugGuards.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/PeeledEncoding.h"
@@ -808,8 +809,8 @@ void ExprEvaluatorV2::evaluateSpecialForm(EvalFrame& f) {
 }
 
 void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
-  // TODO(step 10): port listener invocation, CPU timing, adaptive
-  // sampling, tracer hooks.  Step 4 invokes the bare function.
+  // TODO(step 10b): listener invocation, CPU timing, adaptive
+  // sampling, empty-result handling.
   VELOX_CHECK_NOT_NULL(f.expr.vectorFunction());
   f.expr.vectorFunction()->apply(
       f.remainingRows.rows(),
@@ -817,6 +818,16 @@ void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
       f.expr.type(),
       f.ctx,
       f.result);
+
+  // Tracer hook.  Mirrors Expr::traceOutput (Expr.cpp:2131).
+  auto& tracer = f.nodeRuntime.outputTracer;
+  if (FOLLY_UNLIKELY(tracer != nullptr) && f.result != nullptr) {
+    try {
+      tracer->write(f.result);
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to trace expression output: " << e.what();
+    }
+  }
 }
 
 void ExprEvaluatorV2::emitEmpty(EvalFrame& f) {

--- a/velox/expression/ExprEvaluatorV2.h
+++ b/velox/expression/ExprEvaluatorV2.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/expression/EvalFrame.h"
 
 namespace facebook::velox::exec {
@@ -65,6 +66,19 @@ class ExprEvaluatorV2 {
   bool tryApplyWithPeeling(EvalFrame& f);
   void emitEmpty(EvalFrame& f);
   void setAllNulls(EvalFrame& f, const SelectivityVector& rows);
+
+  // Returns a timer that updates f.nodeRuntime.stats.timing on
+  // destruction, or nullptr if this batch should not be timed.
+  // Mirrors Expr::cpuWallTimer (Expr.cpp:1619).
+  std::unique_ptr<CpuWallTimer> cpuWallTimer(EvalFrame& f);
+
+  // Advances the adaptive sampling state machine after the function
+  // has been invoked.  Mirrors Expr::finalizeAdaptiveCalibration
+  // (Expr.cpp:1650).
+  void finalizeAdaptiveCalibration(
+      EvalFrame& f,
+      double maxOverheadPct,
+      uint64_t timerOverheadNanos);
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -22,6 +22,7 @@
 
 #include <folly/container/F14Map.h>
 
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/expression/ExprStats.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/SelectivityVector.h"
@@ -109,8 +110,44 @@ struct DictionaryMemoState {
   std::unique_ptr<SelectivityVector> cachedDictionaryIndices;
 };
 
-/// Placeholder for adaptive CPU sampling state.  Populated in step 10.
-struct AdaptiveSamplingState {};
+/// Per-Expr adaptive CPU sampling state machine.  Mirrors the cluster
+/// of fields on Expr (Expr.h:802-828).  Decides at runtime whether to
+/// pay CpuWallTimer overhead on each batch, based on a short
+/// calibration phase that measures function cost vs. timer overhead.
+struct AdaptiveSamplingState {
+  /// Number of calibration batches.  Higher = less noise, slower to
+  /// reach steady state.
+  static constexpr uint32_t kCalibrationBatches = 5;
+
+  enum class Phase : uint8_t {
+    /// First batch: warm caches, discard timing.
+    kWarmup,
+    /// Next kCalibrationBatches batches: measure cost without timer.
+    kCalibrating,
+    /// Calibration done: timer overhead acceptable, always track.
+    kAlwaysTrack,
+    /// Calibration done: timer overhead too high, sample 1-of-N.
+    kSampling,
+  };
+
+  Phase phase{Phase::kWarmup};
+
+  // Used only during kCalibrating to measure function cost without
+  // paying the CpuWallTimer overhead.
+  std::optional<DeltaCpuWallTimeStopWatch> calibrationStopWatch;
+
+  // Accumulated function wall time across calibration batches.
+  uint64_t calibrationFunctionWallNanos{0};
+
+  // Calibration batches seen so far.
+  uint32_t calibrationBatchCount{0};
+
+  // Final sampling rate decided after calibration (0 = always track).
+  uint32_t samplingRate{0};
+
+  // Counter for sampling cadence in kSampling phase.
+  uint32_t samplingCounter{0};
+};
 
 /// Mutable per-Expr state that survives across evaluations.  One instance
 /// per ExprV2 per ExprSetV2.  Not thread-safe: concurrent evaluations of

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -26,6 +26,10 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/SelectivityVector.h"
 
+namespace facebook::velox::exec::trace {
+class TraceExprWriter;
+} // namespace facebook::velox::exec::trace
+
 namespace facebook::velox::exec {
 
 class ExprV2;
@@ -117,6 +121,11 @@ struct ExprRuntimeState {
   DictionaryMemoState dictMemo;
   ExprStats stats;
   AdaptiveSamplingState adaptiveState;
+
+  // Per-Expr output tracer.  Set up by ExprSetV2::maybeSetupTracers
+  // when the containing operator has tracing enabled and this
+  // expression's name is in the trace set.  Null when tracing is off.
+  std::unique_ptr<trace::TraceExprWriter> outputTracer;
 };
 
 /// Tree of runtime state parallel-indexed with an ExprV2 forest.  Look

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -16,10 +16,72 @@
 
 #include "velox/expression/ExprSetV2.h"
 
+#include <glog/logging.h>
+
 #include "velox/common/base/Exceptions.h"
+#include "velox/exec/trace/TraceCtx.h"
+#include "velox/exec/trace/TraceWriter.h"
 #include "velox/expression/Expr.h"
 
 namespace facebook::velox::exec {
+
+namespace {
+
+// Walks the V2 tree once, installing per-Expr output tracers on
+// nodes whose name is in the trace set.  Mirrors Expr::maybeSetupTracer
+// (Expr.cpp:2081).  Uses a visited set to avoid redundant work on
+// shared CSE nodes, and an instance counter so multiple Expressions
+// sharing the same name get distinct tracer indices.
+void maybeSetupTracerRecursive(
+    ExprV2& expr,
+    ExprRuntimeStateTree& runtimeStates,
+    const Operator& op,
+    const trace::TraceCtx& traceCtx,
+    std::unordered_set<const ExprV2*>& visited,
+    std::unordered_map<std::string, int>& instanceCounts) {
+  if (!visited.insert(&expr).second) {
+    return;
+  }
+  if (traceCtx.shouldTraceExpr(expr.name())) {
+    const int index = instanceCounts[expr.name()]++;
+    try {
+      runtimeStates.at(expr).outputTracer =
+          traceCtx.createExprOutputTracer(op, expr.name(), index);
+      if (expr.vectorFunction()) {
+        traceCtx.maybeActivateIntraExprTracing(
+            op, expr.name(), *expr.vectorFunction());
+      }
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to set up expression tracer: " << e.what();
+    }
+  }
+  for (const auto& input : expr.inputs()) {
+    maybeSetupTracerRecursive(
+        *input, runtimeStates, op, traceCtx, visited, instanceCounts);
+  }
+}
+
+void finishTracerRecursive(
+    ExprV2& expr,
+    ExprRuntimeStateTree& runtimeStates,
+    std::unordered_set<const ExprV2*>& visited) {
+  if (!visited.insert(&expr).second) {
+    return;
+  }
+  auto& state = runtimeStates.at(expr);
+  if (state.outputTracer) {
+    try {
+      state.outputTracer->finish();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to finish expression output tracer: " << e.what();
+    }
+  }
+  for (const auto& input : expr.inputs()) {
+    finishTracerRecursive(*input, runtimeStates, visited);
+  }
+}
+
+} // namespace
 
 ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> source)
     : sourceSet_{std::move(source)} {
@@ -45,6 +107,28 @@ void ExprSetV2::eval(
   for (size_t i = 0; i < roots_.size(); ++i) {
     EvalFrame frame{*roots_[i], *runtimeStates_, ctx, rows, results[i]};
     evaluator_.evaluate(frame, this);
+  }
+}
+
+void ExprSetV2::maybeSetupTracers(
+    const Operator& op,
+    const trace::TraceCtx& traceCtx) {
+  tracingEnabled_ = true;
+  std::unordered_set<const ExprV2*> visited;
+  std::unordered_map<std::string, int> instanceCounts;
+  for (auto& root : roots_) {
+    maybeSetupTracerRecursive(
+        *root, *runtimeStates_, op, traceCtx, visited, instanceCounts);
+  }
+}
+
+void ExprSetV2::finishTracers() {
+  if (!tracingEnabled_) {
+    return;
+  }
+  std::unordered_set<const ExprV2*> visited;
+  for (auto& root : roots_) {
+    finishTracerRecursive(*root, *runtimeStates_, visited);
   }
 }
 

--- a/velox/expression/ExprSetV2.h
+++ b/velox/expression/ExprSetV2.h
@@ -23,9 +23,14 @@
 #include "velox/expression/ExprRuntimeState.h"
 #include "velox/expression/ExprV2.h"
 
+namespace facebook::velox::exec::trace {
+class TraceCtx;
+} // namespace facebook::velox::exec::trace
+
 namespace facebook::velox::exec {
 
 class ExprSet;
+class Operator;
 
 /// Owner of a tree of immutable ExprV2 nodes plus the parallel runtime
 /// state tree and the stateless evaluator.  Mirrors ExprSet's public
@@ -63,11 +68,25 @@ class ExprSetV2 {
     return sourceSet_;
   }
 
+  /// Mirrors ExprSet::maybeSetupTracers (Expr.cpp:2070).  Walks the V2
+  /// tree once and installs per-Expr output tracers on every node
+  /// whose name is in the operator's trace set.  Tracer state lives
+  /// on ExprRuntimeState::outputTracer.
+  void maybeSetupTracers(
+      const Operator& op,
+      const trace::TraceCtx& traceCtx);
+
+  /// Mirrors ExprSet::finishTracers (Expr.cpp:2105).  Flushes and
+  /// closes every output tracer set up by maybeSetupTracers.  Safe to
+  /// call when tracing was never enabled (no-op in that case).
+  void finishTracers();
+
  private:
   std::shared_ptr<ExprSet> sourceSet_;
   std::vector<std::shared_ptr<ExprV2>> roots_;
   std::unique_ptr<ExprRuntimeStateTree> runtimeStates_;
   ExprEvaluatorV2 evaluator_;
+  bool tracingEnabled_{false};
 };
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
## Summary

Wires observability into the V2 evaluator: output tracer hooks,
listeners, CPU timing, and adaptive sampling — matching V1's
existing surfaces.

Commits:
- `refactor(expression): Output tracer hooks (step 10a)` — hook
  points for tracing per-Expr output vectors.
- `refactor(expression): Listeners + CPU timing + adaptive sampling
  (step 10b)` — VectorFunctionListener integration, per-Expr CPU
  timing, and adaptive sampling of expensive nodes.

## Dependencies

Depends on:
- 1/7 — Design doc (#2232)
- 2/7 — V2 evaluator skeleton (#2233)
- 3/7 — FieldPeeling + DictionaryMemo (#2234)
- 4/7 — NullPruning + SharedSubexprCache (#2235)
- **5/7 — ArgEval + ArgPeeling (#2236)** (immediate parent — must
  merge first)

Follows in the stack:
- 7/7 — Wire V2 evaluator + flag + fuzzer parity (#2238)

## Test plan

- [ ] `velox_expression_test --gtest_filter='ExprV2*'` passes.
- [ ] Tracer / listener test cases fire in the V2 path.
