### PR TITLE
[ExprV2 7/7] Wire V2 evaluator + flag + fuzzer parity

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -39,6 +39,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     // Expression evaluation.
     VELOX_REGISTER_QUERY_CONFIG(kExprEvalSimplified);
     VELOX_REGISTER_QUERY_CONFIG(kExprEvalFlatNoNulls);
+    VELOX_REGISTER_QUERY_CONFIG(kExprEvalV2);
     VELOX_REGISTER_QUERY_CONFIG(kExprTrackCpuUsage);
     VELOX_REGISTER_QUERY_CONFIG(kExprTrackCpuUsageForFunctions);
     VELOX_REGISTER_QUERY_CONFIG(kExprAdaptiveCpuSampling);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -148,6 +148,19 @@ class QueryConfig {
       true,
       "Enable FlatNoNulls fast path for expression evaluation.")
 
+  /// Whether to route expression evaluation through the V2 evaluator
+  /// (ExprEvaluatorV2 + ExprV2).  V2 is a behavior-preserving refactor
+  /// that produces bit-identical output to V1; the flag exists so V2
+  /// can be canaried per-query before the cutover.  False by default
+  /// until canary signal is positive.
+  VELOX_QUERY_CONFIG(
+      kExprEvalV2,
+      exprEvalV2,
+      "expression.eval_v2",
+      bool,
+      false,
+      "Route expression evaluation through the V2 evaluator.")
+
   /// Whether to track CPU usage for individual expressions (supported by call
   /// and cast expressions). False by default. Can be expensive when processing
   /// small batches, e.g. < 10K rows.

--- a/velox/expression/DebugGuards.h
+++ b/velox/expression/DebugGuards.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/velox/expression/EvalFrame.h
+++ b/velox/expression/EvalFrame.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -31,6 +31,7 @@
 #include "velox/common/EnumDefine.h"
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/ExprSetV2.h"
 #include "velox/expression/ExprCompiler.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/LambdaExpr.h"
@@ -2399,6 +2400,10 @@ std::unique_ptr<ExprSet> makeExprSetFromFlag(
   if (execCtx->queryCtx()->queryConfig().exprEvalSimplified() ||
       FLAGS_force_eval_simplified) {
     return std::make_unique<ExprSetSimplified>(std::move(source), execCtx);
+  }
+  if (execCtx->queryCtx()->queryConfig().exprEvalV2()) {
+    return std::make_unique<ExprSetV2>(
+        source, execCtx, /*enableConstantFolding=*/true, lazyDereference);
   }
   return std::make_unique<ExprSet>(
       std::move(source), execCtx, true, lazyDereference);

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -465,6 +465,14 @@ class Expr {
     return trackCpuUsage_;
   }
 
+  /// Returns the per-Expr output tracer if one has been installed by
+  /// ExprSet::maybeSetupTracers, or nullptr otherwise.  Exposed
+  /// publicly so the V2 evaluator can route trace writes through the
+  /// V1 tracer state during the migration period.
+  trace::TraceExprWriter* outputTracer() const {
+    return outputTracer_.get();
+  }
+
   std::vector<VectorPtr>& inputValues() {
     return inputValues_;
   }

--- a/velox/expression/ExprEvaluatorV2.cpp
+++ b/velox/expression/ExprEvaluatorV2.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -939,8 +940,12 @@ void ExprEvaluatorV2::applyFunction(EvalFrame& f) {
     }
   }
 
-  // Tracer hook.  Mirrors Expr::traceOutput (Expr.cpp:2131).
-  auto& tracer = f.nodeRuntime.outputTracer;
+  // Tracer hook.  Mirrors Expr::traceOutput (Expr.cpp:2131).  V2
+  // delegates to the V1 Expr's tracer (installed by
+  // ExprSet::maybeSetupTracers, inherited via ExprSetV2) so we don't
+  // duplicate tracer state across V1 and V2 trees during the
+  // migration period.
+  auto* tracer = f.expr.sourceExpr()->outputTracer();
   if (FOLLY_UNLIKELY(tracer != nullptr) && f.result != nullptr) {
     try {
       tracer->write(f.result);

--- a/velox/expression/ExprEvaluatorV2.h
+++ b/velox/expression/ExprEvaluatorV2.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/velox/expression/ExprRuntimeState.cpp
+++ b/velox/expression/ExprRuntimeState.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/velox/expression/ExprRuntimeState.h
+++ b/velox/expression/ExprRuntimeState.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +27,6 @@
 #include "velox/expression/ExprStats.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/SelectivityVector.h"
-
-namespace facebook::velox::exec::trace {
-class TraceExprWriter;
-} // namespace facebook::velox::exec::trace
 
 namespace facebook::velox::exec {
 
@@ -158,11 +155,10 @@ struct ExprRuntimeState {
   DictionaryMemoState dictMemo;
   ExprStats stats;
   AdaptiveSamplingState adaptiveState;
-
-  // Per-Expr output tracer.  Set up by ExprSetV2::maybeSetupTracers
-  // when the containing operator has tracing enabled and this
-  // expression's name is in the trace set.  Null when tracing is off.
-  std::unique_ptr<trace::TraceExprWriter> outputTracer;
+  // Tracer is read directly from the source Expr via
+  // ExprV2::sourceExpr()->outputTracer().  V2 doesn't own its own
+  // tracer; ExprSet::maybeSetupTracers (inherited by ExprSetV2)
+  // installs tracers on the V1 Expr nodes that V2 wraps.
 };
 
 /// Tree of runtime state parallel-indexed with an ExprV2 forest.  Look

--- a/velox/expression/ExprSetV2.cpp
+++ b/velox/expression/ExprSetV2.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,119 +17,55 @@
 
 #include "velox/expression/ExprSetV2.h"
 
-#include <glog/logging.h>
-
 #include "velox/common/base/Exceptions.h"
-#include "velox/exec/trace/TraceCtx.h"
-#include "velox/exec/trace/TraceWriter.h"
-#include "velox/expression/Expr.h"
+#include "velox/expression/FieldReference.h"
 
 namespace facebook::velox::exec {
 
-namespace {
-
-// Walks the V2 tree once, installing per-Expr output tracers on
-// nodes whose name is in the trace set.  Mirrors Expr::maybeSetupTracer
-// (Expr.cpp:2081).  Uses a visited set to avoid redundant work on
-// shared CSE nodes, and an instance counter so multiple Expressions
-// sharing the same name get distinct tracer indices.
-void maybeSetupTracerRecursive(
-    ExprV2& expr,
-    ExprRuntimeStateTree& runtimeStates,
-    const Operator& op,
-    const trace::TraceCtx& traceCtx,
-    std::unordered_set<const ExprV2*>& visited,
-    std::unordered_map<std::string, int>& instanceCounts) {
-  if (!visited.insert(&expr).second) {
-    return;
-  }
-  if (traceCtx.shouldTraceExpr(expr.name())) {
-    const int index = instanceCounts[expr.name()]++;
-    try {
-      runtimeStates.at(expr).outputTracer =
-          traceCtx.createExprOutputTracer(op, expr.name(), index);
-      if (expr.vectorFunction()) {
-        traceCtx.maybeActivateIntraExprTracing(
-            op, expr.name(), *expr.vectorFunction());
-      }
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "Failed to set up expression tracer: " << e.what();
-    }
-  }
-  for (const auto& input : expr.inputs()) {
-    maybeSetupTracerRecursive(
-        *input, runtimeStates, op, traceCtx, visited, instanceCounts);
-  }
-}
-
-void finishTracerRecursive(
-    ExprV2& expr,
-    ExprRuntimeStateTree& runtimeStates,
-    std::unordered_set<const ExprV2*>& visited) {
-  if (!visited.insert(&expr).second) {
-    return;
-  }
-  auto& state = runtimeStates.at(expr);
-  if (state.outputTracer) {
-    try {
-      state.outputTracer->finish();
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "Failed to finish expression output tracer: " << e.what();
-    }
-  }
-  for (const auto& input : expr.inputs()) {
-    finishTracerRecursive(*input, runtimeStates, visited);
-  }
-}
-
-} // namespace
-
-ExprSetV2::ExprSetV2(std::shared_ptr<ExprSet> source)
-    : sourceSet_{std::move(source)} {
-  VELOX_CHECK_NOT_NULL(sourceSet_, "ExprSetV2 requires a non-null ExprSet");
-
-  roots_.reserve(sourceSet_->exprs().size());
-  for (const auto& root : sourceSet_->exprs()) {
+ExprSetV2::ExprSetV2(
+    const std::vector<core::TypedExprPtr>& source,
+    core::ExecCtx* execCtx,
+    bool enableConstantFolding,
+    bool lazyDereference)
+    : ExprSet(source, execCtx, enableConstantFolding, lazyDereference) {
+  // Base class constructor has populated exprs_ via ExprCompiler.
+  // Walk it once to build the V2 mirror tree.
+  roots_.reserve(exprs().size());
+  for (const auto& root : exprs()) {
     roots_.push_back(ExprV2::from(root));
   }
-
   runtimeStates_ = std::make_unique<ExprRuntimeStateTree>(roots_);
 }
 
 void ExprSetV2::eval(
+    int32_t begin,
+    int32_t end,
+    bool initialize,
     const SelectivityVector& rows,
-    EvalCtx& ctx,
-    std::vector<VectorPtr>& results) {
-  VELOX_CHECK_EQ(
-      results.size(),
-      roots_.size(),
-      "results vector must be sized to the number of expression roots");
+    EvalCtx& context,
+    std::vector<VectorPtr>& result) {
+  VELOX_CHECK_EQ(lazyDereference(), context.lazyDereference());
+  result.resize(exprs().size());
 
-  for (size_t i = 0; i < roots_.size(); ++i) {
-    EvalFrame frame{*roots_[i], *runtimeStates_, ctx, rows, results[i]};
+  // Match ExprSet::eval's setup work (Expr.cpp:2305-2334).  These are
+  // protected helpers on the base class.
+  if (initialize) {
+    clearSharedSubexprs();
+  }
+  if (adaptiveCpuSampling_) {
+    initializeAdaptiveCpuSampling(context);
+  }
+  if (!lazyDereference()) {
+    for (const auto& field : multiplyReferencedFields_) {
+      context.ensureFieldLoaded(field->index(context), rows);
+    }
+  }
+
+  // V2 root iteration.  Equivalent to V1's exprs_[i]->eval(...) loop,
+  // but drives the V2 evaluator against each V2 root.
+  for (int32_t i = begin; i < end; ++i) {
+    EvalFrame frame{*roots_[i], *runtimeStates_, context, rows, result[i]};
     evaluator_.evaluate(frame, this);
-  }
-}
-
-void ExprSetV2::maybeSetupTracers(
-    const Operator& op,
-    const trace::TraceCtx& traceCtx) {
-  tracingEnabled_ = true;
-  std::unordered_set<const ExprV2*> visited;
-  std::unordered_map<std::string, int> instanceCounts;
-  for (auto& root : roots_) {
-    maybeSetupTracerRecursive(
-        *root, *runtimeStates_, op, traceCtx, visited, instanceCounts);
-  }
-}
-
-void ExprSetV2::finishTracers() {
-  if (!tracingEnabled_) {
-    return;
-  }
-  std::unordered_set<const ExprV2*> visited;
-  for (auto& root : roots_) {
-    finishTracerRecursive(*root, *runtimeStates_, visited);
   }
 }
 

--- a/velox/expression/ExprSetV2.h
+++ b/velox/expression/ExprSetV2.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,41 +20,55 @@
 #include <memory>
 #include <vector>
 
+#include "velox/expression/Expr.h"
 #include "velox/expression/ExprEvaluatorV2.h"
 #include "velox/expression/ExprRuntimeState.h"
 #include "velox/expression/ExprV2.h"
 
-namespace facebook::velox::exec::trace {
-class TraceCtx;
-} // namespace facebook::velox::exec::trace
-
 namespace facebook::velox::exec {
 
-class ExprSet;
-class Operator;
-
-/// Owner of a tree of immutable ExprV2 nodes plus the parallel runtime
-/// state tree and the stateless evaluator.  Mirrors ExprSet's public
-/// shape but routes evaluation through the V2 pipeline.
+/// Routes expression evaluation through the V2 evaluator.
 ///
-/// During the migration period, ExprSetV2 is constructed from an
-/// existing ExprSet (which already holds compiled Expr trees).  This
-/// avoids duplicating any compiler, parser, or registry logic.
-class ExprSetV2 {
+/// ExprSetV2 IS-A ExprSet (mirroring ExprSetSimplified's relationship
+/// to ExprSet).  Construction goes through the same compiler pipeline
+/// as the base class — ExprCompiler builds the V1 Expr tree first, and
+/// the parallel ExprV2 mirror tree is built on top in this
+/// constructor.  Callers hold ExprSet pointers; the virtual eval()
+/// dispatches to this override when the active ExprSet is a V2 one.
+///
+/// Constructed by makeExprSetFromFlag (Expr.cpp) when
+/// QueryConfig::exprEvalV2() is true.  Existing operator callers
+/// (FilterProject, ParallelProject) pick it up automatically through
+/// that factory.
+class ExprSetV2 : public ExprSet {
  public:
-  /// Adapts an existing compiled ExprSet to V2 by walking each root
-  /// Expr and producing a parallel ExprV2 tree.  The source ExprSet is
-  /// retained for lifetime of FieldReference pointers and for
-  /// delegated special-form evaluation.
-  explicit ExprSetV2(std::shared_ptr<ExprSet> source);
+  /// Constructs the base ExprSet (V1 Expr tree via ExprCompiler), then
+  /// adapts each root into the parallel ExprV2 mirror tree and builds
+  /// the per-node ExprRuntimeStateTree.
+  ExprSetV2(
+      const std::vector<core::TypedExprPtr>& source,
+      core::ExecCtx* execCtx,
+      bool enableConstantFolding = true,
+      bool lazyDereference = false);
 
-  /// Evaluates all roots for 'rows' and writes outputs into 'results'.
+  ~ExprSetV2() override = default;
+
+  /// Drives the V2 pipeline.  Mirrors ExprSet::eval's setup work
+  /// (clearSharedSubexprs, initializeAdaptiveCpuSampling, lazy field
+  /// pre-loading) and then iterates V2 roots through ExprEvaluatorV2
+  /// instead of calling Expr::eval.
   void eval(
+      int32_t begin,
+      int32_t end,
+      bool initialize,
       const SelectivityVector& rows,
       EvalCtx& ctx,
-      std::vector<VectorPtr>& results);
+      std::vector<VectorPtr>& result) override;
 
-  const std::vector<std::shared_ptr<ExprV2>>& exprs() const {
+  /// V2 mirror tree, parallel to the base class's exprs() but holding
+  /// ExprV2 nodes.  Each ExprV2 retains a shared_ptr to its source
+  /// Expr (which lives in the base class's exprs_).
+  const std::vector<std::shared_ptr<ExprV2>>& exprsV2() const {
     return roots_;
   }
 
@@ -61,32 +76,10 @@ class ExprSetV2 {
     return *runtimeStates_;
   }
 
-  /// The V1 ExprSet this V2 set was adapted from.  During the migration
-  /// period, callers pass this to EvalCtx so it can route exception
-  /// context, memo updates, and tracer hooks through V1's bookkeeping.
-  const std::shared_ptr<ExprSet>& sourceSet() const {
-    return sourceSet_;
-  }
-
-  /// Mirrors ExprSet::maybeSetupTracers (Expr.cpp:2070).  Walks the V2
-  /// tree once and installs per-Expr output tracers on every node
-  /// whose name is in the operator's trace set.  Tracer state lives
-  /// on ExprRuntimeState::outputTracer.
-  void maybeSetupTracers(
-      const Operator& op,
-      const trace::TraceCtx& traceCtx);
-
-  /// Mirrors ExprSet::finishTracers (Expr.cpp:2105).  Flushes and
-  /// closes every output tracer set up by maybeSetupTracers.  Safe to
-  /// call when tracing was never enabled (no-op in that case).
-  void finishTracers();
-
  private:
-  std::shared_ptr<ExprSet> sourceSet_;
   std::vector<std::shared_ptr<ExprV2>> roots_;
   std::unique_ptr<ExprRuntimeStateTree> runtimeStates_;
   ExprEvaluatorV2 evaluator_;
-  bool tracingEnabled_{false};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprV2.cpp
+++ b/velox/expression/ExprV2.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/velox/expression/ExprV2.h
+++ b/velox/expression/ExprV2.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/velox/expression/tests/ExprV2AdapterTest.cpp
+++ b/velox/expression/tests/ExprV2AdapterTest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,22 +140,23 @@ TEST_F(ExprV2AdapterTest, fieldReferencePointersPreserved) {
       root->multiplyReferencedFields().size());
 }
 
-// ExprSetV2 should adapt every root from the source ExprSet and build a
-// runtime-state tree covering all unique nodes.
+// ExprSetV2 should build both the inherited V1 tree (via the base
+// ExprSet constructor) and the parallel V2 tree covering every
+// reachable node.
 TEST_F(ExprV2AdapterTest, exprSetV2Construction) {
   auto rowType = ROW({{"a", BIGINT()}, {"b", BIGINT()}});
-  parse::ParseOptions options;
   std::vector<core::TypedExprPtr> typed{
       parseExpression("a + b", rowType),
       parseExpression("a * b", rowType),
   };
-  auto exprSet = std::make_shared<ExprSet>(std::move(typed), execCtx_.get());
+  ExprSetV2 v2{typed, execCtx_.get()};
 
-  ExprSetV2 v2{exprSet};
-
+  // Inherited V1 surface still works through ExprSetV2.
   ASSERT_EQ(v2.exprs().size(), 2);
-  EXPECT_EQ(v2.exprs()[0]->sourceExpr().get(), exprSet->exprs()[0].get());
-  EXPECT_EQ(v2.exprs()[1]->sourceExpr().get(), exprSet->exprs()[1].get());
+  // V2 mirror tree, parallel to v2.exprs().
+  ASSERT_EQ(v2.exprsV2().size(), 2);
+  EXPECT_EQ(v2.exprsV2()[0]->sourceExpr().get(), v2.exprs()[0].get());
+  EXPECT_EQ(v2.exprsV2()[1]->sourceExpr().get(), v2.exprs()[1].get());
 
   // Runtime-state tree should cover at least the 2 roots + their unique
   // descendants.  Each root is binary so total >= 2 (roots) + 4

--- a/velox/expression/tests/ExprV2ParityTest.cpp
+++ b/velox/expression/tests/ExprV2ParityTest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2026 IBM Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +66,9 @@ class ExprV2ParityTest : public testing::Test,
     v1Set->eval(rows, v1Ctx, v1Results);
 
     // V2 path -- adapt the same compiled ExprSet.
-    ExprSetV2 v2Set{v1Set};
-    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    ExprSetV2 v2Set{
+        std::vector<core::TypedExprPtr>{typed}, execCtx_.get()};
+    EvalCtx v2Ctx{execCtx_.get(), &v2Set, input.get()};
     std::vector<VectorPtr> v2Results(1);
     v2Set.eval(rows, v2Ctx, v2Results);
 
@@ -191,7 +193,8 @@ TEST_F(ExprV2ParityTest, dictionaryMemoAcrossBatches) {
 
   auto v1Set = std::make_shared<ExprSet>(
       std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
-  ExprSetV2 v2Set{v1Set};
+  ExprSetV2 v2Set{
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get()};
 
   for (const auto& input : inputs) {
     SelectivityVector rows{input->size()};
@@ -200,7 +203,7 @@ TEST_F(ExprV2ParityTest, dictionaryMemoAcrossBatches) {
     std::vector<VectorPtr> v1Results(1);
     v1Set->eval(rows, v1Ctx, v1Results);
 
-    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    EvalCtx v2Ctx{execCtx_.get(), &v2Set, input.get()};
     std::vector<VectorPtr> v2Results(1);
     v2Set.eval(rows, v2Ctx, v2Results);
 
@@ -243,7 +246,8 @@ TEST_F(ExprV2ParityTest, sharedSubexprAcrossBatches) {
 
   auto v1Set = std::make_shared<ExprSet>(
       std::vector<core::TypedExprPtr>{typed}, execCtx_.get());
-  ExprSetV2 v2Set{v1Set};
+  ExprSetV2 v2Set{
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get()};
 
   for (int batch = 0; batch < 2; ++batch) {
     auto input = makeRowVector(
@@ -256,7 +260,7 @@ TEST_F(ExprV2ParityTest, sharedSubexprAcrossBatches) {
     std::vector<VectorPtr> v1Results(1);
     v1Set->eval(rows, v1Ctx, v1Results);
 
-    EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+    EvalCtx v2Ctx{execCtx_.get(), &v2Set, input.get()};
     std::vector<VectorPtr> v2Results(1);
     v2Set.eval(rows, v2Ctx, v2Results);
 
@@ -284,8 +288,9 @@ TEST_F(ExprV2ParityTest, emptyRows) {
   std::vector<VectorPtr> v1Results(1);
   v1Set->eval(rows, v1Ctx, v1Results);
 
-  ExprSetV2 v2Set{v1Set};
-  EvalCtx v2Ctx{execCtx_.get(), v2Set.sourceSet().get(), input.get()};
+  ExprSetV2 v2Set{
+      std::vector<core::TypedExprPtr>{typed}, execCtx_.get()};
+  EvalCtx v2Ctx{execCtx_.get(), &v2Set, input.get()};
   std::vector<VectorPtr> v2Results(1);
   v2Set.eval(rows, v2Ctx, v2Results);
 

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -22,6 +22,7 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/ExprSetV2.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/VectorSaver.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
@@ -308,6 +309,30 @@ ExpressionVerifier::verify(
       createExprSetCommon(plans, execCtx_, options_.disableConstantFolding);
   exec::ExprSetSimplified exprSetSimplified(plans, execCtx_);
 
+  // Optional V2 ExprSet built alongside the canonical V1 pair so the
+  // fuzzer can compare V2 output against V1 common on every test case.
+  // The compiler must see exprEvalV2=true during construction so it
+  // emits V2 special-form classes (e.g., CastExprV2).  We save and
+  // restore the full QueryConfig because testingOverrideConfigUnsafe
+  // replaces (not merges) the underlying config map.
+  std::optional<exec::ExprSetV2> exprSetV2;
+  if (options_.enableV2Fuzzing) {
+    auto savedConfig =
+        execCtx_->queryCtx()->queryConfig().rawConfigsCopy();
+    auto v2Config = savedConfig;
+    v2Config[core::QueryConfig::kExprEvalV2] = "true";
+    execCtx_->queryCtx()->testingOverrideConfigUnsafe(std::move(v2Config));
+    try {
+      exprSetV2.emplace(
+          plans, execCtx_, !options_.disableConstantFolding);
+    } catch (...) {
+      execCtx_->queryCtx()->testingOverrideConfigUnsafe(
+          std::move(savedConfig));
+      throw;
+    }
+    execCtx_->queryCtx()->testingOverrideConfigUnsafe(std::move(savedConfig));
+  }
+
   int testCaseItr = 0;
   for (auto [rowVector, rows] : transformedInputTestCases) {
     LOG(INFO) << "Executing test case: " << testCaseItr++;
@@ -383,6 +408,8 @@ ExpressionVerifier::verify(
       }
       LOG(INFO) << "Common eval succeeded.";
     } catch (const VeloxException& e) {
+      // Capture common eval failure pre-V2.  V2 comparison below is
+      // gated on whether common path threw too.
       LOG(INFO) << "Common eval failed.";
       if (e.errorCode() == error_code::kUnsupportedInputUncatchable) {
         unsupportedInputUncatchableError = true;
@@ -413,6 +440,115 @@ ExpressionVerifier::verify(
           sql,
           complexConstants);
       throw;
+    }
+
+    // === V2 fuzzing — evaluate the same expression through ExprSetV2
+    // and compare against the V1 common path's results / exception
+    // pattern.  Any divergence is a V2 bug; we throw out of the test
+    // case so the fuzzer harness reports it with the full repro
+    // context.
+    std::vector<VectorPtr> v2EvalResult;
+    std::exception_ptr exceptionV2Ptr;
+    if (exprSetV2.has_value()) {
+      VLOG(1) << "Starting V2 eval execution.";
+      if (resultVector) {
+        auto resultRowVector = resultVector->asUnchecked<RowVector>();
+        v2EvalResult.resize(resultRowVector->children().size());
+        for (int i = 0; i < resultRowVector->children().size(); ++i) {
+          v2EvalResult[i] = resultRowVector->children()[i];
+        }
+      }
+      try {
+        // Re-fuzz lazy wrapping using the same metadata so V1 and V2
+        // see equivalent inputs.  V2 uses its own freshly-wrapped row
+        // vector; the V1 common path already consumed the previous
+        // wrap above.
+        auto v2InputRowVector = transformInput(
+            rowVector,
+            execCtx_,
+            options_.disableConstantFolding,
+            transformPlans,
+            originalInputFields);
+        v2InputRowVector = VectorFuzzer::fuzzRowChildrenToLazy(
+            v2InputRowVector, inputRowMetadata.columnsToWrapInLazy);
+        exec::EvalCtx evalCtxV2(
+            execCtx_, &*exprSetV2, v2InputRowVector.get());
+        exprSetV2->eval(
+            0,
+            exprSetV2->size(),
+            true /*initialize*/,
+            rows,
+            evalCtxV2,
+            v2EvalResult);
+        LOG(INFO) << "V2 eval succeeded.";
+      } catch (const VeloxException& e) {
+        if (e.errorCode() == error_code::kUnsupportedInputUncatchable) {
+          unsupportedInputUncatchableError = true;
+        } else if (!(canThrow && e.isUserError())) {
+          if (!canThrow) {
+            LOG(ERROR)
+                << "V2 eval wasn't supposed to throw, but it did. Aborting.";
+          } else if (!e.isUserError()) {
+            LOG(ERROR)
+                << "V2 eval: VeloxRuntimeErrors other than UNSUPPORTED_INPUT_UNCATCHABLE are not allowed.";
+          }
+          persistReproInfoIfNeeded(
+              inputTestCases,
+              inputRowMetadata,
+              copiedResult,
+              sql,
+              complexConstants);
+          throw;
+        }
+        exceptionV2Ptr = std::current_exception();
+      } catch (...) {
+        LOG(ERROR) << "V2 eval threw a non-Velox exception.";
+        persistReproInfoIfNeeded(
+            inputTestCases,
+            inputRowMetadata,
+            copiedResult,
+            sql,
+            complexConstants);
+        throw;
+      }
+
+      // Compare V1 common vs V2.  Any mismatch is a V2 parity bug.
+      try {
+        if (exceptionCommonPtr || exceptionV2Ptr) {
+          if (!unsupportedInputUncatchableError) {
+            if (exceptionCommonPtr && exceptionV2Ptr) {
+              fuzzer::compareExceptions(exceptionCommonPtr, exceptionV2Ptr);
+            } else {
+              LOG(ERROR) << fmt::format(
+                  "V1 common vs V2 divergence: only {} threw an exception.",
+                  exceptionCommonPtr ? "V1 common" : "V2");
+              if (exceptionCommonPtr) {
+                std::rethrow_exception(exceptionCommonPtr);
+              } else {
+                std::rethrow_exception(exceptionV2Ptr);
+              }
+            }
+          }
+        } else {
+          VELOX_CHECK_EQ(commonEvalResult.size(), v2EvalResult.size());
+          for (int i = 0; i < commonEvalResult.size(); ++i) {
+            fuzzer::compareVectors(
+                commonEvalResult[i],
+                v2EvalResult[i],
+                "V1 common path results",
+                "V2 path results",
+                rows);
+          }
+        }
+      } catch (...) {
+        persistReproInfoIfNeeded(
+            inputTestCases,
+            inputRowMetadata,
+            copiedResult,
+            sql,
+            complexConstants);
+        throw;
+      }
     }
 
     VLOG(1) << "Starting reference eval execution.";

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -36,6 +36,12 @@ struct ExpressionVerifierOptions {
   bool disableConstantFolding{false};
   std::string reproPersistPath;
   bool persistAndRunOnce{false};
+  // When true, the verifier additionally evaluates each expression
+  // through the V2 evaluator (ExprSetV2) and asserts bit-identical
+  // output (and matching exception patterns) against the V1 common
+  // path.  Defaults to true while V2 is in experimental mode to
+  // maximize divergence coverage from fuzzer runs.
+  bool enableV2Fuzzing{true};
 };
 
 class ExpressionVerifier {


### PR DESCRIPTION
## Summary

Wires ExprSetV2 into `makeExprSetFromFlag` behind the
`expression.eval_v2` QueryConfig flag (default off), and exercises
V2 in the existing expression fuzzer alongside V1 common + simplified.

Commits:
- `refactor(expression): Wire V2 evaluator + flag + fuzzer parity` —
  ExprSetV2 becomes a subclass of ExprSet; `makeExprSetFromFlag`
  branches on `exprEvalV2()`; ExpressionVerifier runs V2 in the
  fuzz harness so any V1-vs-V2 divergence is caught before flip.

## Dependencies

Depends on the entire preceding stack:
- 1/7 — Design doc (#2232)
- 2/7 — V2 evaluator skeleton (#2233)
- 3/7 — FieldPeeling + DictionaryMemo (#2234)
- 4/7 — NullPruning + SharedSubexprCache (#2235)
- 5/7 — ArgEval + ArgPeeling (#2236)
- **6/7 — Output tracer + listeners + CPU timing (#2237)** (immediate
  parent — must merge first)

This is the final PR in the stack.  After it merges, V2 can be
canaried per-query via `SET expression.eval_v2 = true` (native session
property wiring is a separate follow-up).

## Test plan

- [ ] `velox_expression_test --gtest_filter='ExprV2*'` passes.
- [ ] Expression fuzzer runs clean with V2 enabled.
