### PR TITLE
Improve S3 error messages and retryable detection in getErrorStringFr…

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
@@ -41,8 +41,30 @@ std::string getErrorStringFromS3Error(
       return "Service unavailable";
     case Aws::S3::S3Errors::NETWORK_CONNECTION:
       return "Network connection";
+    case Aws::S3::S3Errors::INTERNAL_FAILURE:
+      return "Internal failure (possible incomplete response from S3)";
+    case Aws::S3::S3Errors::THROTTLING:
+      return "Throttling";
+    case Aws::S3::S3Errors::SLOW_DOWN:
+      return "Slow down";
+    case Aws::S3::S3Errors::REQUEST_TIMEOUT:
+      return "Request timeout";
+    case Aws::S3::S3Errors::REQUEST_EXPIRED:
+      return "Request expired";
+    case Aws::S3::S3Errors::REQUEST_TIME_TOO_SKEWED:
+      return "Request time too skewed";
+    case Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID:
+      return "Invalid access key ID";
+    case Aws::S3::S3Errors::INVALID_OBJECT_STATE:
+      return "Invalid object state";
     default:
-      return "Unknown error";
+      auto exceptionName = error.GetExceptionName();
+      if (!exceptionName.empty()) {
+        return std::string(exceptionName.c_str());
+      }
+      return fmt::format(
+          "Unknown error (SDK error type: {})",
+          static_cast<int>(error.GetErrorType()));
   }
 }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -172,11 +172,10 @@ inline std::string getRequestID(
           getS3BackendService(error.GetResponseHeaders()),                                                                      \
           error.GetMessage(),                                                                                                   \
           getRequestID(error.GetResponseHeaders()));                                                                            \
-      if (IsRetryableHttpResponseCode(error.GetResponseCode())) {                                                               \
-        auto retryHint = fmt::format(                                                                                           \
+      if (IsRetryableHttpResponseCode(error.GetResponseCode()) || error.ShouldRetry()) {                                        \
+        errMsg.append(fmt::format(                                                                                              \
             " Request failed after retrying {} times. Try increasing the value of 'hive.s3.max-attempts'.",                     \
-            outcome.GetRetryCount());                                                                                           \
-        errMsg.append(retryHint);                                                                                               \
+            outcome.GetRetryCount()));                                                                                          \
       }                                                                                                                         \
       if (error.GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {                                                  \
         VELOX_FILE_NOT_FOUND_ERROR(errMsg);                                                                                     \


### PR DESCRIPTION
## Summary

Improve `getErrorStringFromS3Error` to cover common AWS S3 error types that
previously fell through to an uninformative "Unknown error" message, and enhance
the retryable detection in `VELOX_CHECK_AWS_OUTCOME` macro.

## Problem

`getErrorStringFromS3Error` only handles 6 out of 25+ possible S3 error types.
Any error outside that set is reported as "Unknown error", losing critical
diagnostic information.

For example, when S3 returns a 503 SlowDown response (a very common throttling
scenario under high request rates), the SDK maps it to `Aws::S3::S3Errors::SLOW_DOWN`
(type=19). Since this case is missing from the switch statement, users see:

Failed to get S3 object due to: 'Unknown error'. Path:'s3://bucket/key',
SDK Error Type:19, HTTP Status Code:503, Message:'Please reduce your request rate.'

The fix makes this actionable:

Failed to get S3 object due to: 'Slow down'. Path:'s3://bucket/key',
SDK Error Type:19, HTTP Status Code:503, Message:'Please reduce your request rate.'
Request failed after retrying 3 times. Try increasing the value of 'hive.s3.max-attempts'.

Similarly, when a response stream is interrupted mid-transfer (e.g., during large
ORC file reads), `CurlHttpClient` sets the error type to `INTERNAL_FAILURE` (type=1)
with HTTP status code=-1. This also falls through to "Unknown error" today.

## Changes

1. **Add 8 error type cases** to `getErrorStringFromS3Error`:
   - `INTERNAL_FAILURE` — response stream interrupted / incomplete response
   - `THROTTLING` — request throttled by service
   - `SLOW_DOWN` — S3 503 SlowDown (rate limiting)
   - `REQUEST_TIMEOUT` — request timed out
   - `REQUEST_EXPIRED` — signature expired
   - `REQUEST_TIME_TOO_SKEWED` — client clock drift
   - `INVALID_ACCESS_KEY_ID` — invalid credentials
   - `INVALID_OBJECT_STATE` — object in Glacier/archive state

   All enum values verified in AWS SDK 1.11.654 `S3Errors.h` and `CoreErrors.cpp`.

- S3Errors.h → generated/src/aws-cpp-sdk-s3/include/aws/s3/S3Errors.h
- CoreErrors.cpp → src/aws-cpp-sdk-core/source/client/CoreErrors.cpp
- CurlHttpClient.cpp → src/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp


2. **Improve default branch** to use `error.GetExceptionName()` as fallback,
   and include the SDK error type number when exception name is empty. This
   ensures future SDK error types are never silently swallowed.

3. **Add `error.ShouldRetry()`** to retryable check in `VELOX_CHECK_AWS_OUTCOME`,
   so SDK-marked retryable errors (e.g., SlowDown, Throttling, InternalFailure
   from XML response) correctly trigger the retry hint message.

## Testing

- Existing `S3UtilTest` continues to pass (no behavioral change for previously covered cases).
- Error string mapping verified against AWS SDK source (`CoreErrors.cpp:28-92`,
  `S3Errors.cpp:44-101`, `CurlHttpClient.cpp:991-999`).