### PR TITLE
perf(expression): Cast evaluation optimizations (cast-perf-3.0)

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -223,7 +223,7 @@ RowVectorPtr FilterProject::getOutput() {
 
   if (!hasFilter_) {
     VELOX_CHECK(!isIdentityProjection_);
-    auto results = project(*rows, evalCtx);
+    const auto& results = project(*rows, evalCtx);
     if (!lazyDereference_) {
       loadReusedLazyVectors(input_, reusedInputChannels_);
     }
@@ -240,12 +240,11 @@ RowVectorPtr FilterProject::getOutput() {
 
   const bool allRowsSelected = (numOut == size);
   // evaluate projections (if present)
-  std::vector<VectorPtr> results;
   if (!isIdentityProjection_) {
     if (!allRowsSelected) {
       rows->setFromBits(filterEvalCtx_.selectedBits->as<uint64_t>(), size);
     }
-    results = project(*rows, evalCtx);
+    project(*rows, evalCtx);
   }
 
   if (!lazyDereference_) {
@@ -254,25 +253,41 @@ RowVectorPtr FilterProject::getOutput() {
   auto output = fillOutput(
       numOut,
       allRowsSelected ? nullptr : filterEvalCtx_.selectedIndices,
-      results);
+      projectResults_);
   return output;
 }
 
-std::vector<VectorPtr> FilterProject::project(
+const std::vector<VectorPtr>& FilterProject::project(
     const SelectivityVector& rows,
     EvalCtx& evalCtx) {
-  std::vector<VectorPtr> results;
+  // Push the prior call's outputs back to execCtx's VectorPool. The pool
+  // only accepts singly-referenced flat vectors and silently skips
+  // anything still held by a downstream consumer - so this is safe
+  // regardless of how the consumer drained the prior output. exprs_->eval
+  // resizes projectResults_ and writes into the (now-null) entries; each
+  // ensureWritable inside the per-Expr eval finds a recycled vector via
+  // VectorPool::get instead of allocating fresh.
+  evalCtx.releaseVectors(projectResults_);
   exprs_->eval(
-      hasFilter_ ? 1 : 0, numExprs_, !hasFilter_, rows, evalCtx, results);
-  return results;
+      hasFilter_ ? 1 : 0,
+      numExprs_,
+      !hasFilter_,
+      rows,
+      evalCtx,
+      projectResults_);
+  return projectResults_;
 }
 
 vector_size_t FilterProject::filter(
     EvalCtx& evalCtx,
     const SelectivityVector& allRows) {
-  std::vector<VectorPtr> results;
-  exprs_->eval(0, 1, true, allRows, evalCtx, results);
-  return processFilterResults(results[0], allRows, filterEvalCtx_, pool());
+  // Same recycle pattern as project(). processFilterResults reads
+  // filterResults_[0] inline and does not retain a reference, so the
+  // boolean vector is free to be reclaimed on the next call.
+  evalCtx.releaseVectors(filterResults_);
+  exprs_->eval(0, 1, true, allRows, evalCtx, filterResults_);
+  return processFilterResults(
+      filterResults_[0], allRows, filterEvalCtx_, pool());
 }
 
 OperatorStats FilterProject::stats(bool clear) {

--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -260,14 +260,20 @@ RowVectorPtr FilterProject::getOutput() {
 const std::vector<VectorPtr>& FilterProject::project(
     const SelectivityVector& rows,
     EvalCtx& evalCtx) {
-  // Push the prior call's outputs back to execCtx's VectorPool. The pool
-  // only accepts singly-referenced flat vectors and silently skips
-  // anything still held by a downstream consumer - so this is safe
-  // regardless of how the consumer drained the prior output. exprs_->eval
-  // resizes projectResults_ and writes into the (now-null) entries; each
-  // ensureWritable inside the per-Expr eval finds a recycled vector via
-  // VectorPool::get instead of allocating fresh.
+  // Drop the prior call's outputs before the next eval so per-Expr state
+  // that wraps a result vector (most importantly Expr::evalWithMemo's
+  // dictionaryCache_) ends the call at use_count == 1 and the next
+  // ensureWritable can rewrite it in place rather than fall through to
+  // BaseVector::ensureWritable's copy-on-write allocation.
+  //
+  // releaseVectors moves any singly-referenced flat entries into
+  // execCtx's VectorPool (those then satisfy subsequent ensureWritable
+  // calls via VectorPool::get without an allocation); clear() drops
+  // anything VectorPool::release rejected - in practice the Dictionary-
+  // Vector wrappers produced by encoding-peeled evaluation, whose
+  // wrapped flat bases are what we actually want to free for reuse.
   evalCtx.releaseVectors(projectResults_);
+  projectResults_.clear();
   exprs_->eval(
       hasFilter_ ? 1 : 0,
       numExprs_,
@@ -285,6 +291,7 @@ vector_size_t FilterProject::filter(
   // filterResults_[0] inline and does not retain a reference, so the
   // boolean vector is free to be reclaimed on the next call.
   evalCtx.releaseVectors(filterResults_);
+  filterResults_.clear();
   exprs_->eval(0, 1, true, allRows, evalCtx, filterResults_);
   return processFilterResults(
       filterResults_[0], allRows, filterEvalCtx_, pool());

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -97,9 +97,11 @@ class FilterProject : public Operator {
   // updated.
   vector_size_t filter(EvalCtx& evalCtx, const SelectivityVector& allRows);
 
-  // Evaluate projections on the specified rows and return the results.
+  // Evaluate projections on the specified rows. The results are written into
+  // 'projectResults_' (a member, reused across calls). Returns a reference to
+  // 'projectResults_' for use by 'fillOutput'.
   // pre-condition: !isIdentityProjection_
-  std::vector<VectorPtr> project(
+  const std::vector<VectorPtr>& project(
       const SelectivityVector& rows,
       EvalCtx& evalCtx);
 
@@ -136,5 +138,16 @@ class FilterProject : public Operator {
   // (no partial-row loading through pushdown hooks) and expects lazy vectors to
   // remain unloaded for downstream parallel processing.
   std::vector<column_index_t> reusedInputChannels_;
+
+  // Filter and projection result vectors held across getOutput() calls so
+  // EvalCtx's VectorPool can recycle them. Each call to filter()/project()
+  // first releases the prior entries (which are singly-referenced when the
+  // downstream consumer has dropped the prior output) back to the pool, so
+  // the next exprs_->eval finds recyclable vectors via ensureWritable
+  // instead of allocating fresh ones. Entries that are still multi-owned
+  // because the consumer still holds the prior output are skipped by
+  // VectorPool::release - the harm is just a missed reuse, not correctness.
+  std::vector<VectorPtr> filterResults_;
+  std::vector<VectorPtr> projectResults_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -31,6 +31,17 @@ target_link_libraries(
   Folly::follybenchmark
 )
 
+add_executable(
+  velox_cast_in_filter_project_benchmark CastInFilterProjectBenchmark.cpp)
+
+target_link_libraries(
+  velox_cast_in_filter_project_benchmark
+  velox_exec
+  velox_vector_test_lib
+  velox_exec_test_lib
+  Folly::follybenchmark
+)
+
 add_executable(velox_exchange_benchmark ExchangeBenchmark.cpp)
 
 target_link_libraries(

--- a/velox/exec/benchmarks/CastInFilterProjectBenchmark.cpp
+++ b/velox/exec/benchmarks/CastInFilterProjectBenchmark.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+/// Exercises CAST inside FilterProject over a dictionary-encoded input,
+/// the shape that prompted FilterProject's filter/project result-vector
+/// recycle path (FilterProject keeps filterResults_ / projectResults_ as
+/// members, releases them to ExecCtx's VectorPool and clears any non-
+/// poolable wrappers at the top of each call). The benchmark builds:
+///
+///   Values(dictionary-encoded input) -> Project(cast(c0 as <type>))
+///
+/// and sweeps rows-per-vector and dictionary cardinality to highlight
+/// the per-call fixed cost that small vectors expose. With the recycle
+/// path in place, the next batch's BaseVector::ensureWritable on the
+/// cast result reuses the prior buffer in place instead of taking the
+/// copy-on-write branch through MemoryPoolImpl::allocate.
+///
+/// READING THE OUTPUT
+///   <CastPair>_<rowsPerVector>_<distinctValueCount>_<nullPct>
+///
+/// numVectors is fixed at kNumVectors (1000) and is not encoded in the
+/// name. nullPct is the percentage of dictionary positions marked null
+/// on the wrap. Each measurement runs the plan once over those 1000
+/// vectors; folly normalises time by the row count returned, so the
+/// printed time/iter is per row.
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using facebook::velox::test::VectorTestBase;
+
+DEFINE_bool(gtest_color, false, "");
+DEFINE_string(gtest_filter, "*", "");
+
+namespace {
+
+constexpr int32_t kNumVectors = 1000;
+
+class CastInFilterProjectBenchmark : public VectorTestBase {
+ public:
+  // Builds `numVectors` row vectors, each `rowsPerVector` rows wide.
+  // Every input vector wraps a flat base of `baseType` and
+  // `distinctValueCount` distinct values in a DictionaryVector with
+  // indices `(row + vectorIdx) % distinctValueCount` - so consecutive
+  // vectors share the same underlying base (enabling
+  // Expr::evalWithMemo's dictionaryCache_ to stay warm) but rotate
+  // which positions are hit.
+  // Builds `numVectors` dictionary-wrapped row vectors. nullPct is the
+  // percentage of dictionary positions marked null on the wrap (not on
+  // the underlying flat base). The wrap-level nulls are what reach
+  // PeeledEncoding::translateToInnerRows via wrapNulls_ - 0 takes the
+  // hoisted no-nulls fast path, 50 exercises the null-aware loop with
+  // a mix, and 100 marks every row null so the inner-rows set comes
+  // out empty.
+  template <typename BaseNativeType>
+  std::vector<RowVectorPtr> makeDictInput(
+      const TypePtr& baseType,
+      int32_t numVectors,
+      int32_t rowsPerVector,
+      int32_t distinctValueCount,
+      int32_t nullPct) {
+    auto base = makeFlatVector<BaseNativeType>(
+        distinctValueCount,
+        [](vector_size_t row) { return static_cast<BaseNativeType>(row + 1); },
+        nullptr,
+        baseType);
+
+    std::vector<RowVectorPtr> vectors;
+    vectors.reserve(numVectors);
+    for (int32_t vectorIdx = 0; vectorIdx < numVectors; ++vectorIdx) {
+      auto indices =
+          AlignedBuffer::allocate<vector_size_t>(rowsPerVector, pool());
+      auto* rawIndices = indices->asMutable<vector_size_t>();
+      for (int32_t row = 0; row < rowsPerVector; ++row) {
+        rawIndices[row] = (row + vectorIdx) % distinctValueCount;
+      }
+
+      BufferPtr nulls;
+      if (nullPct > 0) {
+        nulls = AlignedBuffer::allocate<bool>(rowsPerVector, pool());
+        auto* rawNulls = nulls->asMutable<uint64_t>();
+        if (nullPct >= 100) {
+          // Every row null.
+          bits::fillBits(rawNulls, 0, rowsPerVector, bits::kNull);
+        } else {
+          // Mark every (100/nullPct)-th row null; the rest are
+          // non-null. For nullPct=50 that produces a regular
+          // null/non-null/null/non-null pattern.
+          bits::fillBits(rawNulls, 0, rowsPerVector, bits::kNotNull);
+          const int32_t step = 100 / nullPct;
+          for (int32_t row = 0; row < rowsPerVector; row += step) {
+            bits::setNull(rawNulls, row, true);
+          }
+        }
+      }
+      auto dict =
+          BaseVector::wrapInDictionary(nulls, indices, rowsPerVector, base);
+      vectors.push_back(makeRowVector({dict}));
+    }
+    return vectors;
+  }
+
+  // Builds a Values -> Project plan applying `castExpr` to c0.
+  std::shared_ptr<const core::PlanNode> makePlan(
+      const std::vector<RowVectorPtr>& data,
+      const std::string& castExpr) {
+    exec::test::PlanBuilder builder;
+    builder.values(data);
+    builder.project({castExpr});
+    return builder.planNode();
+  }
+
+  // Runs the plan once via AssertQueryBuilder; returns the total row
+  // count produced.
+  size_t run(const std::shared_ptr<const core::PlanNode>& plan) {
+    auto result = exec::test::AssertQueryBuilder(plan).copyResults(pool());
+    return result ? result->size() : 0;
+  }
+};
+
+// Each free function below is one benchmark entry point. The returned
+// value (total rows produced) tells folly the iteration count for
+// per-row normalisation. Plans are rebuilt per iter (the underlying
+// data vectors stay alive for the bench lifetime, but FilterProject's
+// member state is fresh each Driver instantiation - that's the
+// realistic worst case: a hot operator instance accumulates its
+// recycle pool over many getOutput() calls, whereas a cold one starts
+// empty).
+
+template <typename BaseNativeType>
+size_t runDict(
+    unsigned iters,
+    const TypePtr& baseType,
+    const std::string& castExpr,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t nullPct) {
+  CastInFilterProjectBenchmark bm;
+  auto data = bm.makeDictInput<BaseNativeType>(
+      baseType, kNumVectors, rowsPerVector, distinctValueCount, nullPct);
+  auto plan = bm.makePlan(data, castExpr);
+
+  size_t total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += bm.run(plan);
+  }
+  return total;
+}
+
+unsigned DICT_IntToBigint(
+    unsigned iters,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t nullPct) {
+  return runDict<int32_t>(
+      iters,
+      INTEGER(),
+      "cast(c0 as bigint)",
+      rowsPerVector,
+      distinctValueCount,
+      nullPct);
+}
+
+unsigned DICT_RealToDouble(
+    unsigned iters,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t nullPct) {
+  return runDict<float>(
+      iters,
+      REAL(),
+      "cast(c0 as double)",
+      rowsPerVector,
+      distinctValueCount,
+      nullPct);
+}
+
+unsigned DICT_BigintToVarchar(
+    unsigned iters,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t nullPct) {
+  return runDict<int64_t>(
+      iters,
+      BIGINT(),
+      "cast(c0 as varchar)",
+      rowsPerVector,
+      distinctValueCount,
+      nullPct);
+}
+
+} // namespace
+
+#define DICT(funcName, rowsPerVector, distinctValueCount, nullPct)      \
+  BENCHMARK_NAMED_PARAM_MULTI(                                          \
+      funcName,                                                         \
+      rowsPerVector##_##distinctValueCount##_##nullPct,                 \
+      rowsPerVector,                                                    \
+      distinctValueCount,                                               \
+      nullPct)
+
+#define SWEEP_AT(funcName, rowsPerVector, distinctValueCount) \
+  DICT(funcName, rowsPerVector, distinctValueCount, 0)        \
+  DICT(funcName, rowsPerVector, distinctValueCount, 50)       \
+  DICT(funcName, rowsPerVector, distinctValueCount, 100)
+
+#define SWEEP(funcName)                  \
+  SWEEP_AT(funcName, 1000, 5)            \
+  SWEEP_AT(funcName, 1000, 500)          \
+  SWEEP_AT(funcName, 1000, 15000)        \
+  SWEEP_AT(funcName, 10000, 5)           \
+  SWEEP_AT(funcName, 10000, 500)         \
+  SWEEP_AT(funcName, 10000, 15000)
+
+BENCHMARK_DRAW_LINE();
+SWEEP(DICT_IntToBigint)
+// BENCHMARK_DRAW_LINE();
+// SWEEP(DICT_RealToDouble)
+// BENCHMARK_DRAW_LINE();
+// SWEEP(DICT_BigintToVarchar)
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::initializeMemoryManager(memory::MemoryManager::Options{});
+  functions::prestosql::registerAllScalarFunctions();
+  parse::registerTypeResolver();
+
+  std::cout
+      << "\nBenchmark entry names encode the sweep parameters:\n"
+      << "  DICT_<from>To<to>(rowsPerVector_distinctValueCount_nullPct)\n"
+      << "\n"
+      << "numVectors is fixed at " << kNumVectors
+      << " for every entry and is not encoded in the name. Each measurement\n"
+      << "runs a Values -> Project plan over those " << kNumVectors
+      << " dictionary-encoded vectors; folly normalises time by the row count\n"
+      << "produced, so the printed time/iter is per row.\n"
+      << "\n"
+      << "  rowsPerVector       : rows in each input vector\n"
+      << "  distinctValueCount  : dictionary base cardinality. All vectors\n"
+      << "                        share the same flat base of this size,\n"
+      << "                        so the second-and-subsequent vectors hit\n"
+      << "                        Expr::evalWithMemo's cache path.\n"
+      << "  nullPct             : percentage of dictionary positions marked\n"
+      << "                        null on the wrap. 0 takes the hoisted no-\n"
+      << "                        nulls path in translateToInnerRows; 50\n"
+      << "                        exercises the null-aware loop; 100 marks\n"
+      << "                        every position null.\n"
+      << "\n";
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -151,3 +151,7 @@ if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
   add_subdirectory(fuzzer)
 endif()
+
+if(${VELOX_ENABLE_BENCHMARKS})
+  add_subdirectory(benchmarks)
+endif()

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -586,7 +586,10 @@ void CastExpr::applyCastPrimitives(
   auto* resultFlatVector = result->as<FlatVector<To>>();
   auto* inputSimpleVector = input.as<SimpleVector<From>>();
 
-  switch (hooks_->getPolicy()) {
+  // hooks_->getPolicy() is constant for the lifetime of this CastExpr;
+  // policy() caches the resolved value on the first call so the switch
+  // below doesn't pay a virtual call per applyCastPrimitives.
+  switch (policy()) {
     case LegacyCastPolicy:
       applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
         applyCastKernel<ToKind, FromKind, util::LegacyCastPolicy>(
@@ -613,7 +616,7 @@ void CastExpr::applyCastPrimitives(
       break;
 
     default:
-      VELOX_NYI("Policy {} not yet implemented.", hooks_->getPolicy());
+      VELOX_NYI("Policy {} not yet implemented.", policy());
   }
 }
 

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -58,36 +58,6 @@ inline std::exception_ptr makeBadCastException(
       false));
 }
 
-// Returns true if casting from 'fromType' to 'toType' is a supported fast
-// upcast.
-bool isSupportedFastUpcast(const TypePtr& fromType, const TypePtr& toType) {
-  auto isIntegralType = [](const TypePtr& type) {
-    return type == TINYINT() || type == SMALLINT() || type == INTEGER() ||
-        type == BIGINT();
-  };
-
-  auto isBasicNumericType = [&isIntegralType](const TypePtr& type) {
-    return isIntegralType(type) || type == REAL() || type == DOUBLE();
-  };
-
-  if (isIntegralType(fromType) && isBasicNumericType(toType)) {
-    if (fromType->cppSizeInBytes() < toType->cppSizeInBytes()) {
-      return true;
-    }
-    if (fromType == INTEGER() && toType == REAL()) {
-      return true;
-    }
-    if (fromType == BIGINT() && (toType == REAL() || toType == DOUBLE())) {
-      return true;
-    }
-  }
-
-  if (fromType == REAL() && toType == DOUBLE()) {
-    return true;
-  }
-  return false;
-}
-
 } // namespace
 
 template <typename Func>
@@ -720,7 +690,7 @@ void CastExpr::applyCastPrimitivesDispatch(
     VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
   }
 
-  if (isSupportedFastUpcast(fromType, toType)) {
+  if (CastExpr::isSupportedFastUpcast(fromType, toType)) {
     VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
         applyNumericUpcast,
         ToKind,

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -127,14 +127,45 @@ VectorPtr CastExpr::castFromDate(
   switch (toType->kind()) {
     case TypeKind::VARCHAR: {
       auto* resultFlatVector = castResult->as<FlatVector<StringView>>();
+      // Format options are constant for the whole call; hoist out.
+      TimestampToStringOptions options;
+      options.mode = TimestampToStringOptions::Mode::kDateOnly;
+      options.zeroPaddingYear = true;
+      // getMaxStringLength(kDateOnly) is 17 (signed 10-digit year +
+      // "-MM-DD"). The vast majority of DATE values render as
+      // "YYYY-MM-DD" (10 chars) which fits inside StringView's 12-byte
+      // inline storage - those rows never need an out-of-line string
+      // buffer at all. Only year out of [-9999, 999999] produces a
+      // longer output that has to be persisted in a result-owned
+      // buffer.
+      constexpr size_t kMaxDateLen = 17;
       applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
         try {
-          // TODO Optimize to avoid creating an intermediate string.
-          auto output = DATE()->toString(inputFlatVector->valueAt(row));
-          auto writer = exec::StringWriter(resultFlatVector, row);
-          writer.resize(output.size());
-          ::memcpy(writer.data(), output.data(), output.size());
-          writer.finalize();
+          char stackBuf[kMaxDateLen];
+          const int32_t days = inputFlatVector->valueAt(row);
+          const int64_t daySeconds = static_cast<int64_t>(days) * 86400;
+          std::tm tm;
+          VELOX_CHECK(
+              Timestamp::epochToCalendarUtc(daySeconds, tm),
+              "Can't convert days to date: {}",
+              days);
+          const auto sv =
+              Timestamp::tmToStringView(tm, 0, options, stackBuf);
+          // For sv.size() <= StringView::kInlineSize (12) the
+          // StringView ctor copied the bytes into sv's own inline
+          // storage - stackBuf is unreferenced after this point and
+          // we can store sv directly. For larger outputs (rare large
+          // year) sv points into stackBuf so we must persist the bytes
+          // in a result-owned buffer before storing.
+          if (FOLLY_LIKELY(sv.isInline())) {
+            resultFlatVector->setNoCopy(row, sv);
+          } else {
+            char* persistent =
+                resultFlatVector->getRawStringBufferWithSpace(sv.size());
+            ::memcpy(persistent, sv.data(), sv.size());
+            resultFlatVector->setNoCopy(
+                row, StringView(persistent, sv.size()));
+          }
         } catch (const VeloxException& ue) {
           if (!ue.isUserError()) {
             throw;

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -50,6 +50,70 @@ const tz::TimeZone* getTimeZoneFromConfig(const core::QueryConfig& config) {
 
 } // namespace
 
+bool CastExpr::isSupportedFastUpcast(
+    const TypePtr& fromType,
+    const TypePtr& toType) {
+  auto isIntegralType = [](const TypePtr& type) {
+    return type == TINYINT() || type == SMALLINT() || type == INTEGER() ||
+        type == BIGINT();
+  };
+
+  auto isBasicNumericType = [&isIntegralType](const TypePtr& type) {
+    return isIntegralType(type) || type == REAL() || type == DOUBLE();
+  };
+
+  if (isIntegralType(fromType) && isBasicNumericType(toType)) {
+    if (fromType->cppSizeInBytes() < toType->cppSizeInBytes()) {
+      return true;
+    }
+    if (fromType == INTEGER() && toType == REAL()) {
+      return true;
+    }
+    if (fromType == BIGINT() && (toType == REAL() || toType == DOUBLE())) {
+      return true;
+    }
+  }
+
+  if (fromType == REAL() && toType == DOUBLE()) {
+    return true;
+  }
+  return false;
+}
+
+bool CastExpr::isCheapToReevaluate() const {
+  // Three families of casts qualify as "cheap":
+  //
+  // 1. Fast numeric upcasts (see applyNumericUpcast) - one static_cast
+  //    per row over a flat input. Non-throwing by construction.
+  // 2. DATE -> TIMESTAMP - integer multiply by 86'400'000 plus a
+  //    divmod in Timestamp::fromMillis, optionally followed by a
+  //    timezone shift in Timestamp::toGMT. DATE values always
+  //    represent midnight; midnight does not fall in any IANA DST
+  //    gap, so toGMT is in practice non-throwing for date-derived
+  //    timestamps. The per-row cost is single-digit cycles plus a
+  //    constant timezone-table lookup when adjustment is active.
+  // 3. DATE -> VARCHAR - format DATE(int32 days) into a fixed-width
+  //    "YYYY-MM-DD" string. Non-throwing for valid date values and
+  //    the formatted string is small enough to stay inline in
+  //    StringView, so we avoid out-of-line buffer churn too.
+  //
+  // Filling every base position up front on second sight pays for
+  // itself across the subsequent O(1) dictionary wraps the eager-fill
+  // path enables in Expr::evalWithMemo.
+  if (inputs_.empty()) {
+    return false;
+  }
+  const auto& fromType = inputs_[0]->type();
+  if (isSupportedFastUpcast(fromType, type_)) {
+    return true;
+  }
+  if (fromType->isDate() &&
+      (type_->isTimestamp() || type_->kind() == TypeKind::VARCHAR)) {
+    return true;
+  }
+  return false;
+}
+
 VectorPtr CastExpr::castFromDate(
     const SelectivityVector& rows,
     const BaseVector& input,

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -877,8 +877,13 @@ void CastExpr::applyPeeled(
     const TypePtr& fromType,
     const TypePtr& toType,
     VectorPtr& result) {
-  auto castFromOperator = getCastOperator(fromType);
-  auto castToOperator = getCastOperator(toType);
+  // The (fromType, toType) pair is the same across every per-vector
+  // call for the top-level cast, so cache the operator lookups once
+  // on the CastExpr instance instead of hashing castOperators_ twice
+  // per call.
+  ensureTopLevelCastOperators(fromType, toType);
+  const auto& castFromOperator = topLevelCastFromOperator_;
+  const auto& castToOperator = topLevelCastToOperator_;
 
   // CastRulesRegistry is the source of truth for all custom type cast
   // validation, including container types (e.g., ARRAY<T> → JSON).
@@ -1304,6 +1309,17 @@ CastOperatorPtr CastExpr::getCastOperator(const TypePtr& type) {
 
   castOperators_.emplace(key, castOperator);
   return castOperator;
+}
+
+void CastExpr::ensureTopLevelCastOperators(
+    const TypePtr& fromType,
+    const TypePtr& toType) {
+  if (topLevelCastOperatorsCached_) {
+    return;
+  }
+  topLevelCastFromOperator_ = getCastOperator(fromType);
+  topLevelCastToOperator_ = getCastOperator(toType);
+  topLevelCastOperatorsCached_ = true;
 }
 
 TypePtr CastCallToSpecialForm::resolveType(

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -1189,50 +1189,78 @@ void CastExpr::apply(
 
   context.deselectErrors(*remainingRows);
 
-  LocalDecodedVector decoded(context, *input, *remainingRows);
-  auto* rawNulls = decoded->nulls(remainingRows.get());
-
-  if (rawNulls) {
-    remainingRows->deselectNulls(
-        rawNulls, remainingRows->begin(), remainingRows->end());
-  }
-
   VectorPtr localResult;
-  if (!remainingRows->hasSelections()) {
-    localResult =
-        BaseVector::createNullConstant(toType, rows.end(), context.pool());
-  } else if (decoded->isIdentityMapping()) {
-    applyPeeled(
-        *remainingRows,
-        *decoded->base(),
-        context,
-        fromType,
-        toType,
-        localResult);
-  } else {
-    withContextSaver([&](ContextSaver& saver) {
-      LocalSelectivityVector newRowsHolder(*context.execCtx());
 
-      LocalDecodedVector localDecoded(context);
-      std::vector<VectorPtr> peeledVectors;
-      auto peeledEncoding = PeeledEncoding::peel(
-          {input}, *remainingRows, localDecoded, true, peeledVectors);
-      VELOX_CHECK_EQ(peeledVectors.size(), 1);
-      if (peeledVectors[0]->isLazy()) {
-        peeledVectors[0] =
-            peeledVectors[0]->as<LazyVector>()->loadedVectorShared();
-      }
-      auto newRows =
-          peeledEncoding->translateToInnerRows(*remainingRows, newRowsHolder);
-      // Save context and set the peel.
-      context.saveAndReset(saver, *remainingRows);
-      context.setPeeledEncoding(peeledEncoding);
+  // Flat-identity fast path: skip the LocalDecodedVector + DecodedVector::
+  // decode setup entirely. For a flat input the DecodedVector would set
+  // isIdentityMapping=true with base()==&input and nulls()==input->raw-
+  // Nulls(); we can reach the same state directly without the per-call
+  // allocation and decode cost. This is the common shape at the top of
+  // evaluate() once a child expression has produced a flat result.
+  const uint64_t* rawNulls = nullptr;
+  if (input->isFlatEncoding()) {
+    rawNulls = input->rawNulls();
+    if (rawNulls) {
+      remainingRows->deselectNulls(
+          rawNulls, remainingRows->begin(), remainingRows->end());
+    }
+    if (!remainingRows->hasSelections()) {
+      localResult =
+          BaseVector::createNullConstant(toType, rows.end(), context.pool());
+    } else {
       applyPeeled(
-          *newRows, *peeledVectors[0], context, fromType, toType, localResult);
+          *remainingRows, *input, context, fromType, toType, localResult);
+    }
+  } else {
+    LocalDecodedVector decoded(context, *input, *remainingRows);
+    rawNulls = decoded->nulls(remainingRows.get());
 
-      localResult = context.getPeeledEncoding()->wrap(
-          toType, context.pool(), localResult, *remainingRows);
-    });
+    if (rawNulls) {
+      remainingRows->deselectNulls(
+          rawNulls, remainingRows->begin(), remainingRows->end());
+    }
+
+    if (!remainingRows->hasSelections()) {
+      localResult =
+          BaseVector::createNullConstant(toType, rows.end(), context.pool());
+    } else if (decoded->isIdentityMapping()) {
+      applyPeeled(
+          *remainingRows,
+          *decoded->base(),
+          context,
+          fromType,
+          toType,
+          localResult);
+    } else {
+      withContextSaver([&](ContextSaver& saver) {
+        LocalSelectivityVector newRowsHolder(*context.execCtx());
+
+        LocalDecodedVector localDecoded(context);
+        std::vector<VectorPtr> peeledVectors;
+        auto peeledEncoding = PeeledEncoding::peel(
+            {input}, *remainingRows, localDecoded, true, peeledVectors);
+        VELOX_CHECK_EQ(peeledVectors.size(), 1);
+        if (peeledVectors[0]->isLazy()) {
+          peeledVectors[0] =
+              peeledVectors[0]->as<LazyVector>()->loadedVectorShared();
+        }
+        auto newRows = peeledEncoding->translateToInnerRows(
+            *remainingRows, newRowsHolder);
+        // Save context and set the peel.
+        context.saveAndReset(saver, *remainingRows);
+        context.setPeeledEncoding(peeledEncoding);
+        applyPeeled(
+            *newRows,
+            *peeledVectors[0],
+            context,
+            fromType,
+            toType,
+            localResult);
+
+        localResult = context.getPeeledEncoding()->wrap(
+            toType, context.pool(), localResult, *remainingRows);
+      });
+    }
   }
   context.moveOrCopyResult(localResult, *remainingRows, result);
   context.releaseVector(localResult);

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -191,6 +191,7 @@ VectorPtr CastExpr::castFromDate(
       // virtual dispatch, no per-row exception frame.
       hooks_->castDateToTimestampVector(
           rows, *inputFlatVector, *resultFlatVector, timeZone);
+
       return castResult;
     }
     default:
@@ -211,11 +212,15 @@ VectorPtr CastExpr::castToDate(
   switch (fromType->kind()) {
     case TypeKind::VARCHAR: {
       auto* inputVector = input.as<SimpleVector<StringView>>();
+      // Cache the raw hook pointer outside the loop - skip the
+      // shared_ptr<CastHooks> indirection per row, and let LTO
+      // devirtualize the call given PrestoCastHooks is final.
+      auto* hooks = hooks_.get();
       applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
         bool wrapException = true;
         try {
           const auto result =
-              hooks_->castStringToDate(inputVector->valueAt(row));
+              hooks->castStringToDate(inputVector->valueAt(row));
           setResultOrError(
               row,
               result,

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -154,14 +154,23 @@ VectorPtr CastExpr::castFromDate(
       const auto* timeZone =
           getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
       auto* resultFlatVector = castResult->as<FlatVector<Timestamp>>();
-      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
-        auto timestamp = Timestamp::fromMillis(
-            inputFlatVector->valueAt(row) * kMillisPerDay);
-        if (timeZone) {
+      // Hoist the timezone-presence branch out of the per-row loop:
+      // pick one of two specialized loops here, so the inner body has no
+      // condition to evaluate for every row.
+      if (timeZone != nullptr) {
+        applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
+          auto timestamp = Timestamp::fromMillis(
+              inputFlatVector->valueAt(row) * kMillisPerDay);
           hooks_->castDateTimestampToGMT(timestamp, *timeZone);
-        }
-        resultFlatVector->set(row, timestamp);
-      });
+          resultFlatVector->set(row, timestamp);
+        });
+      } else {
+        applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
+          auto timestamp = Timestamp::fromMillis(
+              inputFlatVector->valueAt(row) * kMillisPerDay);
+          resultFlatVector->set(row, timestamp);
+        });
+      }
 
       return castResult;
     }
@@ -298,22 +307,9 @@ VectorPtr CastExpr::castFromTime(
           true /*exactSize*/);
       char* rawBuffer = buffer->asMutable<char>() + buffer->size();
 
-      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
+      // Hoist the timezone-presence branch out of the per-row loop.
+      auto rowBody = [&](int row, int64_t adjustedTime) {
         try {
-          // Use timezone-aware conversion
-          auto systemTime =
-              systemDay.count() * kMillisInDay + inputFlatVector->valueAt(row);
-
-          int64_t adjustedTime{0};
-          if (timeZone) {
-            adjustedTime =
-                (timeZone->to_local(std::chrono::milliseconds{systemTime}) %
-                 kMillisInDay)
-                    .count();
-          } else {
-            adjustedTime = systemTime % kMillisInDay;
-          }
-
           if (adjustedTime < 0) {
             adjustedTime += kMillisInDay;
           }
@@ -331,7 +327,24 @@ VectorPtr CastExpr::castFromTime(
           VELOX_USER_FAIL(
               makeErrorMessage(input, row, toType) + " " + e.what());
         }
-      });
+      };
+      if (timeZone != nullptr) {
+        applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
+          const auto systemTime =
+              systemDay.count() * kMillisInDay + inputFlatVector->valueAt(row);
+          const int64_t adjustedTime =
+              (timeZone->to_local(std::chrono::milliseconds{systemTime}) %
+               kMillisInDay)
+                  .count();
+          rowBody(row, adjustedTime);
+        });
+      } else {
+        applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
+          const auto systemTime =
+              systemDay.count() * kMillisInDay + inputFlatVector->valueAt(row);
+          rowBody(row, systemTime % kMillisInDay);
+        });
+      }
 
       buffer->setSize(rawBuffer - buffer->asMutable<char>());
       return castResult;

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -150,28 +150,16 @@ VectorPtr CastExpr::castFromDate(
     }
     case TypeKind::TIMESTAMP: {
       VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
-      static const int64_t kMillisPerDay{86'400'000};
       const auto* timeZone =
           getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
       auto* resultFlatVector = castResult->as<FlatVector<Timestamp>>();
-      // Hoist the timezone-presence branch out of the per-row loop:
-      // pick one of two specialized loops here, so the inner body has no
-      // condition to evaluate for every row.
-      if (timeZone != nullptr) {
-        applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
-          auto timestamp = Timestamp::fromMillis(
-              inputFlatVector->valueAt(row) * kMillisPerDay);
-          hooks_->castDateTimestampToGMT(timestamp, *timeZone);
-          resultFlatVector->set(row, timestamp);
-        });
-      } else {
-        applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
-          auto timestamp = Timestamp::fromMillis(
-              inputFlatVector->valueAt(row) * kMillisPerDay);
-          resultFlatVector->set(row, timestamp);
-        });
-      }
-
+      // Single per-batch virtual call. The hook owns the row loop, so
+      // the body inside (multiply, fromMillis, optional Timestamp::
+      // toGMT, store) is concrete code in the hook implementation that
+      // the compiler can inline and partially vectorize. No per-row
+      // virtual dispatch, no per-row exception frame.
+      hooks_->castDateToTimestampVector(
+          rows, *inputFlatVector, *resultFlatVector, timeZone);
       return castResult;
     }
     default:

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -417,8 +417,38 @@ class CastExpr : public SpecialForm {
 
   CastOperatorPtr getCastOperator(const TypePtr& type);
 
+  /// Looks up the cast operators for (inputs_[0]->type(), type_) once via
+  /// getCastOperator and caches them on the first applyPeeled call. The
+  /// pair is constant for the lifetime of this CastExpr, so subsequent
+  /// per-call lookups in castOperators_ are skipped.
+  void ensureTopLevelCastOperators(
+      const TypePtr& fromType,
+      const TypePtr& toType);
+
+  /// Lazily resolves and caches hooks_->getPolicy() so per-call
+  /// applyCastPrimitives doesn't pay the virtual call.
+  PolicyType policy() {
+    if (!policyCached_) {
+      cachedPolicy_ = hooks_->getPolicy();
+      policyCached_ = true;
+    }
+    return cachedPolicy_;
+  }
+
   // Custom cast operators for to and from top-level as well as nested types.
   folly::F14FastMap<std::string, CastOperatorPtr> castOperators_;
+
+  // Cached lookup of (inputs_[0]->type(), type_) in castOperators_. Both
+  // entries are nullptr when no custom operator is registered. Populated
+  // on the first applyPeeled call.
+  bool topLevelCastOperatorsCached_{false};
+  CastOperatorPtr topLevelCastFromOperator_;
+  CastOperatorPtr topLevelCastToOperator_;
+
+  // Cached PolicyType returned by hooks_->getPolicy(). Populated on first
+  // policy() call.
+  bool policyCached_{false};
+  PolicyType cachedPolicy_{LegacyCastPolicy};
 
   bool isTryCast_;
   std::shared_ptr<CastHooks> hooks_;

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -108,6 +108,19 @@ class CastExpr : public SpecialForm {
       const TypePtr& toType,
       VectorPtr& result);
 
+  /// Returns true if casting from 'fromType' to 'toType' takes the fast
+  /// numeric upcast path: a single static_cast per row over a flat input
+  /// (see applyNumericUpcast). Casts on this path are cheap and non-
+  /// throwing, which Expr::evalWithMemo's eager-fill strategy relies on:
+  /// computing every base position up front is acceptable because the
+  /// per-position cost is single-digit cycles and no surprise errors
+  /// from un-requested positions can occur.
+  static bool isSupportedFastUpcast(
+      const TypePtr& fromType,
+      const TypePtr& toType);
+
+  bool isCheapToReevaluate() const override;
+
  private:
   VectorPtr applyMap(
       const SelectivityVector& rows,

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -25,6 +25,8 @@
 #include "velox/type/CppToType.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/tz/TimeZoneMap.h"
+#include "velox/vector/FlatVector.h"
+#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::exec {
 
@@ -132,6 +134,37 @@ class CastHooks {
       Timestamp& timestamp,
       const tz::TimeZone& timeZone) const {
     timestamp.toGMT(timeZone);
+  }
+
+  /// Vector-level entry point for CAST(DATE AS TIMESTAMP). Reads
+  /// int32 days-since-epoch from 'input' at every selected row, builds
+  /// the corresponding Timestamp at midnight UTC, and stores it in
+  /// 'result'. When 'timeZone' is non-null, the timestamp is shifted
+  /// from local-time-at-that-zone to GMT via castDateTimestampToGMT.
+  ///
+  /// The default implementation iterates rows and calls the per-row
+  /// castDateTimestampToGMT hook for each one. Subclasses can override
+  /// to skip the per-row virtual call entirely (the loop body becomes
+  /// concrete code the compiler can inline and partially vectorize).
+  virtual void castDateToTimestampVector(
+      const SelectivityVector& rows,
+      const SimpleVector<int32_t>& input,
+      FlatVector<Timestamp>& result,
+      const tz::TimeZone* timeZone) const {
+    static constexpr int64_t kMillisPerDay = 86'400'000;
+    if (timeZone == nullptr) {
+      rows.applyToSelected([&](vector_size_t row) {
+        result.set(
+            row, Timestamp::fromMillis(input.valueAt(row) * kMillisPerDay));
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t row) {
+        auto ts =
+            Timestamp::fromMillis(input.valueAt(row) * kMillisPerDay);
+        castDateTimestampToGMT(ts, *timeZone);
+        result.set(row, ts);
+      });
+    }
   }
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -251,6 +251,123 @@ bool Expr::isCurrentFunctionDeterministic() const {
   }
 }
 
+namespace {
+
+// Function names whose per-row eval is cheap and non-throwing on
+// arbitrary in-range inputs. evalWithMemo's eager-fill speculation
+// calls these over the entire peeled dictionary base on the second
+// sighting; surfacing errors from speculative rows or paying
+// expensive per-row eval would defeat the win. The list is
+// conservative: only entries that are clearly cheap AND clearly
+// don't throw on plausible inputs are included.
+//
+// Throwing functions deliberately omitted: cast(varchar as <type>)
+// (parsing), mod / divide (divide-by-zero), json_*, regexp_*, md5 /
+// sha*, to_base64 / from_base64, levenshtein, url_*, etc. Casts
+// have their own override in CastExpr.
+const folly::F14FastSet<std::string_view>& cheapFunctionNames() {
+  static const folly::F14FastSet<std::string_view> kSet{
+      // Date / time accessors - extract a field from a date /
+      // timestamp / interval.
+      "year",
+      "month",
+      "day",
+      "day_of_month",
+      "day_of_week",
+      "day_of_year",
+      "hour",
+      "minute",
+      "second",
+      "millisecond",
+      "week",
+      "week_of_year",
+      "year_of_week",
+      "quarter",
+      "yow",
+      "dow",
+      "doy",
+      "last_day_of_month",
+      // Date / time arithmetic and formatting. date_add and date_diff
+      // are bounded arithmetic on integer day / millisecond counts;
+      // date_format / format_datetime / from_unixtime / to_unixtime
+      // are pure formatting that don't throw on any in-range
+      // timestamp.
+      "date_trunc",
+      "date_format",
+      "format_datetime",
+      "to_unixtime",
+      "from_unixtime",
+      "date_add",
+      "date_diff",
+      "current_date",
+      // Simple primitive string ops. Bounded by input size; no
+      // parsing failures.
+      "length",
+      "char_length",
+      "character_length",
+      "lower",
+      "upper",
+      "reverse",
+      "substr",
+      "substring",
+      "trim",
+      "ltrim",
+      "rtrim",
+      "strpos",
+      "position",
+      "starts_with",
+      "ends_with",
+      "split_part",
+      "concat",
+      // Math - non-throwing on IEEE inputs (NaN / Inf instead of
+      // throw). Excludes mod / divide which throw on zero.
+      "abs",
+      "sign",
+      "ceil",
+      "ceiling",
+      "floor",
+      "round",
+      "exp",
+      "ln",
+      "log10",
+      "log2",
+      "sqrt",
+      "cbrt",
+      "cos",
+      "sin",
+      "tan",
+      "acos",
+      "asin",
+      "atan",
+      "atan2",
+      "cosh",
+      "sinh",
+      "tanh",
+      "degrees",
+      "radians",
+      "is_nan",
+      "is_finite",
+      "is_infinite",
+      // Container size accessors. Just a length read.
+      "cardinality",
+      "array_length",
+  };
+  return kSet;
+}
+
+} // namespace
+
+bool Expr::isCheapToReevaluate() const {
+  // For non-special-form expressions (function calls), classify by
+  // the registered function name. Special forms inherit this default
+  // and stay false; CastExpr overrides to return true for known-safe
+  // cast variants.
+  if (vectorFunction_ != nullptr) {
+    return cheapFunctionNames().count(name_) > 0;
+  }
+  return false;
+}
+
 void Expr::computeMetadata() {
   if (metaDataComputed_) {
     return;
@@ -1293,6 +1410,79 @@ void Expr::evalWithMemo(
   }
 
   ++baseOfDictionaryRepeats_;
+
+  // Eager full-base fill: on the second (or later) sighting of a stable
+  // base, expressions whose per-row cost is trivial (see
+  // isCheapToReevaluate, currently CastExpr's fast numeric upcasts) gain
+  // by paying one full-base compute once and turning every subsequent
+  // batch over this base into an O(1) dictionary wrap of the cache. The
+  // alternative incremental path below allocates a fresh `result`,
+  // copies cached values into it, evaluates uncached rows, and copies
+  // back into the cache every batch - all of which is more work per
+  // batch than the cast itself for these types.
+  //
+  // Only fires when isCheapToReevaluate() is true so we never surface
+  // errors from base positions that the caller did not request - the
+  // fast upcast path is non-throwing by construction.
+  if (isCheapToReevaluate()) {
+    const auto baseSize = base->size();
+    LocalSelectivityVector toFillHolder(context, baseSize);
+    auto* toFill = toFillHolder.get();
+    toFill->setAll();
+    // Whether to deselect already-cached positions before evaluating.
+    // The deselect itself is O(baseSize/64), and the resulting sparse
+    // toFill makes the subsequent evalWithNulls / copy slower because
+    // they iterate set bits instead of running over a dense range.
+    // The crossover point: when only a minority of base positions are
+    // already cached, paying the deselect cost to skip <50% of rows
+    // loses more than it saves; re-evaluating every position is
+    // cheaper. When the majority is already cached, deselect saves
+    // enough work to be worth it. Threshold at 50%.
+    const auto cachedCount = cachedDictionaryIndices_->size() > 0
+        ? cachedDictionaryIndices_->countSelected()
+        : 0;
+    const bool deselectCached = cachedCount * 2 >= baseSize;
+    if (deselectCached) {
+      toFill->deselect(*cachedDictionaryIndices_);
+    }
+    if (toFill->hasSelections()) {
+      if (dictionaryCache_->size() < baseSize) {
+        dictionaryCache_->resize(baseSize);
+      }
+      if (cachedDictionaryIndices_->size() < baseSize) {
+        cachedDictionaryIndices_->resize(baseSize, false);
+      }
+      LocalSelectivityVector writableHolder(context, baseSize);
+      auto* writable = writableHolder.get();
+      writable->setAll();
+      if (deselectCached) {
+        writable->deselect(*cachedDictionaryIndices_);
+      }
+      context.ensureWritable(*writable, type(), dictionaryCache_);
+
+      // Evaluate the cast on every selected base position and write
+      // the results directly into the cache. ScopedFinalSelectionSetter
+      // widens the finalSelection so the child evaluator does not
+      // narrow back to `rows`.
+      ScopedFinalSelectionSetter scopedFinalSelectionSetter(
+          context, &rows, /*newFinalSelection=*/true);
+      VectorPtr fillResult;
+      evalWithNulls(*toFill, context, fillResult);
+      context.deselectErrors(*toFill);
+      if (toFill->hasSelections()) {
+        dictionaryCache_->copy(fillResult.get(), *toFill, nullptr);
+        cachedDictionaryIndices_->select(*toFill);
+      }
+      context.releaseVector(fillResult);
+    }
+    // Hand back the (now-complete-for-this-base) cache as the peeled
+    // result. evalEncodings re-wraps with the original dictionary
+    // indices; subsequent batches with the same base hit this branch
+    // again with `toFill` empty and return in O(1).
+    result = dictionaryCache_;
+    context.releaseVector(base);
+    return;
+  }
 
   if (cachedDictionaryIndices_) {
     LocalSelectivityVector cachedHolder(context, rows);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1182,13 +1182,39 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
     return Expr::PeelEncodingsResult::empty();
   }
 
+  // Hot-cache bypass: when dictionaryCache_ already covers every
+  // position of the peeled base from a previous batch over the same
+  // base, the subsequent evalWithMemo call would just return the
+  // cached vector (or copy it row-by-row to a fresh result). Skip
+  // both translateToInnerRows calls and signal the bypass so
+  // evalEncodings wraps the cached vector directly without calling
+  // evalWithMemo at all. This sidesteps the expensive per-batch
+  // FlatVector<StringView>::copy -> acquireSharedStringBuffers
+  // -> addStringBuffer path for VARCHAR-producing exprs (the atomic
+  // refcount increment in intrusive_ptr<Buffer>::push_back is a full
+  // memory barrier; on a hot cache line shared across drivers each
+  // increment can stall the pipeline for hundreds of cycles).
+  bool cacheCoversBase = false;
+  if (context.dictionaryMemoizationEnabled() && distinctFields_.size() == 1 &&
+      peeledEncoding->wrapEncoding() == VectorEncoding::Simple::DICTIONARY &&
+      !peeledVectors[0]->memoDisabled() &&
+      baseOfDictionaryRawPtr_ == peeledVectors[0].get() &&
+      !baseOfDictionaryWeakPtr_.expired() && cachedDictionaryIndices_ != nullptr &&
+      cachedDictionaryIndices_->countSelected() >=
+          static_cast<vector_size_t>(peeledVectors[0]->size())) {
+    cacheCoversBase = true;
+  }
+
   // Translate the relevant rows.
   SelectivityVector* newFinalSelection = nullptr;
-  if (!context.isFinalSelection()) {
-    newFinalSelection = peeledEncoding->translateToInnerRows(
-        *context.finalSelection(), finalRowsHolder);
+  SelectivityVector* newRows = nullptr;
+  if (!cacheCoversBase) {
+    if (!context.isFinalSelection()) {
+      newFinalSelection = peeledEncoding->translateToInnerRows(
+          *context.finalSelection(), finalRowsHolder);
+    }
+    newRows = peeledEncoding->translateToInnerRows(rows, newRowsHolder);
   }
-  auto newRows = peeledEncoding->translateToInnerRows(rows, newRowsHolder);
 
   // Save context and set the peel, peeled fields and final selection (if
   // applicable).
@@ -1213,7 +1239,7 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
 
   common::testutil::TestValue::adjust(
       "facebook::velox::exec::Expr::peelEncodings::mayCache", &mayCache);
-  return {newRows, finalRowsHolder.get(), mayCache};
+  return {newRows, finalRowsHolder.get(), mayCache, cacheCoversBase};
 }
 
 void Expr::evalEncodings(
@@ -1245,8 +1271,15 @@ void Expr::evalEncodings(
             decodedHolder,
             newRowsHolder,
             finalRowsHolder);
-        auto* newRows = peelEncodingsResult.newRows;
-        if (newRows) {
+        if (peelEncodingsResult.cacheCoversBase) {
+          // peelEncodings detected that dictionaryCache_ is already
+          // populated for the whole peeled base and skipped
+          // translateToInnerRows. Wrap the cache directly without
+          // running evalWithMemo/evalWithNulls - they would just
+          // return dictionaryCache_ anyway.
+          wrappedResult = context.getPeeledEncoding()->wrap(
+              this->type(), context.pool(), dictionaryCache_, rows);
+        } else if (auto* newRows = peelEncodingsResult.newRows) {
           VectorPtr peeledResult;
           // peelEncodings() can potentially produce an empty selectivity
           // vector if all selected values we are waiting for are nulls. So,

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1277,6 +1277,7 @@ void Expr::evalEncodings(
           // translateToInnerRows. Wrap the cache directly without
           // running evalWithMemo/evalWithNulls - they would just
           // return dictionaryCache_ anyway.
+          ++stats_.numMemoBypass;
           wrappedResult = context.getPeeledEncoding()->wrap(
               this->type(), context.pool(), dictionaryCache_, rows);
         } else if (auto* newRows = peelEncodingsResult.newRows) {
@@ -1398,6 +1399,7 @@ void Expr::evalWithMemo(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result) {
+  ++stats_.numEvalWithMemo;
   VectorPtr base;
   distinctFields_[0]->evalSpecialForm(rows, context, base);
 
@@ -1415,6 +1417,7 @@ void Expr::evalWithMemo(
 
   if (base.get() != baseOfDictionaryRawPtr_ ||
       baseOfDictionaryWeakPtr_.expired()) {
+    ++stats_.numMemoBaseChange;
     baseOfDictionaryRepeats_ = 0;
     baseOfDictionaryWeakPtr_.reset();
     baseOfDictionaryRawPtr_ = nullptr;
@@ -1428,6 +1431,7 @@ void Expr::evalWithMemo(
   }
 
   if (baseOfDictionaryRepeats_ == 0) {
+    ++stats_.numMemoFirstRepeat;
     evalWithNulls(rows, context, result);
 
     ++baseOfDictionaryRepeats_;
@@ -1458,6 +1462,7 @@ void Expr::evalWithMemo(
   // errors from base positions that the caller did not request - the
   // fast upcast path is non-throwing by construction.
   if (isCheapToReevaluate()) {
+    ++stats_.numMemoEagerFill;
     const auto baseSize = base->size();
     LocalSelectivityVector toFillHolder(context, baseSize);
     auto* toFill = toFillHolder.get();
@@ -1476,7 +1481,10 @@ void Expr::evalWithMemo(
         : 0;
     const bool deselectCached = cachedCount * 2 >= baseSize;
     if (deselectCached) {
+      ++stats_.numEagerFillDeselect;
       toFill->deselect(*cachedDictionaryIndices_);
+    } else {
+      ++stats_.numEagerFillFullReeval;
     }
     if (toFill->hasSelections()) {
       if (dictionaryCache_->size() < baseSize) {
@@ -1500,6 +1508,15 @@ void Expr::evalWithMemo(
       ScopedFinalSelectionSetter scopedFinalSelectionSetter(
           context, &rows, /*newFinalSelection=*/true);
       VectorPtr fillResult;
+      // Rows being evaluated speculatively are those not in `rows` (the
+      // caller's selection). We can only know that approximately - rows
+      // is the outer-row selection, toFill is the inner-row selection -
+      // so use toFill's count minus rows' count as a coarse signal.
+      // Negative deltas (uncommon) clamp to zero.
+      const auto toFillCount = toFill->countSelected();
+      const auto callerCount = rows.countSelected();
+      stats_.numEagerFillSpeculativeRows +=
+          toFillCount > callerCount ? toFillCount - callerCount : 0;
       evalWithNulls(*toFill, context, fillResult);
       context.deselectErrors(*toFill);
       if (toFill->hasSelections()) {
@@ -1517,6 +1534,7 @@ void Expr::evalWithMemo(
     return;
   }
 
+  ++stats_.numMemoIncremental;
   if (cachedDictionaryIndices_) {
     LocalSelectivityVector cachedHolder(context, rows);
     auto cached = cachedHolder.get();

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -327,6 +327,36 @@ class Expr {
     return false;
   }
 
+  /// Returns true if recomputing this expression on the peeled base is
+  /// cheap enough that proactively evaluating all uncached base positions
+  /// (rather than only the rows touched by the current input vector) is
+  /// a net win once the dictionary cache becomes complete. Used by
+  /// Expr::evalWithMemo's eager-fill path: on the second sighting of a
+  /// stable dictionary base, an expression that opts in pays the cost of
+  /// filling every base position once and turns every subsequent batch
+  /// over that base into an O(1) dictionary wrap of the cache (no
+  /// per-batch peel, evaluate, result allocation, or copy). Defaults to
+  /// false. Overridden by CastExpr to return true for fast numeric
+  /// upcasts (e.g. INT->BIGINT, REAL->DOUBLE) where the per-row cost is
+  /// a single static_cast.
+  /// Whether the per-row evaluation of this expression is cheap and
+  /// non-throwing enough that Expr::evalWithMemo's eager-fill path
+  /// can speculatively evaluate every position of the peeled
+  /// dictionary base, not just the rows the current batch requests.
+  /// Eager-fill pays one full-base eval up front so subsequent
+  /// batches over the same base hit cache-covers-base in
+  /// peelEncodings and return the cached vector directly without
+  /// the per-row FlatVector<StringView>::copy ->
+  /// acquireSharedStringBuffers -> atomic-refcount-bump chain.
+  ///
+  /// Default Expr implementation (in Expr.cpp) returns true for
+  /// function calls whose registered name is in the curated
+  /// cheap-and-non-throwing set (date / time accessors, basic string
+  /// ops, simple math, comparisons) and false otherwise. Subclasses
+  /// override - CastExpr returns true for fast numeric upcasts and
+  /// date conversions.
+  virtual bool isCheapToReevaluate() const;
+
   bool hasConditionals() const {
     return hasConditionals_;
   }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -550,8 +550,15 @@ class Expr {
     SelectivityVector* newFinalSelection;
     bool mayCache;
 
+    /// When true, the dictionaryCache_ is already populated for every
+    /// position of the peeled base, so the caller can wrap the cache
+    /// directly with the peeled encoding and skip evalWithMemo /
+    /// evalWithNulls entirely. newRows / newFinalSelection are not
+    /// computed in this case (translateToInnerRows is bypassed).
+    bool cacheCoversBase;
+
     static PeelEncodingsResult empty() {
-      return {nullptr, nullptr, false};
+      return {nullptr, nullptr, false, false};
     }
   };
 

--- a/velox/expression/ExprStats.h
+++ b/velox/expression/ExprStats.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "velox/common/time/CpuWallTimer.h"
 
 namespace facebook::velox::exec {
@@ -35,6 +37,51 @@ struct ExprStats {
   /// evaluation of rows.
   bool defaultNullRowsSkipped{false};
 
+  /// Number of times Expr::evalWithMemo was entered. Less than
+  /// numProcessedVectors when the peelEncodings cache-covers-base
+  /// bypass fires (numMemoBypass counts those).
+  uint64_t numEvalWithMemo{0};
+
+  /// evalWithMemo path counters. Sum of these <= numEvalWithMemo;
+  /// the remainder are calls that did no useful work (empty base
+  /// after deselects, etc).
+  ///
+  /// numMemoBaseChange: the base of the input dictionary differs
+  /// from the cached one, so the prior cache is dropped and this
+  /// batch is evaluated from scratch.
+  /// numMemoFirstRepeat: the second sighting of a base; populates
+  /// dictionaryCache_ for the first time.
+  /// numMemoEagerFill: subsequent batches over the same base where
+  /// isCheapToReevaluate() let evalWithMemo speculatively fill
+  /// uncached base positions in one shot. Hand back the cache.
+  /// numMemoIncremental: subsequent batches that take the
+  /// non-cheap incremental path (copy cached rows to a fresh
+  /// result, evaluate uncached rows separately, extend the cache).
+  uint64_t numMemoBaseChange{0};
+  uint64_t numMemoFirstRepeat{0};
+  uint64_t numMemoEagerFill{0};
+  uint64_t numMemoIncremental{0};
+
+  /// Times peelEncodings short-circuited because dictionaryCache_
+  /// already covered every position of the peeled base. evalEncodings
+  /// wraps the cache directly without calling evalWithMemo at all.
+  /// This is the metric to watch for the cache-hit hot path.
+  uint64_t numMemoBypass{0};
+
+  /// Base positions evaluated by the eager-fill path that the caller
+  /// did not request (the speculative work). Compare to
+  /// numProcessedRows to gauge how much over-evaluation eager-fill
+  /// performs in practice.
+  uint64_t numEagerFillSpeculativeRows{0};
+
+  /// Eager-fill chose to deselect already-cached positions before
+  /// evaluating (numEagerFillDeselect) vs. re-evaluating the whole
+  /// base without paying the deselect bitmap cost
+  /// (numEagerFillFullReeval). Sums to numMemoEagerFill (modulo
+  /// empty-toFill early-outs).
+  uint64_t numEagerFillDeselect{0};
+  uint64_t numEagerFillFullReeval{0};
+
   auto operator<=>(const ExprStats&) const = default;
 
   void add(const ExprStats& other) {
@@ -42,15 +89,37 @@ struct ExprStats {
     numProcessedRows += other.numProcessedRows;
     numProcessedVectors += other.numProcessedVectors;
     defaultNullRowsSkipped |= other.defaultNullRowsSkipped;
+    numEvalWithMemo += other.numEvalWithMemo;
+    numMemoBaseChange += other.numMemoBaseChange;
+    numMemoFirstRepeat += other.numMemoFirstRepeat;
+    numMemoEagerFill += other.numMemoEagerFill;
+    numMemoIncremental += other.numMemoIncremental;
+    numMemoBypass += other.numMemoBypass;
+    numEagerFillSpeculativeRows += other.numEagerFillSpeculativeRows;
+    numEagerFillDeselect += other.numEagerFillDeselect;
+    numEagerFillFullReeval += other.numEagerFillFullReeval;
   }
 
   std::string toString() const {
     return fmt::format(
-        "timing: {}, numProcessedRows: {}, numProcessedVectors: {}, defaultNullRowsSkipped: {}",
+        "timing: {}, numProcessedRows: {}, numProcessedVectors: {}, "
+        "defaultNullRowsSkipped: {}, numEvalWithMemo: {}, "
+        "numMemo(baseChange/firstRepeat/eagerFill/incremental/bypass): "
+        "{}/{}/{}/{}/{}, numEagerFillSpeculativeRows: {}, "
+        "numEagerFill(deselect/fullReeval): {}/{}",
         timing.toString(),
         numProcessedRows,
         numProcessedVectors,
-        defaultNullRowsSkipped ? "true" : "false");
+        defaultNullRowsSkipped ? "true" : "false",
+        numEvalWithMemo,
+        numMemoBaseChange,
+        numMemoFirstRepeat,
+        numMemoEagerFill,
+        numMemoIncremental,
+        numMemoBypass,
+        numEagerFillSpeculativeRows,
+        numEagerFillDeselect,
+        numEagerFillFullReeval);
   }
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -163,4 +163,31 @@ PolicyType PrestoCastHooks::getPolicy() const {
   return legacyCast_ ? PolicyType::LegacyCastPolicy
                      : PolicyType::PrestoCastPolicy;
 }
+
+void PrestoCastHooks::castDateToTimestampVector(
+    const SelectivityVector& rows,
+    const SimpleVector<int32_t>& input,
+    FlatVector<Timestamp>& result,
+    const tz::TimeZone* timeZone) const {
+  // Mirrors the default CastHooks::castDateToTimestampVector body but
+  // calls Timestamp::toGMT directly instead of dispatching through the
+  // virtual castDateTimestampToGMT hook on every row. Since Presto's
+  // castDateTimestampToGMT just calls Timestamp::toGMT, the two paths
+  // are semantically identical here - the difference is that this
+  // version is concrete code the compiler can inline into the loop
+  // body.
+  static constexpr int64_t kMillisPerDay = 86'400'000;
+  if (timeZone == nullptr) {
+    rows.applyToSelected([&](vector_size_t row) {
+      result.set(
+          row, Timestamp::fromMillis(input.valueAt(row) * kMillisPerDay));
+    });
+  } else {
+    rows.applyToSelected([&](vector_size_t row) {
+      auto ts = Timestamp::fromMillis(input.valueAt(row) * kMillisPerDay);
+      ts.toGMT(*timeZone);
+      result.set(row, ts);
+    });
+  }
+}
 } // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -22,7 +22,12 @@
 namespace facebook::velox::exec {
 
 // This class provides cast hooks following Presto semantics.
-class PrestoCastHooks : public CastHooks {
+//
+// Marked `final` so the compiler/LTO can devirtualize calls made
+// through a statically-known PrestoCastHooks*. Hot kernels in
+// CastExpr.cpp now also cache the raw CastHooks* outside per-row
+// loops so each row no longer pays a shared_ptr indirection.
+class PrestoCastHooks final : public CastHooks {
  public:
   explicit PrestoCastHooks(const core::QueryConfig& config);
 

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -81,6 +81,15 @@ class PrestoCastHooks : public CastHooks {
     return false;
   }
 
+  /// Specialized vector-level DATE -> TIMESTAMP path that inlines
+  /// Timestamp::toGMT directly, avoiding the per-row virtual call
+  /// through castDateTimestampToGMT.
+  void castDateToTimestampVector(
+      const SelectivityVector& rows,
+      const SimpleVector<int32_t>& input,
+      FlatVector<Timestamp>& result,
+      const tz::TimeZone* timeZone) const override;
+
  private:
   const bool legacyCast_;
   TimestampToStringOptions options_ = {

--- a/velox/expression/benchmarks/CMakeLists.txt
+++ b/velox/expression/benchmarks/CMakeLists.txt
@@ -58,3 +58,6 @@ target_compile_definitions(
 
 add_executable(velox_benchmark_variadic VariadicBenchmark.cpp)
 target_link_libraries(velox_benchmark_variadic ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_benchmark_widening_cast WideningCastBenchmark.cpp)
+target_link_libraries(velox_benchmark_widening_cast ${BENCHMARK_DEPENDENCIES})

--- a/velox/expression/benchmarks/WideningCastBenchmark.cpp
+++ b/velox/expression/benchmarks/WideningCastBenchmark.cpp
@@ -1,0 +1,645 @@
+/*
+ * Copyright (c) International Business Machines
+ * Corporation and others.  All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <array>
+#include <iostream>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/vector/BaseVector.h"
+
+// Add the following definitions to allow Clion runs.
+DEFINE_bool(gtest_color, false, "");
+DEFINE_string(gtest_filter, "*", "");
+
+// Exercises Expr::evalWithMemo for CAST(BIGINT -> VARCHAR) and the fast
+// numeric upcast CAST(INT -> BIGINT) over a stable dictionary base across
+// many input vectors. This is the exact shape that drove the O(N^2)
+// regression observed on a production worker - each input vector acquired
+// one more string buffer into Expr::dictionaryCache_, so the per-call
+// acquireSharedStringBuffers loop grew linearly with the number of vectors
+// evaluated against the same base.
+//
+// READING THE BENCHMARK OUTPUT
+//   Dict entries: BigintToVarchar(rowsPerVector_distinctValueCount_
+//                                 newIndicesPerVector_nullPct)
+//   Flat entries: BigintToVarchar(rowsPerVector_nullPct)
+//
+//   numVectors is fixed at kNumVectors (1000) for every entry and is
+//   not encoded in the name. Example: `DICT_BigintToVarchar(100_5_1_0)`
+//   means 100 rows per input vector, dictionary base has 5 distinct
+//   values, each input vector introduces 1 new dictionary index
+//   relative to the previous one, and 0% of dictionary positions are
+//   null - over 1000 vectors per iteration.
+//
+// Parameter dimensions:
+//   - numVectors          : how many input vectors per iteration
+//                          (fixed at kNumVectors, not swept, not in name)
+//   - rowsPerVector       : rows in each input vector
+//   - distinctValueCount  : dictionary base cardinality (DICT only)
+//   - newIndicesPerVector : new dictionary indices each input vector
+//                           introduces (drives the cache miss rate)
+//                           (DICT only)
+//   - nullPct             : percentage of positions marked null. For
+//                           DICT, nulls live on the dictionary wrap
+//                           (reach PeeledEncoding::translateToInnerRows
+//                           via wrapNulls_); for FLAT, nulls are on
+//                           the flat input itself.
+// Plus a flat (non-dictionary) baseline per rowsPerVector. The "from
+// -> to" type pair appears in every entry name so the table is
+// self-describing. The same legend is printed at startup before the
+// benchmark output.
+//
+// A NOTE ON "0.00fs Infinity" ENTRIES
+//   Folly normalises measurements by subtracting a globally-measured
+//   baseline (the cost of an empty BENCHMARK loop, ~0.5 ns/iter) and
+//   floors the result at zero (Benchmark.cpp:207). For configurations
+//   where the dictionary cache covers the whole base in the first
+//   couple of batches (small distinctValueCount relative to row count
+//   per vector, e.g. dvc=5 with rowsPerVector=10000 - the bypass in
+//   peelEncodings kicks in for the remaining ~998 batches), the
+//   per-row cost falls below that baseline and folly displays 0.00fs.
+//   It means "below resolution after baseline subtraction", not zero
+//   actual work - the corresponding nullPct=100 row (which doesn't
+//   hit the bypass because translateToInnerRows returns empty inner
+//   rows and dictionaryCache_ never populates) still measures around
+//   400-500 ps/iter, giving a sense of the floor folly can resolve.
+
+using namespace facebook::velox;
+
+namespace {
+
+class WideningCastBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  WideningCastBenchmark() : FunctionBenchmarkBase() {
+    functions::prestosql::registerAllScalarFunctions();
+  }
+
+  // Builds a flat numeric base of `baseType` and runs `numVectors`
+  // evaluations of `expression` over dictionary wrappers of that base. Each
+  // input vector's indices are `(row + vectorIdx * newIndicesPerVector) mod
+  // distinctValueCount`, so consecutive vectors overlap by `rowsPerVector -
+  // newIndicesPerVector` indices. `nullPct` is the percentage of dictionary
+  // positions marked null on the wrap (0, 50, 100) - the wrap-level nulls
+  // are what reach Expr::evalEncodings / PeeledEncoding::translateToInner-
+  // Rows. nullPct=0 hits the hoisted no-nulls path; nullPct=50 exercises
+  // the null-aware loop; nullPct=100 marks every position null so the
+  // downstream cast work short-circuits.
+  template <typename BaseNativeType>
+  size_t runDictionary(
+      const std::string& expression,
+      const TypePtr& baseType,
+      int32_t numVectors,
+      int32_t rowsPerVector,
+      int32_t distinctValueCount,
+      int32_t newIndicesPerVector,
+      int32_t nullPct) {
+    folly::BenchmarkSuspender suspender;
+
+    auto base = vectorMaker_.flatVector<BaseNativeType>(
+        distinctValueCount,
+        [](vector_size_t row) { return static_cast<BaseNativeType>(row + 1); },
+        nullptr,
+        baseType);
+    auto rowType = ROW({"c0"}, {baseType});
+    auto exprSet = compileExpression(expression, rowType);
+
+    std::vector<RowVectorPtr> inputs;
+    inputs.reserve(numVectors);
+    for (int32_t vectorIdx = 0; vectorIdx < numVectors; ++vectorIdx) {
+      const int32_t offset = vectorIdx * newIndicesPerVector;
+      auto indices =
+          AlignedBuffer::allocate<vector_size_t>(rowsPerVector, pool());
+      auto* rawIndices = indices->asMutable<vector_size_t>();
+      for (int32_t row = 0; row < rowsPerVector; ++row) {
+        rawIndices[row] = (row + offset) % distinctValueCount;
+      }
+
+      BufferPtr nulls;
+      if (nullPct > 0) {
+        nulls = AlignedBuffer::allocate<bool>(rowsPerVector, pool());
+        auto* rawNulls = nulls->asMutable<uint64_t>();
+        if (nullPct >= 100) {
+          bits::fillBits(rawNulls, 0, rowsPerVector, bits::kNull);
+        } else {
+          bits::fillBits(rawNulls, 0, rowsPerVector, bits::kNotNull);
+          const int32_t step = 100 / nullPct;
+          for (int32_t row = 0; row < rowsPerVector; row += step) {
+            bits::setNull(rawNulls, row, true);
+          }
+        }
+      }
+      auto dict =
+          BaseVector::wrapInDictionary(nulls, indices, rowsPerVector, base);
+      inputs.push_back(vectorMaker_.rowVector({dict}));
+    }
+    suspender.dismiss();
+
+    size_t count = 0;
+    for (auto& input : inputs) {
+      auto result = evaluate(exprSet, input);
+      folly::doNotOptimizeAway(result);
+      count += result->size();
+    }
+    return count;
+  }
+
+  template <typename BaseNativeType>
+  size_t runFlat(
+      const std::string& expression,
+      const TypePtr& baseType,
+      int32_t numVectors,
+      int32_t rowsPerVector,
+      int32_t nullPct) {
+    folly::BenchmarkSuspender suspender;
+    std::function<bool(vector_size_t)> isNullAt;
+    if (nullPct > 0) {
+      if (nullPct >= 100) {
+        isNullAt = [](vector_size_t) { return true; };
+      } else {
+        const int32_t step = 100 / nullPct;
+        isNullAt = [step](vector_size_t row) { return (row % step) == 0; };
+      }
+    }
+    std::vector<RowVectorPtr> inputs;
+    inputs.reserve(numVectors);
+    for (int32_t vectorIdx = 0; vectorIdx < numVectors; ++vectorIdx) {
+      auto flat = vectorMaker_.flatVector<BaseNativeType>(
+          rowsPerVector,
+          [vectorIdx](vector_size_t row) {
+            return static_cast<BaseNativeType>(row + vectorIdx * 16 + 1);
+          },
+          isNullAt,
+          baseType);
+      inputs.push_back(vectorMaker_.rowVector({flat}));
+    }
+    auto exprSet = compileExpression(expression, inputs[0]->type());
+    suspender.dismiss();
+
+    size_t count = 0;
+    for (auto& input : inputs) {
+      count += evaluate(exprSet, input)->size();
+    }
+    return count;
+  }
+};
+
+// Free functions used by BENCHMARK_NAMED_PARAM_MULTI. Names spell the
+// from -> to type pair. Each loops the work `iters` times so folly's
+// iteration-scaling controls measurement length.
+
+unsigned DICT_BigintToVarchar(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionary<int64_t>(
+        "cast(c0 as varchar)",
+        BIGINT(),
+        numVectors,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct);
+  }
+  return total;
+}
+
+unsigned FLAT_BigintToVarchar(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runFlat<int64_t>(
+        "cast(c0 as varchar)", BIGINT(), numVectors, rowsPerVector, nullPct);
+  }
+  return total;
+}
+
+unsigned DICT_IntToBigint(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionary<int32_t>(
+        "cast(c0 as bigint)",
+        INTEGER(),
+        numVectors,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct);
+  }
+  return total;
+}
+
+unsigned FLAT_IntToBigint(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runFlat<int32_t>(
+        "cast(c0 as bigint)", INTEGER(), numVectors, rowsPerVector, nullPct);
+  }
+  return total;
+}
+
+// DATE is represented natively as int32 days-since-epoch.
+unsigned DICT_DateToVarchar(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionary<int32_t>(
+        "cast(c0 as varchar)",
+        DATE(),
+        numVectors,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct);
+  }
+  return total;
+}
+
+unsigned FLAT_DateToVarchar(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runFlat<int32_t>(
+        "cast(c0 as varchar)", DATE(), numVectors, rowsPerVector, nullPct);
+  }
+  return total;
+}
+
+unsigned DICT_DateToTimestamp(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionary<int32_t>(
+        "cast(c0 as timestamp)",
+        DATE(),
+        numVectors,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct);
+  }
+  return total;
+}
+
+unsigned FLAT_DateToTimestamp(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runFlat<int32_t>(
+        "cast(c0 as timestamp)", DATE(), numVectors, rowsPerVector, nullPct);
+  }
+  return total;
+}
+
+unsigned DICT_RealToDouble(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionary<float>(
+        "cast(c0 as double)",
+        REAL(),
+        numVectors,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct);
+  }
+  return total;
+}
+
+unsigned FLAT_RealToDouble(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runFlat<float>(
+        "cast(c0 as double)", REAL(), numVectors, rowsPerVector, nullPct);
+  }
+  return total;
+}
+
+} // namespace
+
+// DICT_BIGINT_TO_VARCHAR registers cast(BIGINT -> VARCHAR) over a
+// dictionary for every (rowsPerVector, distinctValueCount,
+// newIndicesPerVector) sweep point. numVectors is fixed at 1000 (the
+// literal in the BENCHMARK_NAMED_PARAM_MULTI call below) and is not
+// encoded in the entry name. Each source line through DICT_NULLS /
+// FLAT_NULLS expands to three benchmark entries - one per nullPct in
+// {0, 50, 100}. Comment a single line out of the body to drop those
+// three combinations globally.
+#define DICT(                                                                          \
+    funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct)         \
+  BENCHMARK_NAMED_PARAM_MULTI(                                                         \
+      funcName,                                                                        \
+      rowsPerVector##_##distinctValueCount##_##newIndicesPerVector##_##nullPct,        \
+      1000,                                                                            \
+      rowsPerVector,                                                                   \
+      distinctValueCount,                                                              \
+      newIndicesPerVector,                                                             \
+      nullPct)
+
+#define DICT_NULLS(                                                          \
+    funcName, rowsPerVector, distinctValueCount, newIndicesPerVector)        \
+  DICT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, 0)  \
+  DICT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, 50) \
+  DICT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, 100)
+
+#define FLAT(funcName, rowsPerVector, nullPct)         \
+  BENCHMARK_NAMED_PARAM_MULTI(                         \
+      funcName, rowsPerVector##_##nullPct, 1000, rowsPerVector, nullPct)
+
+#define FLAT_NULLS(funcName, rowsPerVector) \
+  FLAT(funcName, rowsPerVector, 0)          \
+  FLAT(funcName, rowsPerVector, 50)         \
+  FLAT(funcName, rowsPerVector, 100)
+
+// Each DICT(funcName, ...) line below registers one benchmark entry.
+// The three numeric arguments are positional:
+//   DICT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector)
+#define DICT_BIGINT_TO_VARCHAR                         \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 5, 1)      \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 5, 100)    \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 5, 1000)   \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 500, 1)    \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 500, 100)  \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 500, 1000) \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 15000, 1)  \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 15000, 100)\
+  DICT_NULLS(DICT_BigintToVarchar, 100, 15000, 1000)\
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 5, 1)     \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 5, 100)   \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 5, 1000)  \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 500, 1)   \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 500, 100) \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 500, 1000)\
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 15000, 1) \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 15000, 100)\
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 15000, 1000)\
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 5, 1)    \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 5, 100)  \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 5, 1000) \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 500, 1)  \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 500, 100)\
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 500, 1000)\
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 15000, 1)\
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 15000, 100)\
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 15000, 1000)
+
+#define FLAT_BIGINT_TO_VARCHAR                   \
+  FLAT_NULLS(FLAT_BigintToVarchar, 100)      \
+  FLAT_NULLS(FLAT_BigintToVarchar, 1000)     \
+  FLAT_NULLS(FLAT_BigintToVarchar, 10000)
+
+#define DICT_INT_TO_BIGINT                            \
+  DICT_NULLS(DICT_IntToBigint, 100, 5, 1)         \
+  DICT_NULLS(DICT_IntToBigint, 100, 5, 100)       \
+  DICT_NULLS(DICT_IntToBigint, 100, 5, 1000)      \
+  DICT_NULLS(DICT_IntToBigint, 100, 500, 1)       \
+  DICT_NULLS(DICT_IntToBigint, 100, 500, 100)     \
+  DICT_NULLS(DICT_IntToBigint, 100, 500, 1000)    \
+  DICT_NULLS(DICT_IntToBigint, 100, 15000, 1)     \
+  DICT_NULLS(DICT_IntToBigint, 100, 15000, 100)   \
+  DICT_NULLS(DICT_IntToBigint, 100, 15000, 1000)  \
+  DICT_NULLS(DICT_IntToBigint, 1000, 5, 1)        \
+  DICT_NULLS(DICT_IntToBigint, 1000, 5, 100)      \
+  DICT_NULLS(DICT_IntToBigint, 1000, 5, 1000)     \
+  DICT_NULLS(DICT_IntToBigint, 1000, 500, 1)      \
+  DICT_NULLS(DICT_IntToBigint, 1000, 500, 100)    \
+  DICT_NULLS(DICT_IntToBigint, 1000, 500, 1000)   \
+  DICT_NULLS(DICT_IntToBigint, 1000, 15000, 1)    \
+  DICT_NULLS(DICT_IntToBigint, 1000, 15000, 100)  \
+  DICT_NULLS(DICT_IntToBigint, 1000, 15000, 1000) \
+  DICT_NULLS(DICT_IntToBigint, 10000, 5, 1)       \
+  DICT_NULLS(DICT_IntToBigint, 10000, 5, 100)     \
+  DICT_NULLS(DICT_IntToBigint, 10000, 5, 1000)    \
+  DICT_NULLS(DICT_IntToBigint, 10000, 500, 1)     \
+  DICT_NULLS(DICT_IntToBigint, 10000, 500, 100)   \
+  DICT_NULLS(DICT_IntToBigint, 10000, 500, 1000)  \
+  DICT_NULLS(DICT_IntToBigint, 10000, 15000, 1)   \
+  DICT_NULLS(DICT_IntToBigint, 10000, 15000, 100) \
+  DICT_NULLS(DICT_IntToBigint, 10000, 15000, 1000)
+
+// Each FLAT(funcName, ...) line below registers one benchmark entry.
+// The single numeric argument is:
+//   FLAT(funcName, rowsPerVector)
+#define FLAT_INT_TO_BIGINT                       \
+  FLAT_NULLS(FLAT_IntToBigint, 100)          \
+  FLAT_NULLS(FLAT_IntToBigint, 1000)         \
+  FLAT_NULLS(FLAT_IntToBigint, 10000)
+
+#define DICT_DATE_TO_VARCHAR                  \
+  DICT_NULLS(DICT_DateToVarchar, 100, 5, 1)              \
+  DICT_NULLS(DICT_DateToVarchar, 100, 5, 100)            \
+  DICT_NULLS(DICT_DateToVarchar, 100, 5, 1000)           \
+  DICT_NULLS(DICT_DateToVarchar, 100, 500, 1)            \
+  DICT_NULLS(DICT_DateToVarchar, 100, 500, 100)          \
+  DICT_NULLS(DICT_DateToVarchar, 100, 500, 1000)         \
+  DICT_NULLS(DICT_DateToVarchar, 100, 15000, 1)          \
+  DICT_NULLS(DICT_DateToVarchar, 100, 15000, 100)        \
+  DICT_NULLS(DICT_DateToVarchar, 100, 15000, 1000)       \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 5, 1)             \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 5, 100)           \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 5, 1000)          \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 500, 1)           \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 500, 100)         \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 500, 1000)        \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 15000, 1)         \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 15000, 100)       \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 15000, 1000)      \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 5, 1)            \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 5, 100)          \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 5, 1000)         \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 500, 1)          \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 500, 100)        \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 500, 1000)       \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 15000, 1)        \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 15000, 100)      \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 15000, 1000)
+
+#define FLAT_DATE_TO_VARCHAR    \
+  FLAT_NULLS(FLAT_DateToVarchar, 100)      \
+  FLAT_NULLS(FLAT_DateToVarchar, 1000)     \
+  FLAT_NULLS(FLAT_DateToVarchar, 10000)
+
+#define DICT_DATE_TO_TIMESTAMP                  \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 5, 1)              \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 5, 100)            \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 5, 1000)           \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 500, 1)            \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 500, 100)          \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 500, 1000)         \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 15000, 1)          \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 15000, 100)        \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 15000, 1000)       \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 5, 1)             \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 5, 100)           \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 5, 1000)          \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 500, 1)           \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 500, 100)         \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 500, 1000)        \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 15000, 1)         \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 15000, 100)       \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 15000, 1000)      \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 5, 1)            \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 5, 100)          \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 5, 1000)         \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 500, 1)          \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 500, 100)        \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 500, 1000)       \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 15000, 1)        \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 15000, 100)      \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 15000, 1000)
+
+#define FLAT_DATE_TO_TIMESTAMP    \
+  FLAT_NULLS(FLAT_DateToTimestamp, 100)      \
+  FLAT_NULLS(FLAT_DateToTimestamp, 1000)     \
+  FLAT_NULLS(FLAT_DateToTimestamp, 10000)
+
+#define DICT_REAL_TO_DOUBLE                  \
+  DICT_NULLS(DICT_RealToDouble, 100, 5, 1)              \
+  DICT_NULLS(DICT_RealToDouble, 100, 5, 100)            \
+  DICT_NULLS(DICT_RealToDouble, 100, 5, 1000)           \
+  DICT_NULLS(DICT_RealToDouble, 100, 500, 1)            \
+  DICT_NULLS(DICT_RealToDouble, 100, 500, 100)          \
+  DICT_NULLS(DICT_RealToDouble, 100, 500, 1000)         \
+  DICT_NULLS(DICT_RealToDouble, 100, 15000, 1)          \
+  DICT_NULLS(DICT_RealToDouble, 100, 15000, 100)        \
+  DICT_NULLS(DICT_RealToDouble, 100, 15000, 1000)       \
+  DICT_NULLS(DICT_RealToDouble, 1000, 5, 1)             \
+  DICT_NULLS(DICT_RealToDouble, 1000, 5, 100)           \
+  DICT_NULLS(DICT_RealToDouble, 1000, 5, 1000)          \
+  DICT_NULLS(DICT_RealToDouble, 1000, 500, 1)           \
+  DICT_NULLS(DICT_RealToDouble, 1000, 500, 100)         \
+  DICT_NULLS(DICT_RealToDouble, 1000, 500, 1000)        \
+  DICT_NULLS(DICT_RealToDouble, 1000, 15000, 1)         \
+  DICT_NULLS(DICT_RealToDouble, 1000, 15000, 100)       \
+  DICT_NULLS(DICT_RealToDouble, 1000, 15000, 1000)      \
+  DICT_NULLS(DICT_RealToDouble, 10000, 5, 1)            \
+  DICT_NULLS(DICT_RealToDouble, 10000, 5, 100)          \
+  DICT_NULLS(DICT_RealToDouble, 10000, 5, 1000)         \
+  DICT_NULLS(DICT_RealToDouble, 10000, 500, 1)          \
+  DICT_NULLS(DICT_RealToDouble, 10000, 500, 100)        \
+  DICT_NULLS(DICT_RealToDouble, 10000, 500, 1000)       \
+  DICT_NULLS(DICT_RealToDouble, 10000, 15000, 1)        \
+  DICT_NULLS(DICT_RealToDouble, 10000, 15000, 100)      \
+  DICT_NULLS(DICT_RealToDouble, 10000, 15000, 1000)
+
+#define FLAT_REAL_TO_DOUBLE    \
+  FLAT_NULLS(FLAT_RealToDouble, 100)      \
+  FLAT_NULLS(FLAT_RealToDouble, 1000)     \
+  FLAT_NULLS(FLAT_RealToDouble, 10000)
+
+BENCHMARK_DRAW_LINE();
+DICT_BIGINT_TO_VARCHAR
+FLAT_BIGINT_TO_VARCHAR
+BENCHMARK_DRAW_LINE();
+DICT_INT_TO_BIGINT
+FLAT_INT_TO_BIGINT
+BENCHMARK_DRAW_LINE();
+DICT_DATE_TO_VARCHAR
+FLAT_DATE_TO_VARCHAR
+BENCHMARK_DRAW_LINE();
+DICT_DATE_TO_TIMESTAMP
+FLAT_DATE_TO_TIMESTAMP
+BENCHMARK_DRAW_LINE();
+DICT_REAL_TO_DOUBLE
+FLAT_REAL_TO_DOUBLE
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+
+  std::cout
+      << "\nBenchmark entry names encode the sweep parameters:\n"
+      << "  DICT_<from>To<to>("
+         "rowsPerVector_distinctValueCount_newIndicesPerVector_nullPct)\n"
+      << "  FLAT_<from>To<to>(rowsPerVector_nullPct)\n"
+      << "\n"
+      << "numVectors is fixed at 1000 for every entry and is not encoded\n"
+      << "in the name. Each measurement runs the cast over 1000 input\n"
+      << "vectors back-to-back; the reported time/iter is amortized over\n"
+      << "the total row count (1000 * rowsPerVector).\n"
+      << "\n"
+      << "  rowsPerVector       : rows in each input vector\n"
+      << "  distinctValueCount  : dictionary base cardinality (DICT only)\n"
+      << "  newIndicesPerVector : new dictionary indices each input vector\n"
+      << "                        introduces vs the previous one - drives\n"
+      << "                        the dictionary-cache miss rate (DICT only)\n"
+      << "  nullPct             : percentage of positions marked null in\n"
+      << "                        {0, 50, 100}. For DICT, nulls live on\n"
+      << "                        the dictionary wrap; for FLAT, on the\n"
+      << "                        flat input itself.\n"
+      << "\n";
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/expression/benchmarks/WideningCastBenchmark.cpp
+++ b/velox/expression/benchmarks/WideningCastBenchmark.cpp
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-#include <array>
+#include <atomic>
 #include <iostream>
+#include <thread>
 
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
@@ -29,39 +30,67 @@
 DEFINE_bool(gtest_color, false, "");
 DEFINE_string(gtest_filter, "*", "");
 
-// Exercises Expr::evalWithMemo for CAST(BIGINT -> VARCHAR) and the fast
-// numeric upcast CAST(INT -> BIGINT) over a stable dictionary base across
-// many input vectors. This is the exact shape that drove the O(N^2)
-// regression observed on a production worker - each input vector acquired
-// one more string buffer into Expr::dictionaryCache_, so the per-call
-// acquireSharedStringBuffers loop grew linearly with the number of vectors
-// evaluated against the same base.
+// Exercises Expr::evalWithMemo for CAST(BIGINT -> VARCHAR), the fast
+// numeric upcast CAST(INT -> BIGINT), CAST(DATE -> VARCHAR/TIMESTAMP),
+// CAST(REAL -> DOUBLE), and a production-shaped
+// `date_format(CAST(date_trunc(...)) AS timestamp), '%Y-%m-%d')` chain
+// over many input vectors. This is the exact shape that drove the
+// O(N^2) regression observed on a production worker - each input
+// vector acquired one more string buffer into Expr::dictionaryCache_,
+// so the per-call acquireSharedStringBuffers loop grew linearly with
+// the number of vectors evaluated against the same base.
 //
 // READING THE BENCHMARK OUTPUT
-//   Dict entries: BigintToVarchar(rowsPerVector_distinctValueCount_
-//                                 newIndicesPerVector_nullPct)
-//   Flat entries: BigintToVarchar(rowsPerVector_nullPct)
+//   Single-base dict entries (no rotation):
+//     <funcName>(rowsPerVector_distinctValueCount_
+//                newIndicesPerVector_nullPct)
+//   Multi-base dict entries (rotation):
+//     <funcName>(rowsPerVector_distinctValueCount_
+//                newIndicesPerVector_nullPct_bpb<batchesPerBase>)
+//   Multi-thread dict entries:
+//     MT_<funcName>(threads<n>_rowsPerVector_distinctValueCount_
+//                   newIndicesPerVector_nullPct_bpb<batchesPerBase>)
+//   Flat entries: <funcName>(rowsPerVector_nullPct)
 //
-//   numVectors is fixed at kNumVectors (1000) for every entry and is
-//   not encoded in the name. Example: `DICT_BigintToVarchar(100_5_1_0)`
-//   means 100 rows per input vector, dictionary base has 5 distinct
-//   values, each input vector introduces 1 new dictionary index
-//   relative to the previous one, and 0% of dictionary positions are
-//   null - over 1000 vectors per iteration.
+//   numVectors is fixed at kNumVectors (1000) for every entry (per
+//   worker thread for MT entries) and is not encoded in the name.
+//   Example: `DICT_BigintToVarchar(100_5_1_0)` means 100 rows per
+//   input vector, dictionary base has 5 distinct values, each input
+//   vector introduces 1 new dictionary index relative to the
+//   previous one, and 0% of dictionary positions are null - over
+//   1000 vectors per iteration.
 //
 // Parameter dimensions:
 //   - numVectors          : how many input vectors per iteration
-//                          (fixed at kNumVectors, not swept, not in name)
+//                          (fixed at 1000 per worker thread,
+//                          not swept, not in name)
 //   - rowsPerVector       : rows in each input vector
 //   - distinctValueCount  : dictionary base cardinality (DICT only)
 //   - newIndicesPerVector : new dictionary indices each input vector
-//                           introduces (drives the cache miss rate)
-//                           (DICT only)
+//                           introduces (drives the cache miss rate
+//                           against a stable base) (DICT only)
 //   - nullPct             : percentage of positions marked null. For
 //                           DICT, nulls live on the dictionary wrap
 //                           (reach PeeledEncoding::translateToInnerRows
 //                           via wrapNulls_); for FLAT, nulls are on
 //                           the flat input itself.
+//   - batchesPerBase      : how many consecutive batches reuse the
+//                           same base FlatVector before rotating to
+//                           the next one. The "single base" entries
+//                           use batchesPerBase = 1000 (= numVectors,
+//                           so the base never rotates). The "_bpb*"
+//                           sweep covers {1, 10, 100} - matching the
+//                           realistic mix of base-change events that
+//                           a scan operator produces as it advances
+//                           through splits / pages. Lower values mean
+//                           more numMemoBaseChange events per call;
+//                           higher values mean a steadier cache.
+//   - numThreads          : MT entries only. Number of worker threads
+//                           all evaluating against shared base
+//                           FlatVector(s) - reproduces the cross-
+//                           driver atomic refcount contention on the
+//                           source Buffer that was observed in
+//                           production VARCHAR-producing casts.
 // Plus a flat (non-dictionary) baseline per rowsPerVector. The "from
 // -> to" type pair appears in every entry name so the table is
 // self-describing. The same legend is printed at startup before the
@@ -86,6 +115,16 @@ using namespace facebook::velox;
 
 namespace {
 
+// Production expression from a slow query observed in prod:
+// `date_format(CAST(date_trunc('day', date_add('day', 0 - (((day_of_week
+//  (c0) % 7) - 1 + 7) % 7), c0)) AS timestamp), '%Y-%m-%d')`
+// Hot-cache reproducer for the VARCHAR refcount-on-stringBuffer cost.
+constexpr const char* kDateFormatProdExpr =
+    "date_format("
+    "cast(date_trunc('day', "
+    "date_add('day', 0 - mod((day_of_week(c0) % 7 - 1) + 7, 7), c0)) "
+    "as timestamp), '%Y-%m-%d')";
+
 class WideningCastBenchmark : public functions::test::FunctionBenchmarkBase {
  public:
   WideningCastBenchmark() : FunctionBenchmarkBase() {
@@ -93,15 +132,17 @@ class WideningCastBenchmark : public functions::test::FunctionBenchmarkBase {
   }
 
   // Builds a flat numeric base of `baseType` and runs `numVectors`
-  // evaluations of `expression` over dictionary wrappers of that base. Each
-  // input vector's indices are `(row + vectorIdx * newIndicesPerVector) mod
-  // distinctValueCount`, so consecutive vectors overlap by `rowsPerVector -
-  // newIndicesPerVector` indices. `nullPct` is the percentage of dictionary
-  // positions marked null on the wrap (0, 50, 100) - the wrap-level nulls
-  // are what reach Expr::evalEncodings / PeeledEncoding::translateToInner-
-  // Rows. nullPct=0 hits the hoisted no-nulls path; nullPct=50 exercises
-  // the null-aware loop; nullPct=100 marks every position null so the
-  // downstream cast work short-circuits.
+  // evaluations of `expression` over dictionary wrappers of that
+  // base. Each input vector's indices are `(row + vectorIdx *
+  // newIndicesPerVector) mod distinctValueCount`, so consecutive
+  // vectors overlap by `rowsPerVector - newIndicesPerVector`
+  // indices. `nullPct` is the percentage of dictionary positions
+  // marked null on the wrap (0, 50, 100). `batchesPerBase` controls
+  // how often the underlying base FlatVector is swapped for a new
+  // one: every `batchesPerBase` consecutive batches share a base,
+  // then the next group of batches gets a different base (different
+  // BufferPtr, different content). Pass `batchesPerBase >=
+  // numVectors` (or <= 0) for the single-base behavior.
   template <typename BaseNativeType>
   size_t runDictionary(
       const std::string& expression,
@@ -110,14 +151,15 @@ class WideningCastBenchmark : public functions::test::FunctionBenchmarkBase {
       int32_t rowsPerVector,
       int32_t distinctValueCount,
       int32_t newIndicesPerVector,
-      int32_t nullPct) {
+      int32_t nullPct,
+      int32_t batchesPerBase) {
     folly::BenchmarkSuspender suspender;
+    if (batchesPerBase <= 0) {
+      batchesPerBase = numVectors;
+    }
 
-    auto base = vectorMaker_.flatVector<BaseNativeType>(
-        distinctValueCount,
-        [](vector_size_t row) { return static_cast<BaseNativeType>(row + 1); },
-        nullptr,
-        baseType);
+    auto bases = buildBases<BaseNativeType>(
+        baseType, distinctValueCount, numVectors, batchesPerBase, pool());
     auto rowType = ROW({"c0"}, {baseType});
     auto exprSet = compileExpression(expression, rowType);
 
@@ -125,29 +167,14 @@ class WideningCastBenchmark : public functions::test::FunctionBenchmarkBase {
     inputs.reserve(numVectors);
     for (int32_t vectorIdx = 0; vectorIdx < numVectors; ++vectorIdx) {
       const int32_t offset = vectorIdx * newIndicesPerVector;
-      auto indices =
-          AlignedBuffer::allocate<vector_size_t>(rowsPerVector, pool());
-      auto* rawIndices = indices->asMutable<vector_size_t>();
-      for (int32_t row = 0; row < rowsPerVector; ++row) {
-        rawIndices[row] = (row + offset) % distinctValueCount;
-      }
-
-      BufferPtr nulls;
-      if (nullPct > 0) {
-        nulls = AlignedBuffer::allocate<bool>(rowsPerVector, pool());
-        auto* rawNulls = nulls->asMutable<uint64_t>();
-        if (nullPct >= 100) {
-          bits::fillBits(rawNulls, 0, rowsPerVector, bits::kNull);
-        } else {
-          bits::fillBits(rawNulls, 0, rowsPerVector, bits::kNotNull);
-          const int32_t step = 100 / nullPct;
-          for (int32_t row = 0; row < rowsPerVector; row += step) {
-            bits::setNull(rawNulls, row, true);
-          }
-        }
-      }
-      auto dict =
-          BaseVector::wrapInDictionary(nulls, indices, rowsPerVector, base);
+      const int32_t baseIdx = vectorIdx / batchesPerBase;
+      auto dict = wrapInDict(
+          bases[baseIdx],
+          offset,
+          rowsPerVector,
+          distinctValueCount,
+          nullPct,
+          pool());
       inputs.push_back(vectorMaker_.rowVector({dict}));
     }
     suspender.dismiss();
@@ -159,6 +186,108 @@ class WideningCastBenchmark : public functions::test::FunctionBenchmarkBase {
       count += result->size();
     }
     return count;
+  }
+
+  // Same as runDictionary but spawns `numThreads` worker threads.
+  // The base FlatVectors are constructed once on the calling thread
+  // and shared (via shared_ptr / BufferPtr) across all workers - this
+  // puts the source Buffer's atomic refcount on a cache line touched
+  // by every worker, reproducing the cross-driver contention observed
+  // in production. Each worker has its own ExecCtx, ExprSet, and per-
+  // thread input vectors (constructed on a per-thread pool); only the
+  // base FlatVectors are shared.
+  template <typename BaseNativeType>
+  size_t runDictionaryMultiThread(
+      const std::string& expression,
+      const TypePtr& baseType,
+      int32_t numThreads,
+      int32_t numVectorsPerThread,
+      int32_t rowsPerVector,
+      int32_t distinctValueCount,
+      int32_t newIndicesPerVector,
+      int32_t nullPct,
+      int32_t batchesPerBase) {
+    folly::BenchmarkSuspender suspender;
+    if (batchesPerBase <= 0) {
+      batchesPerBase = numVectorsPerThread;
+    }
+
+    // Bases live on the benchmark's pool; their BufferPtrs are
+    // shared across worker threads via wrap.
+    auto bases = buildBases<BaseNativeType>(
+        baseType,
+        distinctValueCount,
+        numVectorsPerThread,
+        batchesPerBase,
+        pool());
+    auto rowType = ROW({"c0"}, {baseType});
+
+    struct ThreadCtx {
+      std::shared_ptr<memory::MemoryPool> pool;
+      std::shared_ptr<core::QueryCtx> queryCtx;
+      std::unique_ptr<core::ExecCtx> execCtx;
+      std::unique_ptr<exec::ExprSet> exprSet;
+      std::vector<RowVectorPtr> inputs;
+    };
+    std::vector<ThreadCtx> threadCtxs(numThreads);
+
+    for (int32_t t = 0; t < numThreads; ++t) {
+      auto& tc = threadCtxs[t];
+      tc.pool = memory::memoryManager()->addLeafPool();
+      tc.queryCtx = core::QueryCtx::create();
+      tc.execCtx =
+          std::make_unique<core::ExecCtx>(tc.pool.get(), tc.queryCtx.get());
+      facebook::velox::test::VectorMaker maker{tc.pool.get()};
+
+      tc.inputs.reserve(numVectorsPerThread);
+      for (int32_t vectorIdx = 0; vectorIdx < numVectorsPerThread;
+           ++vectorIdx) {
+        const int32_t offset = vectorIdx * newIndicesPerVector;
+        const int32_t baseIdx = vectorIdx / batchesPerBase;
+        auto dict = wrapInDict(
+            bases[baseIdx],
+            offset,
+            rowsPerVector,
+            distinctValueCount,
+            nullPct,
+            tc.pool.get());
+        tc.inputs.push_back(maker.rowVector({dict}));
+      }
+
+      // Compile per worker so each holds its own dictionaryCache_.
+      auto untyped =
+          parse::DuckSqlExpressionsParser(options_).parseExpr(expression);
+      auto typed = core::Expressions::inferTypes(
+          untyped, rowType, tc.execCtx->pool());
+      std::vector<core::TypedExprPtr> typedExprs{typed};
+      tc.exprSet =
+          std::make_unique<exec::ExprSet>(typedExprs, tc.execCtx.get());
+    }
+    suspender.dismiss();
+
+    std::atomic<size_t> totalCount{0};
+    std::vector<std::thread> threads;
+    threads.reserve(numThreads);
+    for (int32_t t = 0; t < numThreads; ++t) {
+      threads.emplace_back([&threadCtxs, &totalCount, t]() {
+        auto& tc = threadCtxs[t];
+        size_t count = 0;
+        for (auto& input : tc.inputs) {
+          SelectivityVector rows(input->size());
+          exec::EvalCtx evalCtx(
+              tc.execCtx.get(), tc.exprSet.get(), input.get());
+          std::vector<VectorPtr> results{nullptr};
+          tc.exprSet->eval(rows, evalCtx, results);
+          folly::doNotOptimizeAway(results);
+          count += results[0]->size();
+        }
+        totalCount.fetch_add(count, std::memory_order_relaxed);
+      });
+    }
+    for (auto& th : threads) {
+      th.join();
+    }
+    return totalCount.load();
   }
 
   template <typename BaseNativeType>
@@ -199,11 +328,81 @@ class WideningCastBenchmark : public functions::test::FunctionBenchmarkBase {
     }
     return count;
   }
+
+ private:
+  // Builds the set of distinct base FlatVectors that the dictionary
+  // wraps rotate through. With `batchesPerBase >= numVectors`, this
+  // returns a single base (matching the original behavior). Each
+  // base is populated with values starting at `baseIdx *
+  // distinctValueCount + 1` so distinct bases have distinct content
+  // (which makes peelEncodings register a real base change on
+  // rotation, not just a fresh pointer to the same content).
+  template <typename BaseNativeType>
+  std::vector<VectorPtr> buildBases(
+      const TypePtr& baseType,
+      int32_t distinctValueCount,
+      int32_t numVectors,
+      int32_t batchesPerBase,
+      memory::MemoryPool* basePool) {
+    const int32_t numBases =
+        std::max(1, (numVectors + batchesPerBase - 1) / batchesPerBase);
+    facebook::velox::test::VectorMaker maker{basePool};
+    std::vector<VectorPtr> bases;
+    bases.reserve(numBases);
+    for (int32_t b = 0; b < numBases; ++b) {
+      const int32_t baseOffset = b * distinctValueCount;
+      bases.push_back(maker.flatVector<BaseNativeType>(
+          distinctValueCount,
+          [baseOffset](vector_size_t row) {
+            return static_cast<BaseNativeType>(row + baseOffset + 1);
+          },
+          nullptr,
+          baseType));
+    }
+    return bases;
+  }
+
+  // Builds a DictionaryVector over `base` of `rowsPerVector` rows.
+  // The indices walk `(row + offset) mod distinctValueCount`, so
+  // `offset` shifts the visible slice of the base across batches.
+  // `nullPct` controls how many of the dictionary positions are
+  // marked null on the wrap (not on the base).
+  VectorPtr wrapInDict(
+      const VectorPtr& base,
+      int32_t offset,
+      int32_t rowsPerVector,
+      int32_t distinctValueCount,
+      int32_t nullPct,
+      memory::MemoryPool* dictPool) {
+    auto indices =
+        AlignedBuffer::allocate<vector_size_t>(rowsPerVector, dictPool);
+    auto* rawIndices = indices->asMutable<vector_size_t>();
+    for (int32_t row = 0; row < rowsPerVector; ++row) {
+      rawIndices[row] = (row + offset) % distinctValueCount;
+    }
+
+    BufferPtr nulls;
+    if (nullPct > 0) {
+      nulls = AlignedBuffer::allocate<bool>(rowsPerVector, dictPool);
+      auto* rawNulls = nulls->asMutable<uint64_t>();
+      if (nullPct >= 100) {
+        bits::fillBits(rawNulls, 0, rowsPerVector, bits::kNull);
+      } else {
+        bits::fillBits(rawNulls, 0, rowsPerVector, bits::kNotNull);
+        const int32_t step = 100 / nullPct;
+        for (int32_t row = 0; row < rowsPerVector; row += step) {
+          bits::setNull(rawNulls, row, true);
+        }
+      }
+    }
+    return BaseVector::wrapInDictionary(nulls, indices, rowsPerVector, base);
+  }
 };
 
-// Free functions used by BENCHMARK_NAMED_PARAM_MULTI. Names spell the
-// from -> to type pair. Each loops the work `iters` times so folly's
-// iteration-scaling controls measurement length.
+// === Single-base DICT free functions. Each loops the work `iters`
+// times so folly's iteration-scaling controls measurement length.
+// batchesPerBase is passed as a runtime parameter so the same free
+// function can drive both single-base and multi-base entries.
 
 unsigned DICT_BigintToVarchar(
     unsigned iters,
@@ -211,7 +410,8 @@ unsigned DICT_BigintToVarchar(
     int32_t rowsPerVector,
     int32_t distinctValueCount,
     int32_t newIndicesPerVector,
-    int32_t nullPct) {
+    int32_t nullPct,
+    int32_t batchesPerBase) {
   WideningCastBenchmark benchmark;
   unsigned total = 0;
   for (unsigned i = 0; i < iters; ++i) {
@@ -222,7 +422,8 @@ unsigned DICT_BigintToVarchar(
         rowsPerVector,
         distinctValueCount,
         newIndicesPerVector,
-        nullPct);
+        nullPct,
+        batchesPerBase);
   }
   return total;
 }
@@ -247,7 +448,8 @@ unsigned DICT_IntToBigint(
     int32_t rowsPerVector,
     int32_t distinctValueCount,
     int32_t newIndicesPerVector,
-    int32_t nullPct) {
+    int32_t nullPct,
+    int32_t batchesPerBase) {
   WideningCastBenchmark benchmark;
   unsigned total = 0;
   for (unsigned i = 0; i < iters; ++i) {
@@ -258,7 +460,8 @@ unsigned DICT_IntToBigint(
         rowsPerVector,
         distinctValueCount,
         newIndicesPerVector,
-        nullPct);
+        nullPct,
+        batchesPerBase);
   }
   return total;
 }
@@ -284,7 +487,8 @@ unsigned DICT_DateToVarchar(
     int32_t rowsPerVector,
     int32_t distinctValueCount,
     int32_t newIndicesPerVector,
-    int32_t nullPct) {
+    int32_t nullPct,
+    int32_t batchesPerBase) {
   WideningCastBenchmark benchmark;
   unsigned total = 0;
   for (unsigned i = 0; i < iters; ++i) {
@@ -295,7 +499,8 @@ unsigned DICT_DateToVarchar(
         rowsPerVector,
         distinctValueCount,
         newIndicesPerVector,
-        nullPct);
+        nullPct,
+        batchesPerBase);
   }
   return total;
 }
@@ -320,7 +525,8 @@ unsigned DICT_DateToTimestamp(
     int32_t rowsPerVector,
     int32_t distinctValueCount,
     int32_t newIndicesPerVector,
-    int32_t nullPct) {
+    int32_t nullPct,
+    int32_t batchesPerBase) {
   WideningCastBenchmark benchmark;
   unsigned total = 0;
   for (unsigned i = 0; i < iters; ++i) {
@@ -331,7 +537,8 @@ unsigned DICT_DateToTimestamp(
         rowsPerVector,
         distinctValueCount,
         newIndicesPerVector,
-        nullPct);
+        nullPct,
+        batchesPerBase);
   }
   return total;
 }
@@ -356,7 +563,8 @@ unsigned DICT_RealToDouble(
     int32_t rowsPerVector,
     int32_t distinctValueCount,
     int32_t newIndicesPerVector,
-    int32_t nullPct) {
+    int32_t nullPct,
+    int32_t batchesPerBase) {
   WideningCastBenchmark benchmark;
   unsigned total = 0;
   for (unsigned i = 0; i < iters; ++i) {
@@ -367,7 +575,8 @@ unsigned DICT_RealToDouble(
         rowsPerVector,
         distinctValueCount,
         newIndicesPerVector,
-        nullPct);
+        nullPct,
+        batchesPerBase);
   }
   return total;
 }
@@ -386,32 +595,225 @@ unsigned FLAT_RealToDouble(
   return total;
 }
 
+// === Production date_format expression
+//
+// `date_format(CAST(date_trunc('day', date_add('day',
+//    0 - (((day_of_week(c0) % 7) - 1 + 7) % 7), c0)) AS timestamp),
+//  '%Y-%m-%d')`
+//
+// Input is DATE, output is VARCHAR. This is the exact shape that
+// drove the original profile - the result Buffer is shared across
+// batches via dictionaryCache_, and the per-batch copy iterates its
+// stringBuffers_ with one atomic refcount increment per Buffer.
+
+unsigned DICT_DateFormatProd(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct,
+    int32_t batchesPerBase) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionary<int32_t>(
+        kDateFormatProdExpr,
+        DATE(),
+        numVectors,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct,
+        batchesPerBase);
+  }
+  return total;
+}
+
+unsigned FLAT_DateFormatProd(
+    unsigned iters,
+    int32_t numVectors,
+    int32_t rowsPerVector,
+    int32_t nullPct) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runFlat<int32_t>(
+        kDateFormatProdExpr, DATE(), numVectors, rowsPerVector, nullPct);
+  }
+  return total;
+}
+
+// === Multi-thread DICT free functions. The first runtime arg is the
+// number of worker threads; the second is per-thread numVectors.
+
+unsigned MT_DICT_BigintToVarchar(
+    unsigned iters,
+    int32_t numThreads,
+    int32_t numVectorsPerThread,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct,
+    int32_t batchesPerBase) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionaryMultiThread<int64_t>(
+        "cast(c0 as varchar)",
+        BIGINT(),
+        numThreads,
+        numVectorsPerThread,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct,
+        batchesPerBase);
+  }
+  return total;
+}
+
+unsigned MT_DICT_DateToVarchar(
+    unsigned iters,
+    int32_t numThreads,
+    int32_t numVectorsPerThread,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct,
+    int32_t batchesPerBase) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionaryMultiThread<int32_t>(
+        "cast(c0 as varchar)",
+        DATE(),
+        numThreads,
+        numVectorsPerThread,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct,
+        batchesPerBase);
+  }
+  return total;
+}
+
+unsigned MT_DICT_DateToTimestamp(
+    unsigned iters,
+    int32_t numThreads,
+    int32_t numVectorsPerThread,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct,
+    int32_t batchesPerBase) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionaryMultiThread<int32_t>(
+        "cast(c0 as timestamp)",
+        DATE(),
+        numThreads,
+        numVectorsPerThread,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct,
+        batchesPerBase);
+  }
+  return total;
+}
+
+unsigned MT_DICT_DateFormatProd(
+    unsigned iters,
+    int32_t numThreads,
+    int32_t numVectorsPerThread,
+    int32_t rowsPerVector,
+    int32_t distinctValueCount,
+    int32_t newIndicesPerVector,
+    int32_t nullPct,
+    int32_t batchesPerBase) {
+  WideningCastBenchmark benchmark;
+  unsigned total = 0;
+  for (unsigned i = 0; i < iters; ++i) {
+    total += benchmark.runDictionaryMultiThread<int32_t>(
+        kDateFormatProdExpr,
+        DATE(),
+        numThreads,
+        numVectorsPerThread,
+        rowsPerVector,
+        distinctValueCount,
+        newIndicesPerVector,
+        nullPct,
+        batchesPerBase);
+  }
+  return total;
+}
+
 } // namespace
 
-// DICT_BIGINT_TO_VARCHAR registers cast(BIGINT -> VARCHAR) over a
-// dictionary for every (rowsPerVector, distinctValueCount,
-// newIndicesPerVector) sweep point. numVectors is fixed at 1000 (the
-// literal in the BENCHMARK_NAMED_PARAM_MULTI call below) and is not
-// encoded in the entry name. Each source line through DICT_NULLS /
-// FLAT_NULLS expands to three benchmark entries - one per nullPct in
-// {0, 50, 100}. Comment a single line out of the body to drop those
-// three combinations globally.
-#define DICT(                                                                          \
-    funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct)         \
-  BENCHMARK_NAMED_PARAM_MULTI(                                                         \
-      funcName,                                                                        \
-      rowsPerVector##_##distinctValueCount##_##newIndicesPerVector##_##nullPct,        \
-      1000,                                                                            \
-      rowsPerVector,                                                                   \
-      distinctValueCount,                                                              \
-      newIndicesPerVector,                                                             \
-      nullPct)
+// Each macro pastes the parameter values into the entry name so the
+// table is grep-able. The constant `1000` literal in DICT/FLAT calls
+// is numVectors (also baked into the entry name format described in
+// READING THE BENCHMARK OUTPUT above). `1000` literal in DICT calls
+// for batchesPerBase makes the cache cover the entire iteration -
+// the original "single base" behavior. The `_bpb<n>` suffix opts in
+// to the multi-base behavior.
 
-#define DICT_NULLS(                                                          \
-    funcName, rowsPerVector, distinctValueCount, newIndicesPerVector)        \
+#define DICT(                                                              \
+    funcName,                                                              \
+    rowsPerVector,                                                         \
+    distinctValueCount,                                                    \
+    newIndicesPerVector,                                                   \
+    nullPct)                                                               \
+  BENCHMARK_NAMED_PARAM_MULTI(                                             \
+      funcName,                                                            \
+      rowsPerVector##_##distinctValueCount##_##newIndicesPerVector##_##nullPct, \
+      1000,                                                                \
+      rowsPerVector,                                                       \
+      distinctValueCount,                                                  \
+      newIndicesPerVector,                                                 \
+      nullPct,                                                             \
+      1000)
+
+#define DICT_NULLS(                                                   \
+    funcName, rowsPerVector, distinctValueCount, newIndicesPerVector) \
   DICT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, 0)  \
   DICT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, 50) \
   DICT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, 100)
+
+// Multi-base variant. `batchesPerBase` is the number of consecutive
+// batches that reuse the same base FlatVector before rotating.
+#define DICT_BPB(                                                          \
+    funcName,                                                              \
+    rowsPerVector,                                                         \
+    distinctValueCount,                                                    \
+    newIndicesPerVector,                                                   \
+    nullPct,                                                               \
+    batchesPerBase)                                                        \
+  BENCHMARK_NAMED_PARAM_MULTI(                                             \
+      funcName,                                                            \
+      rowsPerVector##_##distinctValueCount##_##newIndicesPerVector##_##nullPct##_bpb##batchesPerBase, \
+      1000,                                                                \
+      rowsPerVector,                                                       \
+      distinctValueCount,                                                  \
+      newIndicesPerVector,                                                 \
+      nullPct,                                                             \
+      batchesPerBase)
+
+// Sweep batchesPerBase across {1, 10, 100} for a given config. With
+// numVectors=1000, that is {1000, 100, 10} base changes per call.
+#define DICT_ALT(                                                     \
+    funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct) \
+  DICT_BPB(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct, 1) \
+  DICT_BPB(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct, 10) \
+  DICT_BPB(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct, 100)
+
+#define DICT_ALT_NULLS(                                               \
+    funcName, rowsPerVector, distinctValueCount, newIndicesPerVector) \
+  DICT_ALT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, 0) \
+  DICT_ALT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, 50)
 
 #define FLAT(funcName, rowsPerVector, nullPct)         \
   BENCHMARK_NAMED_PARAM_MULTI(                         \
@@ -422,181 +824,295 @@ unsigned FLAT_RealToDouble(
   FLAT(funcName, rowsPerVector, 50)         \
   FLAT(funcName, rowsPerVector, 100)
 
-// Each DICT(funcName, ...) line below registers one benchmark entry.
-// The three numeric arguments are positional:
-//   DICT(funcName, rowsPerVector, distinctValueCount, newIndicesPerVector)
-#define DICT_BIGINT_TO_VARCHAR                         \
-  DICT_NULLS(DICT_BigintToVarchar, 100, 5, 1)      \
-  DICT_NULLS(DICT_BigintToVarchar, 100, 5, 100)    \
-  DICT_NULLS(DICT_BigintToVarchar, 100, 5, 1000)   \
-  DICT_NULLS(DICT_BigintToVarchar, 100, 500, 1)    \
-  DICT_NULLS(DICT_BigintToVarchar, 100, 500, 100)  \
-  DICT_NULLS(DICT_BigintToVarchar, 100, 500, 1000) \
-  DICT_NULLS(DICT_BigintToVarchar, 100, 15000, 1)  \
-  DICT_NULLS(DICT_BigintToVarchar, 100, 15000, 100)\
-  DICT_NULLS(DICT_BigintToVarchar, 100, 15000, 1000)\
-  DICT_NULLS(DICT_BigintToVarchar, 1000, 5, 1)     \
-  DICT_NULLS(DICT_BigintToVarchar, 1000, 5, 100)   \
-  DICT_NULLS(DICT_BigintToVarchar, 1000, 5, 1000)  \
-  DICT_NULLS(DICT_BigintToVarchar, 1000, 500, 1)   \
-  DICT_NULLS(DICT_BigintToVarchar, 1000, 500, 100) \
-  DICT_NULLS(DICT_BigintToVarchar, 1000, 500, 1000)\
-  DICT_NULLS(DICT_BigintToVarchar, 1000, 15000, 1) \
-  DICT_NULLS(DICT_BigintToVarchar, 1000, 15000, 100)\
-  DICT_NULLS(DICT_BigintToVarchar, 1000, 15000, 1000)\
-  DICT_NULLS(DICT_BigintToVarchar, 10000, 5, 1)    \
-  DICT_NULLS(DICT_BigintToVarchar, 10000, 5, 100)  \
-  DICT_NULLS(DICT_BigintToVarchar, 10000, 5, 1000) \
-  DICT_NULLS(DICT_BigintToVarchar, 10000, 500, 1)  \
-  DICT_NULLS(DICT_BigintToVarchar, 10000, 500, 100)\
-  DICT_NULLS(DICT_BigintToVarchar, 10000, 500, 1000)\
-  DICT_NULLS(DICT_BigintToVarchar, 10000, 15000, 1)\
-  DICT_NULLS(DICT_BigintToVarchar, 10000, 15000, 100)\
+// Multi-thread macro. Uses 1000 as the per-thread numVectors literal.
+#define MT(                                                                \
+    funcName,                                                              \
+    numThreads,                                                            \
+    rowsPerVector,                                                         \
+    distinctValueCount,                                                    \
+    newIndicesPerVector,                                                   \
+    nullPct,                                                               \
+    batchesPerBase)                                                        \
+  BENCHMARK_NAMED_PARAM_MULTI(                                             \
+      funcName,                                                            \
+      threads##numThreads##_##rowsPerVector##_##distinctValueCount##_##newIndicesPerVector##_##nullPct##_bpb##batchesPerBase, \
+      numThreads,                                                          \
+      1000,                                                                \
+      rowsPerVector,                                                       \
+      distinctValueCount,                                                  \
+      newIndicesPerVector,                                                 \
+      nullPct,                                                             \
+      batchesPerBase)
+
+// MT_ALT: sweep batchesPerBase {1, 100, 1000} for given thread count
+// and config. Lower batchesPerBase amplifies contention because each
+// batch starts a fresh evalWithMemo path, repeatedly touching the
+// source Buffer's refcount line across threads.
+#define MT_ALT(                                                       \
+    funcName,                                                         \
+    numThreads,                                                       \
+    rowsPerVector,                                                    \
+    distinctValueCount,                                               \
+    newIndicesPerVector,                                              \
+    nullPct)                                                          \
+  MT(funcName, numThreads, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct, 1) \
+  MT(funcName, numThreads, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct, 100) \
+  MT(funcName, numThreads, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct, 1000)
+
+// MT_THREADS: sweep thread counts for a fixed dict config, sweeping
+// batchesPerBase within each thread count.
+#define MT_THREADS(                                                   \
+    funcName, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct) \
+  MT_ALT(funcName, 4, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct) \
+  MT_ALT(funcName, 16, rowsPerVector, distinctValueCount, newIndicesPerVector, nullPct)
+
+// === Existing single-base entries (batchesPerBase = numVectors = 1000)
+// kept as a "best-case cache hit" baseline.
+
+#define DICT_BIGINT_TO_VARCHAR                          \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 5, 1)          \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 5, 100)        \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 5, 1000)       \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 500, 1)        \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 500, 100)      \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 500, 1000)     \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 15000, 1)      \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 15000, 100)    \
+  DICT_NULLS(DICT_BigintToVarchar, 100, 15000, 1000)   \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 5, 1)         \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 5, 100)       \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 5, 1000)      \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 500, 1)       \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 500, 100)     \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 500, 1000)    \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 15000, 1)     \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 15000, 100)   \
+  DICT_NULLS(DICT_BigintToVarchar, 1000, 15000, 1000)  \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 5, 1)        \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 5, 100)      \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 5, 1000)     \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 500, 1)      \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 500, 100)    \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 500, 1000)   \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 15000, 1)    \
+  DICT_NULLS(DICT_BigintToVarchar, 10000, 15000, 100)  \
   DICT_NULLS(DICT_BigintToVarchar, 10000, 15000, 1000)
 
-#define FLAT_BIGINT_TO_VARCHAR                   \
-  FLAT_NULLS(FLAT_BigintToVarchar, 100)      \
-  FLAT_NULLS(FLAT_BigintToVarchar, 1000)     \
+#define FLAT_BIGINT_TO_VARCHAR              \
+  FLAT_NULLS(FLAT_BigintToVarchar, 100)     \
+  FLAT_NULLS(FLAT_BigintToVarchar, 1000)    \
   FLAT_NULLS(FLAT_BigintToVarchar, 10000)
 
-#define DICT_INT_TO_BIGINT                            \
-  DICT_NULLS(DICT_IntToBigint, 100, 5, 1)         \
-  DICT_NULLS(DICT_IntToBigint, 100, 5, 100)       \
-  DICT_NULLS(DICT_IntToBigint, 100, 5, 1000)      \
-  DICT_NULLS(DICT_IntToBigint, 100, 500, 1)       \
-  DICT_NULLS(DICT_IntToBigint, 100, 500, 100)     \
-  DICT_NULLS(DICT_IntToBigint, 100, 500, 1000)    \
-  DICT_NULLS(DICT_IntToBigint, 100, 15000, 1)     \
-  DICT_NULLS(DICT_IntToBigint, 100, 15000, 100)   \
-  DICT_NULLS(DICT_IntToBigint, 100, 15000, 1000)  \
-  DICT_NULLS(DICT_IntToBigint, 1000, 5, 1)        \
-  DICT_NULLS(DICT_IntToBigint, 1000, 5, 100)      \
-  DICT_NULLS(DICT_IntToBigint, 1000, 5, 1000)     \
-  DICT_NULLS(DICT_IntToBigint, 1000, 500, 1)      \
-  DICT_NULLS(DICT_IntToBigint, 1000, 500, 100)    \
-  DICT_NULLS(DICT_IntToBigint, 1000, 500, 1000)   \
-  DICT_NULLS(DICT_IntToBigint, 1000, 15000, 1)    \
-  DICT_NULLS(DICT_IntToBigint, 1000, 15000, 100)  \
-  DICT_NULLS(DICT_IntToBigint, 1000, 15000, 1000) \
-  DICT_NULLS(DICT_IntToBigint, 10000, 5, 1)       \
-  DICT_NULLS(DICT_IntToBigint, 10000, 5, 100)     \
-  DICT_NULLS(DICT_IntToBigint, 10000, 5, 1000)    \
-  DICT_NULLS(DICT_IntToBigint, 10000, 500, 1)     \
-  DICT_NULLS(DICT_IntToBigint, 10000, 500, 100)   \
-  DICT_NULLS(DICT_IntToBigint, 10000, 500, 1000)  \
-  DICT_NULLS(DICT_IntToBigint, 10000, 15000, 1)   \
-  DICT_NULLS(DICT_IntToBigint, 10000, 15000, 100) \
+#define DICT_INT_TO_BIGINT                              \
+  DICT_NULLS(DICT_IntToBigint, 100, 5, 1)              \
+  DICT_NULLS(DICT_IntToBigint, 100, 5, 100)            \
+  DICT_NULLS(DICT_IntToBigint, 100, 5, 1000)           \
+  DICT_NULLS(DICT_IntToBigint, 100, 500, 1)            \
+  DICT_NULLS(DICT_IntToBigint, 100, 500, 100)          \
+  DICT_NULLS(DICT_IntToBigint, 100, 500, 1000)         \
+  DICT_NULLS(DICT_IntToBigint, 100, 15000, 1)          \
+  DICT_NULLS(DICT_IntToBigint, 100, 15000, 100)        \
+  DICT_NULLS(DICT_IntToBigint, 100, 15000, 1000)       \
+  DICT_NULLS(DICT_IntToBigint, 1000, 5, 1)             \
+  DICT_NULLS(DICT_IntToBigint, 1000, 5, 100)           \
+  DICT_NULLS(DICT_IntToBigint, 1000, 5, 1000)          \
+  DICT_NULLS(DICT_IntToBigint, 1000, 500, 1)           \
+  DICT_NULLS(DICT_IntToBigint, 1000, 500, 100)         \
+  DICT_NULLS(DICT_IntToBigint, 1000, 500, 1000)        \
+  DICT_NULLS(DICT_IntToBigint, 1000, 15000, 1)         \
+  DICT_NULLS(DICT_IntToBigint, 1000, 15000, 100)       \
+  DICT_NULLS(DICT_IntToBigint, 1000, 15000, 1000)      \
+  DICT_NULLS(DICT_IntToBigint, 10000, 5, 1)            \
+  DICT_NULLS(DICT_IntToBigint, 10000, 5, 100)          \
+  DICT_NULLS(DICT_IntToBigint, 10000, 5, 1000)         \
+  DICT_NULLS(DICT_IntToBigint, 10000, 500, 1)          \
+  DICT_NULLS(DICT_IntToBigint, 10000, 500, 100)        \
+  DICT_NULLS(DICT_IntToBigint, 10000, 500, 1000)       \
+  DICT_NULLS(DICT_IntToBigint, 10000, 15000, 1)        \
+  DICT_NULLS(DICT_IntToBigint, 10000, 15000, 100)      \
   DICT_NULLS(DICT_IntToBigint, 10000, 15000, 1000)
 
-// Each FLAT(funcName, ...) line below registers one benchmark entry.
-// The single numeric argument is:
-//   FLAT(funcName, rowsPerVector)
-#define FLAT_INT_TO_BIGINT                       \
-  FLAT_NULLS(FLAT_IntToBigint, 100)          \
-  FLAT_NULLS(FLAT_IntToBigint, 1000)         \
+#define FLAT_INT_TO_BIGINT                  \
+  FLAT_NULLS(FLAT_IntToBigint, 100)         \
+  FLAT_NULLS(FLAT_IntToBigint, 1000)        \
   FLAT_NULLS(FLAT_IntToBigint, 10000)
 
-#define DICT_DATE_TO_VARCHAR                  \
-  DICT_NULLS(DICT_DateToVarchar, 100, 5, 1)              \
-  DICT_NULLS(DICT_DateToVarchar, 100, 5, 100)            \
-  DICT_NULLS(DICT_DateToVarchar, 100, 5, 1000)           \
-  DICT_NULLS(DICT_DateToVarchar, 100, 500, 1)            \
-  DICT_NULLS(DICT_DateToVarchar, 100, 500, 100)          \
-  DICT_NULLS(DICT_DateToVarchar, 100, 500, 1000)         \
-  DICT_NULLS(DICT_DateToVarchar, 100, 15000, 1)          \
-  DICT_NULLS(DICT_DateToVarchar, 100, 15000, 100)        \
-  DICT_NULLS(DICT_DateToVarchar, 100, 15000, 1000)       \
-  DICT_NULLS(DICT_DateToVarchar, 1000, 5, 1)             \
-  DICT_NULLS(DICT_DateToVarchar, 1000, 5, 100)           \
-  DICT_NULLS(DICT_DateToVarchar, 1000, 5, 1000)          \
-  DICT_NULLS(DICT_DateToVarchar, 1000, 500, 1)           \
-  DICT_NULLS(DICT_DateToVarchar, 1000, 500, 100)         \
-  DICT_NULLS(DICT_DateToVarchar, 1000, 500, 1000)        \
-  DICT_NULLS(DICT_DateToVarchar, 1000, 15000, 1)         \
-  DICT_NULLS(DICT_DateToVarchar, 1000, 15000, 100)       \
-  DICT_NULLS(DICT_DateToVarchar, 1000, 15000, 1000)      \
-  DICT_NULLS(DICT_DateToVarchar, 10000, 5, 1)            \
-  DICT_NULLS(DICT_DateToVarchar, 10000, 5, 100)          \
-  DICT_NULLS(DICT_DateToVarchar, 10000, 5, 1000)         \
-  DICT_NULLS(DICT_DateToVarchar, 10000, 500, 1)          \
-  DICT_NULLS(DICT_DateToVarchar, 10000, 500, 100)        \
-  DICT_NULLS(DICT_DateToVarchar, 10000, 500, 1000)       \
-  DICT_NULLS(DICT_DateToVarchar, 10000, 15000, 1)        \
-  DICT_NULLS(DICT_DateToVarchar, 10000, 15000, 100)      \
+#define DICT_DATE_TO_VARCHAR                            \
+  DICT_NULLS(DICT_DateToVarchar, 100, 5, 1)            \
+  DICT_NULLS(DICT_DateToVarchar, 100, 5, 100)          \
+  DICT_NULLS(DICT_DateToVarchar, 100, 5, 1000)         \
+  DICT_NULLS(DICT_DateToVarchar, 100, 500, 1)          \
+  DICT_NULLS(DICT_DateToVarchar, 100, 500, 100)        \
+  DICT_NULLS(DICT_DateToVarchar, 100, 500, 1000)       \
+  DICT_NULLS(DICT_DateToVarchar, 100, 15000, 1)        \
+  DICT_NULLS(DICT_DateToVarchar, 100, 15000, 100)      \
+  DICT_NULLS(DICT_DateToVarchar, 100, 15000, 1000)     \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 5, 1)           \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 5, 100)         \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 5, 1000)        \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 500, 1)         \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 500, 100)       \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 500, 1000)      \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 15000, 1)       \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 15000, 100)     \
+  DICT_NULLS(DICT_DateToVarchar, 1000, 15000, 1000)    \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 5, 1)          \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 5, 100)        \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 5, 1000)       \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 500, 1)        \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 500, 100)      \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 500, 1000)     \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 15000, 1)      \
+  DICT_NULLS(DICT_DateToVarchar, 10000, 15000, 100)    \
   DICT_NULLS(DICT_DateToVarchar, 10000, 15000, 1000)
 
-#define FLAT_DATE_TO_VARCHAR    \
-  FLAT_NULLS(FLAT_DateToVarchar, 100)      \
-  FLAT_NULLS(FLAT_DateToVarchar, 1000)     \
+#define FLAT_DATE_TO_VARCHAR                \
+  FLAT_NULLS(FLAT_DateToVarchar, 100)       \
+  FLAT_NULLS(FLAT_DateToVarchar, 1000)      \
   FLAT_NULLS(FLAT_DateToVarchar, 10000)
 
-#define DICT_DATE_TO_TIMESTAMP                  \
-  DICT_NULLS(DICT_DateToTimestamp, 100, 5, 1)              \
-  DICT_NULLS(DICT_DateToTimestamp, 100, 5, 100)            \
-  DICT_NULLS(DICT_DateToTimestamp, 100, 5, 1000)           \
-  DICT_NULLS(DICT_DateToTimestamp, 100, 500, 1)            \
-  DICT_NULLS(DICT_DateToTimestamp, 100, 500, 100)          \
-  DICT_NULLS(DICT_DateToTimestamp, 100, 500, 1000)         \
-  DICT_NULLS(DICT_DateToTimestamp, 100, 15000, 1)          \
-  DICT_NULLS(DICT_DateToTimestamp, 100, 15000, 100)        \
-  DICT_NULLS(DICT_DateToTimestamp, 100, 15000, 1000)       \
-  DICT_NULLS(DICT_DateToTimestamp, 1000, 5, 1)             \
-  DICT_NULLS(DICT_DateToTimestamp, 1000, 5, 100)           \
-  DICT_NULLS(DICT_DateToTimestamp, 1000, 5, 1000)          \
-  DICT_NULLS(DICT_DateToTimestamp, 1000, 500, 1)           \
-  DICT_NULLS(DICT_DateToTimestamp, 1000, 500, 100)         \
-  DICT_NULLS(DICT_DateToTimestamp, 1000, 500, 1000)        \
-  DICT_NULLS(DICT_DateToTimestamp, 1000, 15000, 1)         \
-  DICT_NULLS(DICT_DateToTimestamp, 1000, 15000, 100)       \
-  DICT_NULLS(DICT_DateToTimestamp, 1000, 15000, 1000)      \
-  DICT_NULLS(DICT_DateToTimestamp, 10000, 5, 1)            \
-  DICT_NULLS(DICT_DateToTimestamp, 10000, 5, 100)          \
-  DICT_NULLS(DICT_DateToTimestamp, 10000, 5, 1000)         \
-  DICT_NULLS(DICT_DateToTimestamp, 10000, 500, 1)          \
-  DICT_NULLS(DICT_DateToTimestamp, 10000, 500, 100)        \
-  DICT_NULLS(DICT_DateToTimestamp, 10000, 500, 1000)       \
-  DICT_NULLS(DICT_DateToTimestamp, 10000, 15000, 1)        \
-  DICT_NULLS(DICT_DateToTimestamp, 10000, 15000, 100)      \
+#define DICT_DATE_TO_TIMESTAMP                          \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 5, 1)          \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 5, 100)        \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 5, 1000)       \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 500, 1)        \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 500, 100)      \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 500, 1000)     \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 15000, 1)      \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 15000, 100)    \
+  DICT_NULLS(DICT_DateToTimestamp, 100, 15000, 1000)   \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 5, 1)         \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 5, 100)       \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 5, 1000)      \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 500, 1)       \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 500, 100)     \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 500, 1000)    \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 15000, 1)     \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 15000, 100)   \
+  DICT_NULLS(DICT_DateToTimestamp, 1000, 15000, 1000)  \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 5, 1)        \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 5, 100)      \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 5, 1000)     \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 500, 1)      \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 500, 100)    \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 500, 1000)   \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 15000, 1)    \
+  DICT_NULLS(DICT_DateToTimestamp, 10000, 15000, 100)  \
   DICT_NULLS(DICT_DateToTimestamp, 10000, 15000, 1000)
 
-#define FLAT_DATE_TO_TIMESTAMP    \
-  FLAT_NULLS(FLAT_DateToTimestamp, 100)      \
-  FLAT_NULLS(FLAT_DateToTimestamp, 1000)     \
+#define FLAT_DATE_TO_TIMESTAMP              \
+  FLAT_NULLS(FLAT_DateToTimestamp, 100)     \
+  FLAT_NULLS(FLAT_DateToTimestamp, 1000)    \
   FLAT_NULLS(FLAT_DateToTimestamp, 10000)
 
-#define DICT_REAL_TO_DOUBLE                  \
-  DICT_NULLS(DICT_RealToDouble, 100, 5, 1)              \
-  DICT_NULLS(DICT_RealToDouble, 100, 5, 100)            \
-  DICT_NULLS(DICT_RealToDouble, 100, 5, 1000)           \
-  DICT_NULLS(DICT_RealToDouble, 100, 500, 1)            \
-  DICT_NULLS(DICT_RealToDouble, 100, 500, 100)          \
-  DICT_NULLS(DICT_RealToDouble, 100, 500, 1000)         \
-  DICT_NULLS(DICT_RealToDouble, 100, 15000, 1)          \
-  DICT_NULLS(DICT_RealToDouble, 100, 15000, 100)        \
-  DICT_NULLS(DICT_RealToDouble, 100, 15000, 1000)       \
-  DICT_NULLS(DICT_RealToDouble, 1000, 5, 1)             \
-  DICT_NULLS(DICT_RealToDouble, 1000, 5, 100)           \
-  DICT_NULLS(DICT_RealToDouble, 1000, 5, 1000)          \
-  DICT_NULLS(DICT_RealToDouble, 1000, 500, 1)           \
-  DICT_NULLS(DICT_RealToDouble, 1000, 500, 100)         \
-  DICT_NULLS(DICT_RealToDouble, 1000, 500, 1000)        \
-  DICT_NULLS(DICT_RealToDouble, 1000, 15000, 1)         \
-  DICT_NULLS(DICT_RealToDouble, 1000, 15000, 100)       \
-  DICT_NULLS(DICT_RealToDouble, 1000, 15000, 1000)      \
-  DICT_NULLS(DICT_RealToDouble, 10000, 5, 1)            \
-  DICT_NULLS(DICT_RealToDouble, 10000, 5, 100)          \
-  DICT_NULLS(DICT_RealToDouble, 10000, 5, 1000)         \
-  DICT_NULLS(DICT_RealToDouble, 10000, 500, 1)          \
-  DICT_NULLS(DICT_RealToDouble, 10000, 500, 100)        \
-  DICT_NULLS(DICT_RealToDouble, 10000, 500, 1000)       \
-  DICT_NULLS(DICT_RealToDouble, 10000, 15000, 1)        \
-  DICT_NULLS(DICT_RealToDouble, 10000, 15000, 100)      \
+#define DICT_REAL_TO_DOUBLE                             \
+  DICT_NULLS(DICT_RealToDouble, 100, 5, 1)             \
+  DICT_NULLS(DICT_RealToDouble, 100, 5, 100)           \
+  DICT_NULLS(DICT_RealToDouble, 100, 5, 1000)          \
+  DICT_NULLS(DICT_RealToDouble, 100, 500, 1)           \
+  DICT_NULLS(DICT_RealToDouble, 100, 500, 100)         \
+  DICT_NULLS(DICT_RealToDouble, 100, 500, 1000)        \
+  DICT_NULLS(DICT_RealToDouble, 100, 15000, 1)         \
+  DICT_NULLS(DICT_RealToDouble, 100, 15000, 100)       \
+  DICT_NULLS(DICT_RealToDouble, 100, 15000, 1000)      \
+  DICT_NULLS(DICT_RealToDouble, 1000, 5, 1)            \
+  DICT_NULLS(DICT_RealToDouble, 1000, 5, 100)          \
+  DICT_NULLS(DICT_RealToDouble, 1000, 5, 1000)         \
+  DICT_NULLS(DICT_RealToDouble, 1000, 500, 1)          \
+  DICT_NULLS(DICT_RealToDouble, 1000, 500, 100)        \
+  DICT_NULLS(DICT_RealToDouble, 1000, 500, 1000)       \
+  DICT_NULLS(DICT_RealToDouble, 1000, 15000, 1)        \
+  DICT_NULLS(DICT_RealToDouble, 1000, 15000, 100)      \
+  DICT_NULLS(DICT_RealToDouble, 1000, 15000, 1000)     \
+  DICT_NULLS(DICT_RealToDouble, 10000, 5, 1)           \
+  DICT_NULLS(DICT_RealToDouble, 10000, 5, 100)         \
+  DICT_NULLS(DICT_RealToDouble, 10000, 5, 1000)        \
+  DICT_NULLS(DICT_RealToDouble, 10000, 500, 1)         \
+  DICT_NULLS(DICT_RealToDouble, 10000, 500, 100)       \
+  DICT_NULLS(DICT_RealToDouble, 10000, 500, 1000)      \
+  DICT_NULLS(DICT_RealToDouble, 10000, 15000, 1)       \
+  DICT_NULLS(DICT_RealToDouble, 10000, 15000, 100)     \
   DICT_NULLS(DICT_RealToDouble, 10000, 15000, 1000)
 
-#define FLAT_REAL_TO_DOUBLE    \
-  FLAT_NULLS(FLAT_RealToDouble, 100)      \
-  FLAT_NULLS(FLAT_RealToDouble, 1000)     \
+#define FLAT_REAL_TO_DOUBLE                 \
+  FLAT_NULLS(FLAT_RealToDouble, 100)        \
+  FLAT_NULLS(FLAT_RealToDouble, 1000)       \
   FLAT_NULLS(FLAT_RealToDouble, 10000)
+
+// === Multi-base alternation entries. Production scans rarely stay on
+// one base for 1000 batches - the underlying storage chunk advances
+// every batch or every handful of batches. Sweep the realistic
+// regime by picking a few high-signal shapes per type pair.
+
+#define DICT_ALT_BIGINT_TO_VARCHAR                                  \
+  DICT_ALT_NULLS(DICT_BigintToVarchar, 1000, 500, 1)                \
+  DICT_ALT_NULLS(DICT_BigintToVarchar, 1000, 15000, 1)              \
+  DICT_ALT_NULLS(DICT_BigintToVarchar, 10000, 500, 1)               \
+  DICT_ALT_NULLS(DICT_BigintToVarchar, 10000, 15000, 1)
+
+#define DICT_ALT_INT_TO_BIGINT                                      \
+  DICT_ALT_NULLS(DICT_IntToBigint, 1000, 500, 1)                    \
+  DICT_ALT_NULLS(DICT_IntToBigint, 1000, 15000, 1)                  \
+  DICT_ALT_NULLS(DICT_IntToBigint, 10000, 500, 1)                   \
+  DICT_ALT_NULLS(DICT_IntToBigint, 10000, 15000, 1)
+
+#define DICT_ALT_DATE_TO_VARCHAR                                    \
+  DICT_ALT_NULLS(DICT_DateToVarchar, 1000, 500, 1)                  \
+  DICT_ALT_NULLS(DICT_DateToVarchar, 1000, 15000, 1)                \
+  DICT_ALT_NULLS(DICT_DateToVarchar, 10000, 500, 1)                 \
+  DICT_ALT_NULLS(DICT_DateToVarchar, 10000, 15000, 1)
+
+#define DICT_ALT_DATE_TO_TIMESTAMP                                  \
+  DICT_ALT_NULLS(DICT_DateToTimestamp, 1000, 500, 1)                \
+  DICT_ALT_NULLS(DICT_DateToTimestamp, 1000, 15000, 1)              \
+  DICT_ALT_NULLS(DICT_DateToTimestamp, 10000, 500, 1)               \
+  DICT_ALT_NULLS(DICT_DateToTimestamp, 10000, 15000, 1)
+
+#define DICT_ALT_REAL_TO_DOUBLE                                     \
+  DICT_ALT_NULLS(DICT_RealToDouble, 1000, 500, 1)                   \
+  DICT_ALT_NULLS(DICT_RealToDouble, 1000, 15000, 1)                 \
+  DICT_ALT_NULLS(DICT_RealToDouble, 10000, 500, 1)                  \
+  DICT_ALT_NULLS(DICT_RealToDouble, 10000, 15000, 1)
+
+// === Production date_format expression (DATE -> VARCHAR).
+
+#define DICT_DATE_FORMAT_PROD                                       \
+  DICT_NULLS(DICT_DateFormatProd, 1000, 500, 1)                     \
+  DICT_NULLS(DICT_DateFormatProd, 1000, 15000, 1)                   \
+  DICT_NULLS(DICT_DateFormatProd, 10000, 500, 1)                    \
+  DICT_NULLS(DICT_DateFormatProd, 10000, 15000, 1)                  \
+  DICT_ALT_NULLS(DICT_DateFormatProd, 1000, 500, 1)                 \
+  DICT_ALT_NULLS(DICT_DateFormatProd, 1000, 15000, 1)               \
+  DICT_ALT_NULLS(DICT_DateFormatProd, 10000, 500, 1)                \
+  DICT_ALT_NULLS(DICT_DateFormatProd, 10000, 15000, 1)
+
+#define FLAT_DATE_FORMAT_PROD                                       \
+  FLAT_NULLS(FLAT_DateFormatProd, 1000)                             \
+  FLAT_NULLS(FLAT_DateFormatProd, 10000)
+
+// === Multi-thread entries. Threads share the source base
+// FlatVector(s) - cross-driver atomic refcount on the source Buffer
+// is exactly the contention pattern observed in production.
+
+#define MT_DICT_BIGINT_TO_VARCHAR                                   \
+  MT_THREADS(MT_DICT_BigintToVarchar, 1000, 500, 1, 0)              \
+  MT_THREADS(MT_DICT_BigintToVarchar, 1000, 15000, 1, 0)            \
+  MT_THREADS(MT_DICT_BigintToVarchar, 10000, 500, 1, 0)
+
+#define MT_DICT_DATE_TO_VARCHAR                                     \
+  MT_THREADS(MT_DICT_DateToVarchar, 1000, 500, 1, 0)                \
+  MT_THREADS(MT_DICT_DateToVarchar, 1000, 15000, 1, 0)              \
+  MT_THREADS(MT_DICT_DateToVarchar, 10000, 500, 1, 0)
+
+#define MT_DICT_DATE_TO_TIMESTAMP                                   \
+  MT_THREADS(MT_DICT_DateToTimestamp, 1000, 500, 1, 0)              \
+  MT_THREADS(MT_DICT_DateToTimestamp, 1000, 15000, 1, 0)            \
+  MT_THREADS(MT_DICT_DateToTimestamp, 10000, 500, 1, 0)
+
+#define MT_DICT_DATE_FORMAT_PROD                                    \
+  MT_THREADS(MT_DICT_DateFormatProd, 1000, 500, 1, 0)               \
+  MT_THREADS(MT_DICT_DateFormatProd, 1000, 15000, 1, 0)             \
+  MT_THREADS(MT_DICT_DateFormatProd, 10000, 500, 1, 0)
 
 BENCHMARK_DRAW_LINE();
 DICT_BIGINT_TO_VARCHAR
@@ -613,6 +1129,27 @@ FLAT_DATE_TO_TIMESTAMP
 BENCHMARK_DRAW_LINE();
 DICT_REAL_TO_DOUBLE
 FLAT_REAL_TO_DOUBLE
+BENCHMARK_DRAW_LINE();
+DICT_ALT_BIGINT_TO_VARCHAR
+BENCHMARK_DRAW_LINE();
+DICT_ALT_INT_TO_BIGINT
+BENCHMARK_DRAW_LINE();
+DICT_ALT_DATE_TO_VARCHAR
+BENCHMARK_DRAW_LINE();
+DICT_ALT_DATE_TO_TIMESTAMP
+BENCHMARK_DRAW_LINE();
+DICT_ALT_REAL_TO_DOUBLE
+BENCHMARK_DRAW_LINE();
+DICT_DATE_FORMAT_PROD
+FLAT_DATE_FORMAT_PROD
+BENCHMARK_DRAW_LINE();
+MT_DICT_BIGINT_TO_VARCHAR
+BENCHMARK_DRAW_LINE();
+MT_DICT_DATE_TO_VARCHAR
+BENCHMARK_DRAW_LINE();
+MT_DICT_DATE_TO_TIMESTAMP
+BENCHMARK_DRAW_LINE();
+MT_DICT_DATE_FORMAT_PROD
 
 int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
@@ -621,23 +1158,41 @@ int main(int argc, char** argv) {
   std::cout
       << "\nBenchmark entry names encode the sweep parameters:\n"
       << "  DICT_<from>To<to>("
-         "rowsPerVector_distinctValueCount_newIndicesPerVector_nullPct)\n"
+         "rowsPerVector_distinctValueCount_newIndicesPerVector_nullPct[_bpb<batchesPerBase>])\n"
       << "  FLAT_<from>To<to>(rowsPerVector_nullPct)\n"
+      << "  MT_DICT_<from>To<to>("
+         "threads<n>_rowsPerVector_distinctValueCount_newIndicesPerVector_nullPct_bpb<batchesPerBase>)\n"
       << "\n"
-      << "numVectors is fixed at 1000 for every entry and is not encoded\n"
-      << "in the name. Each measurement runs the cast over 1000 input\n"
-      << "vectors back-to-back; the reported time/iter is amortized over\n"
-      << "the total row count (1000 * rowsPerVector).\n"
+      << "numVectors is fixed at 1000 for every entry (per worker thread for\n"
+      << "MT entries) and is not encoded in the name. Each measurement runs\n"
+      << "the cast over 1000 input vectors back-to-back; the reported\n"
+      << "time/iter is amortized over the total row count\n"
+      << "(numThreads * 1000 * rowsPerVector for MT entries).\n"
       << "\n"
       << "  rowsPerVector       : rows in each input vector\n"
       << "  distinctValueCount  : dictionary base cardinality (DICT only)\n"
       << "  newIndicesPerVector : new dictionary indices each input vector\n"
       << "                        introduces vs the previous one - drives\n"
-      << "                        the dictionary-cache miss rate (DICT only)\n"
+      << "                        the dictionary-cache miss rate against\n"
+      << "                        a stable base (DICT only)\n"
       << "  nullPct             : percentage of positions marked null in\n"
       << "                        {0, 50, 100}. For DICT, nulls live on\n"
       << "                        the dictionary wrap; for FLAT, on the\n"
       << "                        flat input itself.\n"
+      << "  batchesPerBase      : how many consecutive batches reuse the\n"
+      << "                        same base FlatVector before rotating to\n"
+      << "                        a different base (different BufferPtr,\n"
+      << "                        different content). Entries without\n"
+      << "                        _bpb<n> use a single base for the whole\n"
+      << "                        run (= 1000). _bpb1 / _bpb10 / _bpb100\n"
+      << "                        sweep the realistic mix of base-change\n"
+      << "                        events. Lower means more\n"
+      << "                        numMemoBaseChange events per call.\n"
+      << "  threads<n>          : MT entries only. Number of worker threads\n"
+      << "                        all evaluating against the shared base\n"
+      << "                        FlatVectors - reproduces cross-driver\n"
+      << "                        atomic refcount contention on source\n"
+      << "                        Buffers.\n"
       << "\n";
 
   folly::runBenchmarks();

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -1361,12 +1361,21 @@ std::string IntervalDayTimeType::valueToString(int64_t value) const {
   }
   const int64_t days = remainMillis / kMillisInDay;
   remainMillis -= days * kMillisInDay;
-  const int64_t hours = remainMillis / kMillisInHour;
-  remainMillis -= hours * kMillisInHour;
-  const int64_t minutes = remainMillis / kMillisInMinute;
-  remainMillis -= minutes * kMillisInMinute;
-  const int64_t seconds = remainMillis / kMillisInSecond;
-  remainMillis -= seconds * kMillisInSecond;
+  // After the day divmod every remaining component (hours, minutes,
+  // seconds, milliseconds) fits in int by construction:
+  // hours < 24, minutes < 60, seconds < 60, milliseconds < 1000.
+  // Narrow to int so the %d / %02d / %03d specifiers in the format
+  // string receive arguments of the type they expect - passing the
+  // wider int64_t / int128_t through varargs to a %d conversion is
+  // undefined behavior on common ABIs and produced garbage millis
+  // in practice.
+  const int hours = static_cast<int>(remainMillis / kMillisInHour);
+  remainMillis -= int64_t{hours} * kMillisInHour;
+  const int minutes = static_cast<int>(remainMillis / kMillisInMinute);
+  remainMillis -= int64_t{minutes} * kMillisInMinute;
+  const int seconds = static_cast<int>(remainMillis / kMillisInSecond);
+  remainMillis -= int64_t{seconds} * kMillisInSecond;
+  const int millis = static_cast<int>(remainMillis);
   char buf[64];
   snprintf(
       buf,
@@ -1377,7 +1386,7 @@ std::string IntervalDayTimeType::valueToString(int64_t value) const {
       hours,
       minutes,
       seconds,
-      remainMillis);
+      millis);
 
   return buf;
 }

--- a/velox/vector/SelectivityVector.cpp
+++ b/velox/vector/SelectivityVector.cpp
@@ -93,6 +93,18 @@ void translateToInnerRows(
     const vector_size_t* indices,
     const uint64_t* nulls,
     SelectivityVector& innerRows) {
+  // Fast path: when 'nulls' is present and the selected outer range is
+  // entirely null, no inner row can be selected. Detect via a single
+  // vectorised popcount over the null bitmap instead of walking every
+  // row with isBitNull (~150 popcnts vs ~10000 per-row branches for a
+  // 10K-row bitmap). Only valid when outerRows is contiguous - for
+  // sparse outerRows we'd need to intersect with outerRows.bits()
+  // first; that path is rarer and stays on the per-row loop below.
+  if (nulls != nullptr && outerRows.isAllSelected() &&
+      bits::countBits(nulls, outerRows.begin(), outerRows.end()) == 0) {
+    innerRows.updateBounds();
+    return;
+  }
   outerRows.applyToSelected([&](vector_size_t row) {
     if (!(nulls && bits::isBitNull(nulls, row))) {
       innerRows.setValid(indices[row], true);

--- a/velox/vector/benchmarks/SelectivityVectorBenchmark.cpp
+++ b/velox/vector/benchmarks/SelectivityVectorBenchmark.cpp
@@ -19,6 +19,7 @@
 #include <folly/init/Init.h>
 
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Nulls.h"
 #include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::test {
@@ -275,6 +276,64 @@ BENCHMARK_PARAM(BM_countSelected, 1);
 BENCHMARK_PARAM(BM_countSelected, 1000);
 BENCHMARK_PARAM(BM_countSelected, 1000000);
 BENCHMARK_PARAM(BM_countSelected, 10000000);
+BENCHMARK_DRAW_LINE();
+
+// translateToInnerRows Tests
+//
+// Measures the free function velox::translateToInnerRows used by
+// PeeledEncoding::translateToInnerRows when an Expr peels a dictionary
+// wrapping. It walks every selected outer row, optionally checks
+// whether the corresponding dictionary position is null, and sets the
+// inner-row bit at indices[row] when not null. The hoisted-branch fast
+// path (nulls == nullptr) is the common production case; nullPct=50
+// exercises the null-aware loop; nullPct=100 marks every position
+// null so no inner row is selected.
+
+void BM_translateToInnerRows(
+    uint32_t iterations,
+    size_t numEntries,
+    int32_t nullPct) {
+  folly::BenchmarkSuspender suspender;
+  SelectivityVector outerRows(numEntries);
+  SelectivityVector innerRows(numEntries);
+  innerRows.clearAll();
+
+  std::vector<vector_size_t> indices(numEntries);
+  for (size_t i = 0; i < numEntries; ++i) {
+    // Identity mapping: indices[row] == row.
+    indices[i] = static_cast<vector_size_t>(i);
+  }
+
+  std::vector<uint64_t> nullsStorage;
+  const uint64_t* nulls = nullptr;
+  if (nullPct > 0) {
+    nullsStorage.resize((numEntries + 63) / 64);
+    if (nullPct >= 100) {
+      bits::fillBits(nullsStorage.data(), 0, numEntries, bits::kNull);
+    } else {
+      bits::fillBits(nullsStorage.data(), 0, numEntries, bits::kNotNull);
+      const int32_t step = 100 / nullPct;
+      for (size_t i = 0; i < numEntries; i += step) {
+        bits::setNull(nullsStorage.data(), i, true);
+      }
+    }
+    nulls = nullsStorage.data();
+  }
+  suspender.dismiss();
+
+  for (uint32_t i = 0; i < iterations; ++i) {
+    translateToInnerRows(outerRows, indices.data(), nulls, innerRows);
+    folly::doNotOptimizeAway(innerRows);
+  }
+  suspender.rehire();
+}
+
+BENCHMARK_NAMED_PARAM(BM_translateToInnerRows, 1000_0, 1000, 0);
+BENCHMARK_NAMED_PARAM(BM_translateToInnerRows, 1000_50, 1000, 50);
+BENCHMARK_NAMED_PARAM(BM_translateToInnerRows, 1000_100, 1000, 100);
+BENCHMARK_NAMED_PARAM(BM_translateToInnerRows, 1000000_0, 1000000, 0);
+BENCHMARK_NAMED_PARAM(BM_translateToInnerRows, 1000000_50, 1000000, 50);
+BENCHMARK_NAMED_PARAM(BM_translateToInnerRows, 1000000_100, 1000000, 100);
 BENCHMARK_DRAW_LINE();
 
 // operatorEquals test


### PR DESCRIPTION
## Summary

17 performance commits for CAST-heavy expression evaluation, rebased onto `bolt`. Highlights:

- **CastExpr hot path**: cache cast operators/policy on the instance, devirtualize `CastHooks` calls, skip `DecodedVector` decode for flat inputs, avoid per-row heap allocation in DATE→VARCHAR, vectorize DATE→TIMESTAMP, hoist per-row-invariant timezone branches.
- **Memoization**: eager full-base fill in `evalWithMemo` for cheap expressions; skip `translateToInnerRows` when `dictionaryCache_` covers the peeled base; memoization counters in `ExprStats`.
- **FilterProject**: recycle filter/project result vectors via `ExecCtx`'s `VectorPool`; clear result members after release so wrapped flats can be reused in place.
- **SelectivityVector**: early-exit `translateToInnerRows` when all selected outer rows are null.
- **Fix**: `IntervalDayTimeType::valueToString` casts fields to int for `snprintf` (fixes garbage output in interval→varchar cast).
- Benchmarks: `WideningCastBenchmark`, `CastInFilterProjectBenchmark`, `SelectivityVectorBenchmark` additions.

## Test plan

Built RelWithDebInfo and ran the affected suites:
- `velox_expression_test` CastExpr + ExprV2 parity/adapter: 75/75 pass (incl. `intervalDayTimeToVarchar`, now fixed).
- `FilterProjectTest`: 17/17 pass.
- `SelectivityVectorTest`: 20/20 pass.