### PR TITLE
fix(expression): Restore ExprSetV2 3-arg eval and fix adapter test node lookup

### DIFF
--- a/velox/expression/ExprSetV2.h
+++ b/velox/expression/ExprSetV2.h
@@ -53,6 +53,11 @@ class ExprSetV2 : public ExprSet {
 
   ~ExprSetV2() override = default;
 
+  // Un-hide the base-class eval overloads (notably the 3-argument
+  // convenience wrapper) that the eval override below would otherwise
+  // hide via name lookup.
+  using ExprSet::eval;
+
   /// Drives the V2 pipeline.  Mirrors ExprSet::eval's setup work
   /// (clearSharedSubexprs, initializeAdaptiveCpuSampling, lazy field
   /// pre-loading) and then iterates V2 roots through ExprEvaluatorV2

--- a/velox/expression/tests/ExprV2AdapterTest.cpp
+++ b/velox/expression/tests/ExprV2AdapterTest.cpp
@@ -165,8 +165,8 @@ TEST_F(ExprV2AdapterTest, exprSetV2Construction) {
   EXPECT_GE(v2.runtimeStates().size(), 6u);
 
   // at() returns distinct state instances per node.
-  auto& s0 = v2.runtimeStates().at(*v2.exprs()[0]);
-  auto& s1 = v2.runtimeStates().at(*v2.exprs()[1]);
+  auto& s0 = v2.runtimeStates().at(*v2.exprsV2()[0]);
+  auto& s1 = v2.runtimeStates().at(*v2.exprsV2()[1]);
   EXPECT_NE(&s0, &s1);
 }
 


### PR DESCRIPTION
## Summary

The ExprV2 test files on `bolt` do not compile in a clean build — a latent defect from PR #2238 (ExprV2 step 07) that incremental builds masked by reusing stale test objects.

Two bugs:

1. **`ExprSetV2` hid the base 3-arg `eval()`.** `ExprSetV2` overrides only the 6-argument virtual `eval(...)`, which via C++ name hiding removed the base `ExprSet::eval(rows, ctx, result)` convenience wrapper from lookup. `ExprV2ParityTest` calls that 3-argument form → `error: too few arguments to function call, expected 6, have 3`. Fixed with `using ExprSet::eval;`.
2. **`ExprV2AdapterTest` passed an `Expr` to `at(const ExprV2&)`.** `runtimeStates().at(*v2.exprs()[0])` used `exprs()` (returns `Expr`) instead of `exprsV2()` (returns `ExprV2`) → `error: no viable conversion from 'exec::Expr' to 'const ExprV2'`. Fixed by using `exprsV2()`.

## Test plan

- Force clean-recompiled both `ExprV2ParityTest.cpp` and `ExprV2AdapterTest.cpp` (deleted their `.o` first) to defeat incremental staleness.
- `velox_expression_test --gtest_filter='ExprV2ParityTest.*:ExprV2AdapterTest.*'` → 19/19 pass.