### PR TITLE
feat(cudf): expose live-allocated GPU bytes via statistics_resource_adaptor

### DIFF
--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -87,9 +87,22 @@ cudf::detail::cuda_stream_pool& cudfGlobalStreamPool() {
 
 std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> output_mr_;
+std::optional<rmm::mr::statistics_resource_adaptor> statsMr_;
+std::optional<rmm::mr::statistics_resource_adaptor> outputStatsMr_;
 
 rmm::device_async_resource_ref get_output_mr() {
   return output_mr_.value();
+}
+
+int64_t cudfAllocatedBytes() {
+  if (!statsMr_.has_value()) {
+    return -1;
+  }
+  int64_t bytes = static_cast<int64_t>(statsMr_->get_bytes_counter().value);
+  if (outputStatsMr_.has_value()) {
+    bytes += static_cast<int64_t>(outputStatsMr_->get_bytes_counter().value);
+  }
+  return bytes;
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -18,10 +18,12 @@
 
 #include <cudf/detail/utilities/stream_pool.hpp>
 
+#include <rmm/mr/statistics_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
 
+#include <cstdint>
 #include <optional>
 #include <string_view>
 
@@ -31,8 +33,22 @@ extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
 extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
     output_mr_;
 
+// Statistics adaptors wrapping the main (and, if distinct, output) memory
+// resources so we can report live-allocated GPU bytes. statistics_resource_adaptor
+// is a cuda::mr::shared_resource: it is copyable and copies share the same
+// counter state, so the copies placed in mr_/output_mr_ increment the same
+// counters that these read.
+extern std::optional<rmm::mr::statistics_resource_adaptor> statsMr_;
+extern std::optional<rmm::mr::statistics_resource_adaptor> outputStatsMr_;
+
 /// Returns the memory resource designated for output vector allocations.
 rmm::device_async_resource_ref get_output_mr();
+
+/// Live bytes currently allocated through the cuDF/RMM memory resource(s), or
+/// -1 if cuDF is not registered. Unlike cudaMemGetInfo (which reflects the
+/// retained RMM pool high-water mark), this drops when queries free their
+/// allocations, so it can distinguish an idle worker from a busy one.
+int64_t cudfAllocatedBytes();
 
 /**
  * @brief Creates a memory resource based on the given mode.

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -316,15 +316,22 @@ void registerCudf() {
   cudaFree(nullptr); // Initialize CUDA context at startup
 
   const std::string mrMode = CudfConfig::getInstance().memoryResource;
-  auto mr = cudf_velox::createMemoryResource(
+  auto base = cudf_velox::createMemoryResource(
       mrMode, CudfConfig::getInstance().memoryPercent);
-  cudf::set_current_device_resource(mr);
-  mr_ = std::move(mr);
+  // Wrap the device resource in a statistics adaptor so we can report the live
+  // (currently-allocated) GPU bytes. The RMM pool retains VRAM between queries,
+  // so cudaMemGetInfo alone cannot tell free-for-reuse pool from active work.
+  statsMr_.emplace(std::move(base));
+  // statistics_resource_adaptor is a cuda::mr::shared_resource: this copy shares
+  // the same counter state, so allocations via mr_/output_mr_ are counted too.
+  mr_ = statsMr_.value();
+  cudf::set_current_device_resource(mr_.value());
 
   const auto& outputMrMode = CudfConfig::getInstance().outputMemoryResource;
   if (!outputMrMode.empty() && outputMrMode != mrMode) {
-    output_mr_ = cudf_velox::createMemoryResource(
-        outputMrMode, CudfConfig::getInstance().memoryPercent);
+    outputStatsMr_.emplace(cudf_velox::createMemoryResource(
+        outputMrMode, CudfConfig::getInstance().memoryPercent));
+    output_mr_ = outputStatsMr_.value();
   } else {
     output_mr_ = mr_;
   }


### PR DESCRIPTION
## What

Wrap the cuDF/RMM device resource (and the separate output MR, when present) in an
`rmm::mr::statistics_resource_adaptor`, and add a `cudfAllocatedBytes()` accessor that
returns the live-allocated device bytes.

## Why

`cudaMemGetInfo` only reflects the retained RMM pool high-water mark — it cannot
distinguish a pool that is free-for-reuse from one with active work. The adaptor's
current-bytes counter drops when queries free their allocations, giving a true
"busy vs. idle" GPU-memory signal.

This is needed by a downstream Prestissimo change that reports live GPU pool usage on
`/v1/status` for GPU-aware autoscaling (scale a GPU worker in only when its GPU memory
is actually free, not merely because the retained pool looks full).

## How

`statistics_resource_adaptor` is a `cuda::mr::shared_resource` (copyable, shared counter
state), so the copies stored in `mr_` / `output_mr_` feed the same counters read by
`cudfAllocatedBytes()`.

## Scope / impact

- Files: `velox/experimental/cudf/exec/GpuResources.{h,cpp}`, `velox/experimental/cudf/exec/ToCudf.cpp`.
- Only active when cuDF is enabled; no effect on non-cuDF builds.
- Adds a per-allocation counter on the RMM path (statistics adaptor); overhead expected
  to be negligible.

## Test plan

- Built with cuDF enabled; `cudfAllocatedBytes()` tracks a query's allocations and
  returns to ~0 when the query frees, whereas `cudaMemGetInfo` stays at the retained
  pool high-water mark.