### PR TITLE
Backport GooglePolyline and Parquet writer fixes to branch-1.7

### DIFF
--- a/velox/dwio/common/FlushPolicy.h
+++ b/velox/dwio/common/FlushPolicy.h
@@ -18,6 +18,7 @@
 
 namespace facebook::velox::dwio::common {
 
+/// Format-specific writers may use different underlying metrics.
 struct StripeProgress {
   uint32_t stripeIndex{0};
   uint64_t stripeRowCount{0};
@@ -27,7 +28,8 @@ struct StripeProgress {
 };
 
 // Specific formats can extend this interface to do additional
-// checks and customize how the decisions are combined.
+// checks and customize how the decisions are combined. They may only populate
+// or honor a subset of StripeProgress fields.
 class FlushPolicy {
  public:
   virtual ~FlushPolicy() = default;

--- a/velox/dwio/parquet/tests/ParquetTestBase.cpp
+++ b/velox/dwio/parquet/tests/ParquetTestBase.cpp
@@ -251,19 +251,20 @@ dwio::common::MemorySink* ParquetTestBase::write(
 
 dwio::common::MemorySink* ParquetTestBase::write(
     const std::vector<RowVectorPtr>& batches,
-    const WriterOptions& writerOptions) {
+    const dwio::common::WriterOptions& options,
+    const ParquetWriterOptions& writerOptions) {
   VELOX_CHECK(!batches.empty());
   auto sink = std::make_unique<dwio::common::MemorySink>(
       200 * 1024 * 1024,
       dwio::common::FileSink::Options{.pool = leafPool_.get()});
   auto* sinkPtr = sink.get();
+  auto writerOptionsBase = options;
+  writerOptionsBase.formatSpecificOptions =
+      std::make_shared<ParquetWriterOptions>(writerOptions);
   auto writer = std::make_unique<Writer>(
-      std::move(sink), writerOptions, batches[0]->rowType());
+      std::move(sink), writerOptionsBase, batches[0]->rowType());
   for (size_t i = 0; i < batches.size(); ++i) {
     writer->write(batches[i]);
-    if (i + 1 < batches.size()) {
-      writer->flush();
-    }
   }
   writer->close();
   writers_.push_back(std::move(writer));

--- a/velox/dwio/parquet/tests/ParquetTestBase.cpp
+++ b/velox/dwio/parquet/tests/ParquetTestBase.cpp
@@ -251,18 +251,14 @@ dwio::common::MemorySink* ParquetTestBase::write(
 
 dwio::common::MemorySink* ParquetTestBase::write(
     const std::vector<RowVectorPtr>& batches,
-    const dwio::common::WriterOptions& options,
-    const ParquetWriterOptions& writerOptions) {
+    const WriterOptions& writerOptions) {
   VELOX_CHECK(!batches.empty());
   auto sink = std::make_unique<dwio::common::MemorySink>(
       200 * 1024 * 1024,
       dwio::common::FileSink::Options{.pool = leafPool_.get()});
   auto* sinkPtr = sink.get();
-  auto writerOptionsBase = options;
-  writerOptionsBase.formatSpecificOptions =
-      std::make_shared<ParquetWriterOptions>(writerOptions);
   auto writer = std::make_unique<Writer>(
-      std::move(sink), writerOptionsBase, batches[0]->rowType());
+      std::move(sink), writerOptions, batches[0]->rowType());
   for (size_t i = 0; i < batches.size(); ++i) {
     writer->write(batches[i]);
   }

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -217,8 +217,7 @@ class ParquetTestBase : public testing::Test,
   /// further by the writer.
   dwio::common::MemorySink* write(
       const std::vector<RowVectorPtr>& batches,
-      const dwio::common::WriterOptions& options,
-      const ParquetWriterOptions& writerOptions);
+      const WriterOptions& writerOptions);
 
   dwio::common::MemorySink* write(
       const RowVectorPtr& data,

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -211,13 +211,14 @@ class ParquetTestBase : public testing::Test,
       const WriterOptions& writerOptions,
       const RowTypePtr& rowType = nullptr);
 
-  /// Writes each batch as a separate Parquet row group by flushing between
-  /// batches. Uses batches[0]->rowType() as the file schema. Configure
+  /// Writes batches data into Parquet file.
+  /// Uses batches[0]->rowType() as the file schema. Configure
   /// WriterOptions (e.g. flushPolicyFactory) so batch sizes are not split
   /// further by the writer.
   dwio::common::MemorySink* write(
       const std::vector<RowVectorPtr>& batches,
-      const WriterOptions& writerOptions);
+      const dwio::common::WriterOptions& options,
+      const ParquetWriterOptions& writerOptions);
 
   dwio::common::MemorySink* write(
       const RowVectorPtr& data,

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2074,12 +2074,21 @@ TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
       return std::make_unique<DefaultFlushPolicy>(
           kSecondRowGroupRows, kBytesInRowGroup);
     };
-    auto* sink = write(
-        {makeRowVector({"a"}, {columnData->slice(0, kFirstRowGroupRows)}),
-         makeRowVector(
-             {"a"},
-             {columnData->slice(kFirstRowGroupRows, kSecondRowGroupRows)})},
-        writerOptions);
+    // Flush between the two batches so each becomes its own row group; the
+    // writer otherwise repacks rows into fixed-size row groups.
+    auto memSink = std::make_unique<dwio::common::MemorySink>(
+        200 * 1024 * 1024,
+        dwio::common::FileSink::Options{.pool = leafPool_.get()});
+    auto* sink = memSink.get();
+    auto writer = std::make_unique<facebook::velox::parquet::Writer>(
+        std::move(memSink), writerOptions, rowType);
+    writer->write(
+        makeRowVector({"a"}, {columnData->slice(0, kFirstRowGroupRows)}));
+    writer->flush();
+    writer->write(makeRowVector(
+        {"a"}, {columnData->slice(kFirstRowGroupRows, kSecondRowGroupRows)}));
+    writer->close();
+    writers_.push_back(std::move(writer));
     auto [reader, rowReader] = readerBuilder(*sink, rowType).build();
     ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
     ASSERT_EQ(reader->fileMetaData().rowGroup(0).numRows(), kFirstRowGroupRows);

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -748,6 +748,94 @@ TEST_F(ParquetWriterTest, writerMagic) {
   EXPECT_EQ("PAR1", std::string(fileData.data() + fileData.size() - 4, 4));
 }
 
+TEST_F(ParquetWriterTest, flushWhenStreamBuffersGrow) {
+  constexpr int64_t kNumRows = 200;
+
+  ParquetWriterOptions writerOptions;
+  dwio::common::WriterOptions options;
+  writerOptions.enableDictionary = false;
+  options.memoryPool = rootPool_.get();
+  options.flushPolicyFactory =
+      []() -> std::unique_ptr<dwio::common::FlushPolicy> {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/1,
+        /*bytesInRowGroup=*/4 * 1024);
+  };
+
+  const auto schema = ROW({"c0"}, {BIGINT()});
+  auto sink = std::make_unique<MemorySink>(
+      200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  options.formatSpecificOptions =
+      std::make_shared<ParquetWriterOptions>(writerOptions);
+  auto writer = std::make_unique<facebook::velox::parquet::Writer>(
+      std::move(sink), options, schema);
+  const auto data = makeRowVector(
+      {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; })});
+
+  writer->write(data);
+
+  // Data should be flushed into the FileSink by acculumated closed row groups.
+  EXPECT_GT(sinkPtr->size(), 0);
+
+  writer->close();
+
+  const auto reader = createReaderInMemory(*sinkPtr);
+  EXPECT_EQ(kNumRows, reader->numberOfRows());
+  EXPECT_EQ(kNumRows, reader->fileMetaData().numRowGroups());
+}
+
+TEST_F(ParquetWriterTest, flushRowGroupByBufferedSize) {
+  ParquetWriterOptions writerOptions;
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/10'000,
+        /*bytesInRowGroup=*/200);
+  };
+
+  auto rowType = ROW({"c0"}, {INTEGER()});
+  auto testBatches =
+      [&](int numBatches, int expectedNumRowGroups, int expectedNumRows) {
+        std::vector<RowVectorPtr> batches;
+        for (int i = 0; i < numBatches; ++i) {
+          batches.push_back(
+              makeRowVector({makeFlatVector<int32_t>({1, 1, 1, 1, 1})}));
+        }
+
+        const auto* sinkPtr = write(batches, options, writerOptions);
+        const auto reader = createReaderInMemory(*sinkPtr);
+        EXPECT_EQ(expectedNumRowGroups, reader->fileMetaData().numRowGroups());
+        EXPECT_EQ(expectedNumRows, reader->numberOfRows());
+      };
+
+  testBatches(10, 1, 50);
+  testBatches(20, 2, 100);
+}
+
+TEST_F(ParquetWriterTest, flushEmptyRowGroup) {
+  ParquetWriterOptions writerOptions;
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/50,
+        /*bytesInRowGroup=*/128 * 1'024 * 1'024);
+  };
+
+  std::vector<RowVectorPtr> batches;
+  for (int i = 0; i < 10; ++i) {
+    batches.push_back(
+        makeRowVector({makeFlatVector<int32_t>({1, 1, 1, 1, 1})}));
+  }
+
+  const auto* sinkPtr = write(batches, options, writerOptions);
+  const auto reader = createReaderInMemory(*sinkPtr);
+  EXPECT_EQ(1, reader->fileMetaData().numRowGroups());
+  EXPECT_EQ(50, reader->numberOfRows());
+}
+
 TEST_F(ParquetWriterTest, largeMetadata) {
   const auto data = makeRowVector(
       {makeFlatVector<int32_t>(1'000, [](auto row) { return row; })});

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -751,11 +751,10 @@ TEST_F(ParquetWriterTest, writerMagic) {
 TEST_F(ParquetWriterTest, flushWhenStreamBuffersGrow) {
   constexpr int64_t kNumRows = 200;
 
-  ParquetWriterOptions writerOptions;
-  dwio::common::WriterOptions options;
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
   writerOptions.enableDictionary = false;
-  options.memoryPool = rootPool_.get();
-  options.flushPolicyFactory =
+  writerOptions.flushPolicyFactory =
       []() -> std::unique_ptr<dwio::common::FlushPolicy> {
     return std::make_unique<DefaultFlushPolicy>(
         /*rowsInRowGroup=*/1,
@@ -766,10 +765,8 @@ TEST_F(ParquetWriterTest, flushWhenStreamBuffersGrow) {
   auto sink = std::make_unique<MemorySink>(
       200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
   auto* sinkPtr = sink.get();
-  options.formatSpecificOptions =
-      std::make_shared<ParquetWriterOptions>(writerOptions);
   auto writer = std::make_unique<facebook::velox::parquet::Writer>(
-      std::move(sink), options, schema);
+      std::move(sink), writerOptions, schema);
   const auto data = makeRowVector(
       {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; })});
 
@@ -786,10 +783,9 @@ TEST_F(ParquetWriterTest, flushWhenStreamBuffersGrow) {
 }
 
 TEST_F(ParquetWriterTest, flushRowGroupByBufferedSize) {
-  ParquetWriterOptions writerOptions;
-  dwio::common::WriterOptions options;
-  options.memoryPool = rootPool_.get();
-  options.flushPolicyFactory = []() {
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+  writerOptions.flushPolicyFactory = []() {
     return std::make_unique<DefaultFlushPolicy>(
         /*rowsInRowGroup=*/10'000,
         /*bytesInRowGroup=*/200);
@@ -804,7 +800,7 @@ TEST_F(ParquetWriterTest, flushRowGroupByBufferedSize) {
               makeRowVector({makeFlatVector<int32_t>({1, 1, 1, 1, 1})}));
         }
 
-        const auto* sinkPtr = write(batches, options, writerOptions);
+        const auto* sinkPtr = write(batches, writerOptions);
         const auto reader = createReaderInMemory(*sinkPtr);
         EXPECT_EQ(expectedNumRowGroups, reader->fileMetaData().numRowGroups());
         EXPECT_EQ(expectedNumRows, reader->numberOfRows());
@@ -815,10 +811,9 @@ TEST_F(ParquetWriterTest, flushRowGroupByBufferedSize) {
 }
 
 TEST_F(ParquetWriterTest, flushEmptyRowGroup) {
-  ParquetWriterOptions writerOptions;
-  dwio::common::WriterOptions options;
-  options.memoryPool = rootPool_.get();
-  options.flushPolicyFactory = []() {
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+  writerOptions.flushPolicyFactory = []() {
     return std::make_unique<DefaultFlushPolicy>(
         /*rowsInRowGroup=*/50,
         /*bytesInRowGroup=*/128 * 1'024 * 1'024);
@@ -830,7 +825,7 @@ TEST_F(ParquetWriterTest, flushEmptyRowGroup) {
         makeRowVector({makeFlatVector<int32_t>({1, 1, 1, 1, 1})}));
   }
 
-  const auto* sinkPtr = write(batches, options, writerOptions);
+  const auto* sinkPtr = write(batches, writerOptions);
   const auto reader = createReaderInMemory(*sinkPtr);
   EXPECT_EQ(1, reader->fileMetaData().numRowGroups());
   EXPECT_EQ(50, reader->numberOfRows());

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -80,6 +80,10 @@ class ArrowDataBufferSink : public ::arrow::io::OutputStream {
     return bytesFlushed_ + buffer_.size();
   }
 
+  int64_t bufferedBytes() const {
+    return buffer_.size();
+  }
+
   ::arrow::Status Close() override {
     ARROW_RETURN_NOT_OK(Flush());
     sink_->close();
@@ -118,6 +122,7 @@ class ArrowDataBufferSink : public ::arrow::io::OutputStream {
 
 struct ArrowContext {
   std::unique_ptr<FileWriter> writer;
+  std::shared_ptr<::arrow::Schema> schema;
   std::shared_ptr<WriterProperties> properties;
 };
 
@@ -419,8 +424,15 @@ Writer::Writer(
 
 void Writer::flush() {
   if (arrowContext_->writer) {
-    PARQUET_THROW_NOT_OK(arrowContext_->writer->flushBufferedRowGroup());
+    PARQUET_THROW_NOT_OK(arrowContext_->writer->finishRowGroup());
   }
+  PARQUET_THROW_NOT_OK(stream_->Flush());
+}
+
+dwio::common::StripeProgress getStripeProgress(int64_t bufferedBytes) {
+  // Arrow Parquet FileWriter will new row group based on the row number, so
+  // we only check buffered bytes to flush row group here.
+  return dwio::common::StripeProgress{.stripeSizeEstimate = bufferedBytes};
 }
 
 /**
@@ -437,31 +449,40 @@ void Writer::write(const VectorPtr& data) {
   }
 
   ArrowArray array;
-  ArrowSchema schema;
   exportToArrow(exportData, array, generalPool_.get(), options_);
-  exportToArrow(exportData, schema, options_);
 
-  // Convert the arrow schema to Schema and then update the column names based
-  // on schema_.
-  auto arrowSchema = ::arrow::ImportSchema(&schema).ValueOrDie();
-  common::testutil::TestValue::adjust(
-      "facebook::velox::parquet::Writer::write", arrowSchema.get());
-  std::vector<std::shared_ptr<::arrow::Field>> newFields;
-  auto childSize = schema_->size();
-  if (!parquetFieldIds_.empty()) {
-    VELOX_CHECK(childSize == parquetFieldIds_.size());
-  }
-  for (auto i = 0; i < childSize; i++) {
-    newFields.push_back(updateFieldNameAndIdRecursive(
-        arrowSchema->fields()[i],
-        *schema_->childAt(i),
-        !parquetFieldIds_.empty() ? &parquetFieldIds_.at(i) : nullptr,
-        schema_->nameOf(i)));
+  if (!arrowContext_->schema) {
+    // First batch: export and fix up the Arrow schema, then cache it.
+    ArrowSchema schema;
+    exportToArrow(exportData, schema, options_);
+
+    auto arrowSchema = ::arrow::ImportSchema(&schema).ValueOrDie();
+    common::testutil::TestValue::adjust(
+        "facebook::velox::parquet::Writer::write", arrowSchema.get());
+    std::vector<std::shared_ptr<::arrow::Field>> newFields;
+    auto childSize = schema_->size();
+    if (!parquetFieldIds_.empty()) {
+      VELOX_CHECK(childSize == parquetFieldIds_.size());
+    }
+    for (auto i = 0; i < childSize; i++) {
+      newFields.push_back(updateFieldNameAndIdRecursive(
+          arrowSchema->fields()[i],
+          *schema_->childAt(i),
+          !parquetFieldIds_.empty() ? &parquetFieldIds_.at(i) : nullptr,
+          schema_->nameOf(i)));
+    }
+
+    arrowContext_->schema = ::arrow::schema(newFields);
   }
 
+  // Import the data array using the cached schema.
   PARQUET_ASSIGN_OR_THROW(
       auto recordBatch,
-      ::arrow::ImportRecordBatch(&array, ::arrow::schema(newFields)));
+      ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
+
+  if (recordBatch->num_rows() == 0) {
+    return;
+  }
 
   if (!arrowContext_->writer) {
     ArrowWriterProperties::Builder builder;
@@ -478,7 +499,21 @@ void Writer::write(const VectorPtr& data) {
             arrowContext_->properties,
             arrowProperties));
   }
-  (void)arrowContext_->writer->writeRecordBatch(*recordBatch);
+
+  PARQUET_THROW_NOT_OK(arrowContext_->writer->writeRecordBatch(*recordBatch));
+
+  // Flush as soon as the current write pushes the staged row group past the
+  // policy threshold. Otherwise callers that rotate files based on raw written
+  // bytes won't observe the row group until the next write.
+  if (flushPolicy_->shouldFlush(getStripeProgress(
+          arrowContext_->writer->currentRowGroupTotalBytes()))) {
+    flush();
+  } else if (flushPolicy_->bytesInRowGroup() <= stream_->bufferedBytes()) {
+    // Flush the sink separately so completed row groups don't keep accumulating
+    // in the stream buffer when Arrow keeps starting new row groups before the
+    // current one hits the byte threshold.
+    PARQUET_THROW_NOT_OK(stream_->Flush());
+  }
 }
 
 bool Writer::isCodecAvailable(common::CompressionKind compression) {
@@ -491,8 +526,6 @@ void Writer::newRowGroup(int32_t numRows) {
 }
 
 std::unique_ptr<dwio::common::FileMetadata> Writer::close() {
-  flush();
-
   std::unique_ptr<ParquetFileMetadata> parquetFileMetadata;
   if (arrowContext_->writer) {
     PARQUET_THROW_NOT_OK(arrowContext_->writer->close());

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -57,6 +57,12 @@ class ParquetFileMetadata : public dwio::common::FileMetadata {
   std::shared_ptr<arrow::FileMetaData> metadata_;
 };
 
+/// Parquet writer enforces the row-count cap via Arrow, and this policy
+/// supplements it with a byte threshold. For Parquet,
+/// - stripeSizeEstimate: the actual compressed bytes of current row group.
+/// - stripeRowCount: remains 0.
+/// Custom Parquet policies should derive from DefaultFlushPolicy to preserve
+/// this contract.
 class DefaultFlushPolicy : public dwio::common::FlushPolicy {
  public:
   DefaultFlushPolicy()
@@ -70,8 +76,7 @@ class DefaultFlushPolicy : public dwio::common::FlushPolicy {
 
   bool shouldFlush(
       const dwio::common::StripeProgress& stripeProgress) override {
-    return stripeProgress.stripeRowCount >= rowsInRowGroup_ ||
-        stripeProgress.stripeSizeEstimate >= bytesInRowGroup_;
+    return stripeProgress.stripeSizeEstimate >= bytesInRowGroup_;
   }
 
   void onClose() override {
@@ -161,11 +166,11 @@ struct WriterOptions : public dwio::common::WriterOptions {
 // Writes Velox vectors into  a DataSink using Arrow Parquet writer.
 class Writer : public dwio::common::Writer {
  public:
-  // Constructs a writer with output to 'sink'. A new row group is
-  // started every 'rowsInRowGroup' top level rows. 'pool' is used for
-  // temporary memory. 'properties' specifies Parquet-specific
-  // options. 'schema' specifies the file's overall schema, and it is always
-  // non-null.
+  // Constructs a writer with output to 'sink'. 'options' carries common writer
+  // options and Parquet-specific format options. For Parquet,
+  // 'options.flushPolicyFactory' must create a DefaultFlushPolicy (or a
+  // subclass); 'pool' is used for temporary memory. 'schema' specifies the
+  // file's overall schema, and it is always non-null.
   Writer(
       std::unique_ptr<dwio::common::FileSink> sink,
       const WriterOptions& options,

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
@@ -1628,6 +1628,21 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     return currentEncoder_->estimatedDataEncodedSize();
   }
 
+  int64_t estimatedBufferedDefLevelBytes() const override {
+    return definitionLevelsSink_.length();
+  }
+
+  int64_t estimatedBufferedRepLevelBytes() const override {
+    return repetitionLevelsSink_.length();
+  }
+
+  int64_t estimatedBufferedDictBytes() const override {
+    if (currentDictEncoder_) {
+      return currentDictEncoder_->dictEncodedSize();
+    }
+    return 0;
+  }
+
  protected:
   std::shared_ptr<Buffer> getValuesBuffer() override {
     return currentEncoder_->flushValues();

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.h
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.h
@@ -194,6 +194,21 @@ class PARQUET_EXPORT ColumnWriter {
   /// totalBytesWritten().
   virtual int64_t totalCompressedBytesWritten() const = 0;
 
+  /// Estimated size of the values that are not written to a page yet.
+  virtual int64_t estimatedBufferedValueBytes() const = 0;
+
+  /// \brief Estimated size of the definition levels that are not written to a
+  /// page yet.
+  virtual int64_t estimatedBufferedDefLevelBytes() const = 0;
+
+  /// \brief Estimated size of the repetition levels that are not written to a
+  /// page yet.
+  virtual int64_t estimatedBufferedRepLevelBytes() const = 0;
+
+  /// \brief Estimated size of the dictionary that are not written to a page
+  /// yet.
+  virtual int64_t estimatedBufferedDictBytes() const = 0;
+
   /// \brief The file-level writer properties.
   virtual const WriterProperties* properties() = 0;
 
@@ -211,9 +226,6 @@ class PARQUET_EXPORT ColumnWriter {
       const ::arrow::Array& leafArray,
       ArrowWriteContext* ctx,
       bool leafFieldNullable) = 0;
-
-  /// \brief Estimated size of the values that are not written to a page yet.
-  virtual int64_t estimatedBufferedValueBytes() const = 0;
 };
 
 // API to write values to a single column. This is the main client facing API.

--- a/velox/dwio/parquet/writer/arrow/FileWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/FileWriter.cpp
@@ -79,6 +79,10 @@ int64_t RowGroupWriter::totalBufferedBytes() const {
       contents_->estimatedBufferedValueBytes();
 }
 
+RowGroupWriter::BufferedStats RowGroupWriter::estimatedBufferedStats() const {
+  return contents_->estimatedBufferedStats();
+}
+
 bool RowGroupWriter::buffered() const {
   return contents_->buffered();
 }
@@ -287,6 +291,22 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     return estimatedBufferedValueBytes;
   }
 
+  RowGroupWriter::BufferedStats estimatedBufferedStats() const override {
+    RowGroupWriter::BufferedStats stats;
+    if (closed_) {
+      return stats;
+    }
+    for (const auto& columnWriter : columnWriters_) {
+      if (columnWriter) {
+        stats.defLevelBytes += columnWriter->estimatedBufferedDefLevelBytes();
+        stats.repLevelBytes += columnWriter->estimatedBufferedRepLevelBytes();
+        stats.valueBytes += columnWriter->estimatedBufferedValueBytes();
+        stats.dictBytes += columnWriter->estimatedBufferedDictBytes();
+      }
+    }
+    return stats;
+  }
+
   bool buffered() const override {
     return bufferedRowGroup_;
   }
@@ -436,11 +456,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
       // If any functions here raise an exception, we set isOpen_ to be false
       // so that this does not get called again (possibly causing segfault).
       isOpen_ = false;
-      if (rowGroupWriter_) {
-        numRows_ += rowGroupWriter_->numRows();
-        rowGroupWriter_->close();
-      }
-      rowGroupWriter_.reset();
+      finishRowGroup();
 
       writePageIndex();
 
@@ -472,10 +488,16 @@ class FileSerializer : public ParquetFileWriter::Contents {
     return properties_;
   }
 
-  RowGroupWriter* appendRowGroup(bool bufferedRowGroup) {
+  void finishRowGroup() override {
     if (rowGroupWriter_) {
+      numRows_ += rowGroupWriter_->numRows();
       rowGroupWriter_->close();
+      rowGroupWriter_.reset();
     }
+  }
+
+  RowGroupWriter* appendRowGroup(bool bufferedRowGroup) {
+    finishRowGroup();
     numRowGroups_++;
     auto rgMetadata = metadata_->appendRowGroup();
     if (pageIndexBuilder_) {
@@ -769,6 +791,12 @@ RowGroupWriter* ParquetFileWriter::appendRowGroup() {
 
 RowGroupWriter* ParquetFileWriter::appendBufferedRowGroup() {
   return contents_->appendBufferedRowGroup();
+}
+
+void ParquetFileWriter::finishRowGroup() {
+  if (contents_) {
+    contents_->finishRowGroup();
+  }
 }
 
 RowGroupWriter* ParquetFileWriter::appendRowGroup(int64_t numRows) {

--- a/velox/dwio/parquet/writer/arrow/FileWriter.h
+++ b/velox/dwio/parquet/writer/arrow/FileWriter.h
@@ -37,6 +37,15 @@ static constexpr uint8_t kParquetEMagic[4] = {'P', 'A', 'R', 'E'};
 
 class PARQUET_EXPORT RowGroupWriter {
  public:
+  /// Estimated uncompressed byte sizes of data buffered by column writers
+  /// that have not yet been serialized into pages.
+  struct BufferedStats {
+    int64_t defLevelBytes = 0;
+    int64_t repLevelBytes = 0;
+    int64_t valueBytes = 0;
+    int64_t dictBytes = 0;
+  };
+
   // Forward declare a virtual class 'Contents' to aid dependency injection and
   // more easily create test fixtures. An implementation of the Contents class
   // is defined in the .cpp file.
@@ -61,6 +70,9 @@ class PARQUET_EXPORT RowGroupWriter {
     virtual int64_t totalCompressedBytesWritten() const = 0;
     /// \brief Estimated size of the values that are not written to a page yet.
     virtual int64_t estimatedBufferedValueBytes() const = 0;
+    /// \brief Estimated sizes of buffered data (levels, values, dict) not yet
+    /// written to pages.
+    virtual BufferedStats estimatedBufferedStats() const = 0;
 
     virtual bool buffered() const = 0;
   };
@@ -105,6 +117,9 @@ class PARQUET_EXPORT RowGroupWriter {
   /// \brief Including compressed bytes in page writer and uncompressed data
   /// value buffer.
   int64_t totalBufferedBytes() const;
+  /// \brief Estimated sizes of buffered data (levels, values, dict) not yet
+  /// written to pages.
+  BufferedStats estimatedBufferedStats() const;
   /// Returns whether the current RowGroupWriter is in the buffered mode and is
   /// created by calling ParquetFileWriter::appendBufferedRowGroup().
   bool buffered() const;
@@ -163,6 +178,8 @@ class PARQUET_EXPORT ParquetFileWriter {
 
     virtual RowGroupWriter* appendRowGroup() = 0;
     virtual RowGroupWriter* appendBufferedRowGroup() = 0;
+
+    virtual void finishRowGroup() = 0;
 
     virtual int64_t numRows() const = 0;
     virtual int numColumns() const = 0;
@@ -232,6 +249,12 @@ class PARQUET_EXPORT ParquetFileWriter {
   /// only valid until the next call to appendRowGroup() or
   /// appendBufferedRowGroup() or close().
   RowGroupWriter* appendBufferedRowGroup();
+
+  /// Finalize the current row group if one is active. Pages and column
+  /// metadata of the buffered row group are serialized to the underlying
+  /// sink and the active RowGroupWriter is destroyed.
+  /// No-op if there is no active row group.
+  void finishRowGroup();
 
   /// \brief Add key-value metadata to the file.
   /// \param[in] keyValueMetadata The metadata to add.

--- a/velox/dwio/parquet/writer/arrow/Writer.cpp
+++ b/velox/dwio/parquet/writer/arrow/Writer.cpp
@@ -346,10 +346,16 @@ class FileWriterImpl : public FileWriter {
     if (!closed_) {
       // Make idempotent.
       closed_ = true;
-      if (rowGroupWriter_ != nullptr) {
-        PARQUET_CATCH_NOT_OK(rowGroupWriter_->close());
-      }
+      PARQUET_CATCH_NOT_OK(finishRowGroup());
       PARQUET_CATCH_NOT_OK(writer_->close());
+    }
+    return Status::OK();
+  }
+
+  ::arrow::Status finishRowGroup() override {
+    if (rowGroupWriter_ != nullptr) {
+      PARQUET_CATCH_NOT_OK(rowGroupWriter_->close());
+      rowGroupWriter_ = nullptr;
     }
     return Status::OK();
   }
@@ -505,32 +511,34 @@ class FileWriterImpl : public FileWriter {
 
     // Max number of rows allowed in a row group.
     const int64_t maxRowGroupLength = this->properties().maxRowGroupLength();
-    // Max number of bytes allowed in a row group.
-    const int64_t maxRowGroupBytes = this->properties().maxRowGroupBytes();
 
     int64_t offset = 0;
     while (offset < batch.num_rows()) {
-      int64_t groupRows = rowGroupWriter_->numRows();
-      int64_t batchSize =
-          std::min(maxRowGroupLength - groupRows, batch.num_rows() - offset);
-      if (groupRows > 0) {
-        int64_t bufferedBytes = rowGroupWriter_->totalBufferedBytes();
-        double avgRowSize = bufferedBytes * 1.0 / groupRows;
-        batchSize = std::min(
-            batchSize,
-            static_cast<int64_t>(
-                (maxRowGroupBytes - bufferedBytes) / avgRowSize));
-      }
-      if (batchSize > 0) {
-        RETURN_NOT_OK(writeBatch(offset, batchSize));
-        offset += batchSize;
-      } else if (offset < batch.num_rows()) {
-        // Current row group is full, write remaining rows in a new group.
+      const int64_t batchSize = std::min(
+          maxRowGroupLength - rowGroupWriter_->numRows(),
+          batch.num_rows() - offset);
+      RETURN_NOT_OK(writeBatch(offset, batchSize));
+      offset += batchSize;
+
+      // Flush current row group if it is full.
+      if (rowGroupWriter_->numRows() >= maxRowGroupLength &&
+          // Avoid leaving an empty row group at the end of the file.
+          offset < batch.num_rows()) {
         RETURN_NOT_OK(newBufferedRowGroup());
       }
     }
 
     return Status::OK();
+  }
+
+  int64_t currentRowGroupTotalBytes() const override {
+    if (rowGroupWriter_ == nullptr) {
+      return 0;
+    }
+    auto stats = rowGroupWriter_->estimatedBufferedStats();
+    return stats.defLevelBytes + stats.repLevelBytes + stats.valueBytes +
+        stats.dictBytes + rowGroupWriter_->totalCompressedBytes() +
+        rowGroupWriter_->totalCompressedBytesWritten();
   }
 
   const WriterProperties& properties() const {

--- a/velox/dwio/parquet/writer/arrow/Writer.h
+++ b/velox/dwio/parquet/writer/arrow/Writer.h
@@ -155,6 +155,16 @@ class PARQUET_EXPORT FileWriter {
   /// \brief Finalize the current buffered row group, if any, without closing
   /// the file.
   virtual ::arrow::Status flushBufferedRowGroup() = 0;
+
+  /// \brief Estimated total bytes in the current row group. Including page
+  /// data and buffered data that are not yet written to pages.
+  virtual int64_t currentRowGroupTotalBytes() const = 0;
+
+  /// \brief Finalize the current buffered row group, if any, so that its
+  /// pages and column metadata are serialized to the underlying sink. After
+  /// this call there is no active row group.
+  virtual ::arrow::Status finishRowGroup() = 0;
+
   /// \brief Write the footer and close the file.
   virtual ::arrow::Status close() = 0;
   virtual ~FileWriter();

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -46,7 +46,6 @@ velox_add_library(
   FilterFunctions.cpp
   FindFirst.cpp
   FromUtf8.cpp
-  GooglePolylineFunctions.cpp
   InPredicate.cpp
   JsonFunctions.cpp
   Map.cpp
@@ -170,6 +169,8 @@ endif()
 
 if(VELOX_ENABLE_GEO)
   add_subdirectory(geospatial)
+
+  velox_sources(velox_functions_prestosql_impl PRIVATE GooglePolylineFunctions.cpp)
 
   # S2 cell operations are isolated in a separate library to prevent a
   # nallocx symbol conflict between s2geometry's malloc_extension.h and


### PR DESCRIPTION
Backported the folowing Velox commits, with code conflicts resolved.
- fix(geo): Gate GooglePolyline on VELOX_ENABLE_GEO
https://github.com/facebookincubator/velox/commit/e48e3cd6cbb2e26138e32a72ca2b1ff8808eeaf4
- fix(parquet): Flush row group by buffered bytes in the writer
https://github.com/facebookincubator/velox/commit/4c9a221f3ee36c558c141a555aced65cd2343753

Gluten test PR: https://github.com/apache/gluten/pull/12561